### PR TITLE
Refactor Transforms to Actions in App Controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ ALLEGROFLARE_INCLUDE_DIR=$(ALLEGROFLARE_DIR)/include
 
 OBJS=command_bar fullscore_application_controller gui_score_editor main mixer music_engraver playback_control playback_device_interface run_script
 OBJS+=actions/action_base actions/move_cursor_down_action actions/move_cursor_left_action actions/move_cursor_right_action actions/paste_measure_from_buffer_action actions/move_cursor_up_action actions/reset_playback_action actions/save_measure_grid_action actions/toggle_command_bar_action actions/toggle_playback_action actions/yank_measure_to_buffer_action
+OBJS+=$(addprefix actions/transforms/,$(basename $(notdir $(wildcard src/actions/transforms/*.cpp))))
 OBJS+=components/time_signature_render_component
 OBJS+=converters/measure_grid_file_converter converters/note_string_converter
 OBJS+=models/measure models/measure_grid models/note models/note_playback_info models/time_signature

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,16 @@ bin/fullscore$(EXE_EXTENSION): $(OBJ_FILES)
 
 $(OBJ_FILES): obj/%.o : src/%.cpp
 	g++ -std=gnu++11 -c -o $@ $< -I./include -I$(ALLEGRO_INCLUDE_DIR) -I$(ALLEGROFLARE_INCLUDE_DIR)
-	
+
+
+
+#
+# Tools
+#
+
+
+tools: src/tools/generate.cpp
+	g++ -std=gnu++11 -o bin/generate$(EXE_EXTENSION) src/tools/generate.cpp
 
 
 #

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ $(OBJ_FILES): obj/%.o : src/%.cpp
 
 
 tools: src/tools/generate.cpp
-	g++ -std=gnu++11 -o bin/generate$(EXE_EXTENSION) src/tools/generate.cpp
+	g++ -std=gnu++11 -o bin/generate$(EXE_EXTENSION) src/tools/generate.cpp -I$(ALLEGRO_INCLUDE_DIR) -L$(ALLEGRO_LIB_DIR) $(ALLEGRO_LIBS)
+
 
 
 #

--- a/include/fullscore/actions/__template.h
+++ b/include/fullscore/actions/__template.h
@@ -1,0 +1,25 @@
+#pragma once
+
+
+
+
+#include <fullscore/action/action_base.h>
+
+
+
+
+namespace Action
+{
+   class Template : public Base
+   {
+   public:
+      Template();
+      ~Template();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/__transforms_template.h
+++ b/include/fullscore/actions/__transforms_template.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   class TEMPLATE : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+
+   public:
+      TEMPLATE(std::vector<Note> *notes);
+      ~TEMPLATE();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/add_dot_transform_action.h
+++ b/include/fullscore/actions/transforms/add_dot_transform_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   class AddDotTransform : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+
+   public:
+      AddDotTransform(std::vector<Note> *notes);
+      ~AddDotTransform();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/double_duration_transform_action.h
+++ b/include/fullscore/actions/transforms/double_duration_transform_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   class DoubleDurationTransform : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+
+   public:
+      DoubleDurationTransform(std::vector<Note> *notes);
+      ~DoubleDurationTransform();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/erase_note_action.h
+++ b/include/fullscore/actions/transforms/erase_note_action.h
@@ -1,0 +1,32 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   class EraseNote : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+      int index;
+
+   public:
+      EraseNote(std::vector<Note> *notes, int index);
+      ~EraseNote();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/half_duration_transform_action.h
+++ b/include/fullscore/actions/transforms/half_duration_transform_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   class HalfDurationTransform : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+
+   public:
+      HalfDurationTransform(std::vector<Note> *notes);
+      ~HalfDurationTransform();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/insert_note_action.h
+++ b/include/fullscore/actions/transforms/insert_note_action.h
@@ -1,0 +1,32 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+#include <fullscore/models/note.h>
+
+
+
+
+namespace Action
+{
+   class InsertNoteTransform : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+      int at_index;
+      Note note;
+
+   public:
+      InsertNoteTransform(std::vector<Note> *notes, int at_index, Note note);
+      ~InsertNoteTransform();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/invert_action.h
+++ b/include/fullscore/actions/transforms/invert_action.h
@@ -1,0 +1,35 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   namespace Transform
+   {
+      class Invert : public Base
+      {
+      private:
+         std::vector<Note> *notes;
+         int axis;
+
+      public:
+         Invert(std::vector<Note> *notes, int axis=0);
+         ~Invert();
+
+         bool execute() override;
+      };
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/remove_dot_transform_action.h
+++ b/include/fullscore/actions/transforms/remove_dot_transform_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   class RemoveDotTransform : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+
+   public:
+      RemoveDotTransform(std::vector<Note> *notes);
+      ~RemoveDotTransform();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/retrograde_action.h
+++ b/include/fullscore/actions/transforms/retrograde_action.h
@@ -1,0 +1,34 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   namespace Transform
+   {
+      class Retrograde : public Base
+      {
+      private:
+         std::vector<Note> *notes;
+
+      public:
+         Retrograde(std::vector<Note> *notes);
+         ~Retrograde();
+
+         bool execute() override;
+      };
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/toggle_rest_action.h
+++ b/include/fullscore/actions/transforms/toggle_rest_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   class ToggleRest : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+
+   public:
+      ToggleRest(std::vector<Note> *notes);
+      ~ToggleRest();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/transforms/transpose_transform_action.h
+++ b/include/fullscore/actions/transforms/transpose_transform_action.h
@@ -1,0 +1,32 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+
+class Note;
+
+namespace Action
+{
+   class TransposeTransform : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+      int transposition;
+
+   public:
+      TransposeTransform(std::vector<Note> *notes, int transposition);
+      ~TransposeTransform();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/gui_score_editor.h
+++ b/include/fullscore/gui_score_editor.h
@@ -17,13 +17,19 @@
 class GUIScoreEditor : public UIWidget
 {
 public:
+   enum edit_mode_target_t
+   {
+      NOTE_TARGET=0,
+      MEASURE_TARGET
+   };
+
    MeasureGrid measure_grid;
    PlaybackControl playback_control;
 
    int measure_cursor_x; // should be renamed to grid_cursor_x, grid_cursor_y
    int measure_cursor_y;
    int note_cursor_x;
-   bool input_mode;
+   edit_mode_target_t edit_mode_target;
 
    MusicEngraver music_engraver;
 
@@ -47,7 +53,7 @@ public:
    float get_measure_length_to_note(Measure &measure, int note_index);
    float get_measure_width(Measure &m);
 
-   void toggle_input_mode();
+   void toggle_edit_mode_target();
    bool is_measure_mode();
    bool is_note_mode();
 };

--- a/obj/actions/transforms/.gitignore
+++ b/obj/actions/transforms/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/src/actions/__template.cpp
+++ b/src/actions/__template.cpp
@@ -1,0 +1,31 @@
+
+
+
+
+#include <fullscore/action/__template.h>
+
+
+
+
+Action::Template::Template()
+   : Base("name_of_action")
+{}
+
+
+
+
+Action::Template::~Template()
+{}
+
+
+
+
+bool Template::execute()
+{
+   // unimplemented
+   return false;
+}
+
+
+
+

--- a/src/actions/__template.cpp
+++ b/src/actions/__template.cpp
@@ -20,7 +20,7 @@ Action::Template::~Template()
 
 
 
-bool Template::execute()
+bool Action::Template::execute()
 {
    // unimplemented
    return false;

--- a/src/actions/__transforms_template.cpp
+++ b/src/actions/__transforms_template.cpp
@@ -1,0 +1,37 @@
+
+
+
+
+#include <fullscore/actions/transforms/ACTION_NAME.h>
+
+#include <fullscore/transforms/TRANSFORM_NAME.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::TEMPLATE::TEMPLATE(std::vector<Note> *notes)
+   : Base("TEMPLATE")
+   , notes(notes)
+{}
+
+
+
+
+Action::TEMPLATE::~TEMPLATE()
+{}
+
+
+
+
+bool Action::TEMPLATE::execute()
+{
+   if (!notes) return false;
+
+   // unimplemented
+   return false;
+}
+
+
+
+

--- a/src/actions/transforms/add_dot_transform_action.cpp
+++ b/src/actions/transforms/add_dot_transform_action.cpp
@@ -31,8 +31,7 @@ bool Action::AddDotTransform::execute()
    Transform::AddDot add_dot_transform;
    *notes = add_dot_transform.transform(*notes);
 
-   // unimplemented
-   return false;
+   return true;
 }
 
 

--- a/src/actions/transforms/add_dot_transform_action.cpp
+++ b/src/actions/transforms/add_dot_transform_action.cpp
@@ -1,0 +1,40 @@
+
+
+
+
+#include <fullscore/actions/transforms/add_dot_transform_action.h>
+
+#include <fullscore/transforms/add_dot_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::AddDotTransform::AddDotTransform(std::vector<Note> *notes)
+   : Base("add_dot_transform")
+   , notes(notes)
+{}
+
+
+
+
+Action::AddDotTransform::~AddDotTransform()
+{}
+
+
+
+
+bool Action::AddDotTransform::execute()
+{
+   if (!notes) return false;
+
+   Transform::AddDot add_dot_transform;
+   *notes = add_dot_transform.transform(*notes);
+
+   // unimplemented
+   return false;
+}
+
+
+
+

--- a/src/actions/transforms/double_duration_transform_action.cpp
+++ b/src/actions/transforms/double_duration_transform_action.cpp
@@ -1,0 +1,39 @@
+
+
+
+
+#include <fullscore/actions/transforms/double_duration_transform_action.h>
+
+#include <fullscore/transforms/double_duration_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::DoubleDurationTransform::DoubleDurationTransform(std::vector<Note> *notes)
+   : Base("double_duration")
+   , notes(notes)
+{}
+
+
+
+
+Action::DoubleDurationTransform::~DoubleDurationTransform()
+{}
+
+
+
+
+bool Action::DoubleDurationTransform::execute()
+{
+   if (!notes) return false;
+
+   Transform::DoubleDuration double_duration_transform;
+   *notes = double_duration_transform.transform(*notes);
+
+   return true;
+}
+
+
+
+

--- a/src/actions/transforms/erase_note_action.cpp
+++ b/src/actions/transforms/erase_note_action.cpp
@@ -1,0 +1,39 @@
+
+
+
+
+#include <fullscore/actions/transforms/erase_note_action.h>
+
+#include <fullscore/transforms/erase_note_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::EraseNote::EraseNote(std::vector<Note> *notes, int index)
+   : Base("erase_note")
+   , notes(notes)
+   , index(index)
+{}
+
+
+
+
+Action::EraseNote::~EraseNote()
+{}
+
+
+
+
+bool Action::EraseNote::execute()
+{
+   if (!notes || notes->empty() || index < 0 || index >= notes->size()) return false;
+
+   Transform::EraseNote erase_note_transform(index);
+   *notes = erase_note_transform.transform(*notes);
+   return true;
+}
+
+
+
+

--- a/src/actions/transforms/half_duration_transform_action.cpp
+++ b/src/actions/transforms/half_duration_transform_action.cpp
@@ -1,0 +1,39 @@
+
+
+
+
+#include <fullscore/actions/transforms/half_duration_transform_action.h>
+
+#include <fullscore/transforms/half_duration_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::HalfDurationTransform::HalfDurationTransform(std::vector<Note> *notes)
+   : Base("half_duration")
+   , notes(notes)
+{}
+
+
+
+
+Action::HalfDurationTransform::~HalfDurationTransform()
+{}
+
+
+
+
+bool Action::HalfDurationTransform::execute()
+{
+   if (!notes) return false;
+
+   Transform::HalfDuration half_duration_transform;
+   *notes = half_duration_transform.transform(*notes);
+
+   return true;
+}
+
+
+
+

--- a/src/actions/transforms/insert_note_action.cpp
+++ b/src/actions/transforms/insert_note_action.cpp
@@ -27,10 +27,12 @@ Action::InsertNoteTransform::~InsertNoteTransform()
 
 bool Action::InsertNoteTransform::execute()
 {
-   if (!notes) return false;
+   if (!notes || notes->empty() || at_index < 0 || at_index >= notes->size()) return false;
 
-   // unimplemented
-   return false;
+   ::Transform::InsertNote insert_note_transform(at_index, note);
+   *notes = insert_note_transform.transform(*notes);
+
+   return true;
 }
 
 

--- a/src/actions/transforms/insert_note_action.cpp
+++ b/src/actions/transforms/insert_note_action.cpp
@@ -1,0 +1,38 @@
+
+
+
+
+#include <fullscore/actions/transforms/insert_note_action.h>
+
+#include <fullscore/transforms/insert_note_transform.h>
+
+
+
+
+Action::InsertNoteTransform::InsertNoteTransform(std::vector<Note> *notes, int at_index, Note note)
+   : Base("insert_note")
+   , notes(notes)
+   , at_index(at_index)
+   , note(note)
+{}
+
+
+
+
+Action::InsertNoteTransform::~InsertNoteTransform()
+{}
+
+
+
+
+bool Action::InsertNoteTransform::execute()
+{
+   if (!notes) return false;
+
+   // unimplemented
+   return false;
+}
+
+
+
+

--- a/src/actions/transforms/invert_action.cpp
+++ b/src/actions/transforms/invert_action.cpp
@@ -1,0 +1,40 @@
+
+
+
+
+#include <fullscore/actions/transforms/invert_action.h>
+
+#include <fullscore/transforms/invert_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::Transform::Invert::Invert(std::vector<Note> *notes, int axis)
+   : Base("invert")
+   , notes(notes)
+   , axis(axis)
+{}
+
+
+
+
+Action::Transform::Invert::~Invert()
+{}
+
+
+
+
+bool Action::Transform::Invert::execute()
+{
+   if (!notes) return false;
+
+   ::Transform::Invert invert_transform(axis);
+   *notes = invert_transform.transform(*notes);
+
+   return true;
+}
+
+
+
+

--- a/src/actions/transforms/remove_dot_transform_action.cpp
+++ b/src/actions/transforms/remove_dot_transform_action.cpp
@@ -1,0 +1,39 @@
+
+
+
+
+#include <fullscore/actions/transforms/remove_dot_transform_action.h>
+
+#include <fullscore/transforms/remove_dot_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::RemoveDotTransform::RemoveDotTransform(std::vector<Note> *notes)
+   : Base("remove_dot_transform")
+   , notes(notes)
+{}
+
+
+
+
+Action::RemoveDotTransform::~RemoveDotTransform()
+{}
+
+
+
+
+bool Action::RemoveDotTransform::execute()
+{
+   if (!notes) return false;
+
+   Transform::RemoveDot remove_dot_transform;
+   *notes = remove_dot_transform.transform(*notes);
+
+   return true;
+}
+
+
+
+

--- a/src/actions/transforms/retrograde_action.cpp
+++ b/src/actions/transforms/retrograde_action.cpp
@@ -1,0 +1,37 @@
+
+
+
+
+#include <fullscore/actions/transforms/retrograde_action.h>
+
+#include <fullscore/transforms/retrograde_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::Transform::Retrograde::Retrograde(std::vector<Note> *notes)
+   : Base("retrograde")
+   , notes(notes)
+{}
+
+
+
+
+Action::Transform::Retrograde::~Retrograde()
+{}
+
+
+
+
+bool Action::Transform::Retrograde::execute()
+{
+   if (!notes) return false;
+
+   // unimplemented
+   return false;
+}
+
+
+
+

--- a/src/actions/transforms/retrograde_action.cpp
+++ b/src/actions/transforms/retrograde_action.cpp
@@ -28,8 +28,10 @@ bool Action::Transform::Retrograde::execute()
 {
    if (!notes) return false;
 
-   // unimplemented
-   return false;
+   ::Transform::Retrograde retrograde_transform;
+   *notes = retrograde_transform.transform(*notes);
+
+   return true;
 }
 
 

--- a/src/actions/transforms/toggle_rest_action.cpp
+++ b/src/actions/transforms/toggle_rest_action.cpp
@@ -1,0 +1,38 @@
+
+
+
+
+#include <fullscore/actions/transforms/toggle_rest_action.h>
+
+#include <fullscore/transforms/toggle_rest_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::ToggleRest::ToggleRest(std::vector<Note> *notes)
+   : Base("toggle_rest")
+   , notes(notes)
+{}
+
+
+
+
+Action::ToggleRest::~ToggleRest()
+{}
+
+
+
+
+bool Action::ToggleRest::execute()
+{
+   if (!notes) return false;
+
+   Transform::ToggleRest toggle_rest_transform;
+   *notes = toggle_rest_transform.transform(*notes);
+   return true;
+}
+
+
+
+

--- a/src/actions/transforms/transpose_transform_action.cpp
+++ b/src/actions/transforms/transpose_transform_action.cpp
@@ -29,8 +29,10 @@ bool Action::TransposeTransform::execute()
 {
    if (!notes) return false;
 
-   // unimplemented
-   return false;
+   Transform::Transpose transpose_transform(transposition);
+   *notes = transpose_transform.transform(*notes);
+
+   return true;
 }
 
 

--- a/src/actions/transforms/transpose_transform_action.cpp
+++ b/src/actions/transforms/transpose_transform_action.cpp
@@ -1,0 +1,38 @@
+
+
+
+
+#include <fullscore/actions/transforms/transpose_transform_action.h>
+
+#include <fullscore/transforms/transpose_transform.h>
+#include <fullscore/models/note.h>
+
+
+
+
+Action::TransposeTransform::TransposeTransform(std::vector<Note> *notes, int transposition)
+   : Base("transpose")
+   , notes(notes)
+   , transposition(transposition)
+{}
+
+
+
+
+Action::TransposeTransform::~TransposeTransform()
+{}
+
+
+
+
+bool Action::TransposeTransform::execute()
+{
+   if (!notes) return false;
+
+   // unimplemented
+   return false;
+}
+
+
+
+

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -104,10 +104,22 @@ void FullscoreApplicationController::key_down_func()
       Transform::Base *transform = nullptr;
 
       std::vector<Note> *notes = nullptr;
+      Note *single_note = nullptr;
+      std::vector<Note> single_note_as_array;
+
       if (score_editor->is_measure_mode())
       {
          Measure *focused_measure = score_editor->get_measure_at_cursor();
          if (focused_measure) notes = &focused_measure->notes;
+      }
+      else
+      {
+         single_note = score_editor->get_note_at_cursor();
+         if (single_note)
+         {
+            single_note_as_array.push_back(*single_note);
+            notes = &single_note_as_array;
+         }
       }
 
       // locate and build the appropriate transform
@@ -181,6 +193,11 @@ void FullscoreApplicationController::key_down_func()
          break;
       default:
          break;
+      }
+
+      if (single_note && !single_note_as_array.empty())
+      {
+         *single_note = single_note_as_array.at(0);
       }
 
       if (transform)

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -351,12 +351,14 @@ void FullscoreApplicationController::key_down_func()
             Action::YankMeasureToBuffer yank_measure_to_buffer_action(&yank_measure_buffer, focused_measure);
             yank_measure_to_buffer_action.execute();
          }
+         break;
       case ALLEGRO_KEY_P:
          {
             Measure *destination_measure = score_editor->get_measure_at_cursor();
             Action::PasteMeasureFromBuffer paste_measure_from_buffer_action(destination_measure, &yank_measure_buffer);
             paste_measure_from_buffer_action.execute();
          }
+         break;
       case ALLEGRO_KEY_TAB:
          score_editor->toggle_input_mode();
          break;

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -8,6 +8,7 @@
 #include <fullscore/actions/transforms/double_duration_transform_action.h>
 #include <fullscore/actions/transforms/half_duration_transform_action.h>
 #include <fullscore/actions/transforms/remove_dot_transform_action.h>
+#include <fullscore/actions/transforms/toggle_rest_action.h>
 #include <fullscore/actions/transforms/transpose_transform_action.h>
 #include <fullscore/actions/move_cursor_down_action.h>
 #include <fullscore/actions/move_cursor_left_action.h>
@@ -24,7 +25,6 @@
 #include <fullscore/transforms/insert_note_transform.h>
 #include <fullscore/transforms/invert_transform.h>
 #include <fullscore/transforms/retrograde_transform.h>
-#include <fullscore/transforms/toggle_rest_transform.h>
 
 
 
@@ -150,8 +150,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_R:
          {
-            Transform::ToggleRest toggle_rest_transform;
-            transform = &toggle_rest_transform;
+            Action::ToggleRest toggle_rest_action(notes);
+            toggle_rest_action.execute();
          }
          break;
       case ALLEGRO_KEY_E:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -6,6 +6,7 @@
 
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
 #include <fullscore/actions/transforms/remove_dot_transform_action.h>
+#include <fullscore/actions/transforms/transpose_transform_action.h>
 #include <fullscore/actions/move_cursor_down_action.h>
 #include <fullscore/actions/move_cursor_left_action.h>
 #include <fullscore/actions/move_cursor_right_action.h>
@@ -23,7 +24,6 @@
 #include <fullscore/transforms/insert_note_transform.h>
 #include <fullscore/transforms/invert_transform.h>
 #include <fullscore/transforms/retrograde_transform.h>
-#include <fullscore/transforms/transpose_transform.h>
 #include <fullscore/transforms/toggle_rest_transform.h>
 
 
@@ -126,14 +126,14 @@ void FullscoreApplicationController::key_down_func()
       {
       case ALLEGRO_KEY_W:
          {
-            Transform::Transpose transpose_transform(Framework::key_shift ? 7 : 1);
-            transform = &transpose_transform;
+            Action::TransposeTransform transpose_transform_action(notes, Framework::key_shift ? 7 : 1);
+            transpose_transform_action.execute();
          }
          break;
       case ALLEGRO_KEY_S:
          {
-            Transform::Transpose transpose_transform(Framework::key_shift ? -7 : -1);
-            transform = &transpose_transform;
+            Action::TransposeTransform transpose_transform_action(notes, Framework::key_shift ? -7 : -1);
+            transpose_transform_action.execute();
          }
          break;
       case ALLEGRO_KEY_A:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -8,6 +8,7 @@
 #include <fullscore/actions/transforms/double_duration_transform_action.h>
 #include <fullscore/actions/transforms/erase_note_action.h>
 #include <fullscore/actions/transforms/half_duration_transform_action.h>
+#include <fullscore/actions/transforms/invert_action.h>
 #include <fullscore/actions/transforms/remove_dot_transform_action.h>
 #include <fullscore/actions/transforms/toggle_rest_action.h>
 #include <fullscore/actions/transforms/transpose_transform_action.h>
@@ -23,7 +24,6 @@
 #include <fullscore/actions/yank_measure_to_buffer_action.h>
 #include <fullscore/converters/measure_grid_file_converter.h>
 #include <fullscore/transforms/insert_note_transform.h>
-#include <fullscore/transforms/invert_transform.h>
 #include <fullscore/transforms/retrograde_transform.h>
 
 
@@ -162,8 +162,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_I:
          {
-            Transform::Invert invert_transform(0);
-            transform = &invert_transform;
+            Action::Transform::Invert invert_action(0);
+            invert_action.execute();
          }
          break;
       case ALLEGRO_KEY_G:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -4,6 +4,7 @@
 
 #include <fullscore/fullscore_application_controller.h>
 
+#include <fullscore/actions/transforms/add_dot_transform_action.h>
 #include <fullscore/actions/move_cursor_down_action.h>
 #include <fullscore/actions/move_cursor_left_action.h>
 #include <fullscore/actions/move_cursor_right_action.h>
@@ -102,6 +103,13 @@ void FullscoreApplicationController::key_down_func()
 
       Transform::Base *transform = nullptr;
 
+      std::vector<Note> *notes = nullptr;
+      if (score_editor->is_measure_mode())
+      {
+         Measure *focused_measure = score_editor->get_measure_at_cursor();
+         if (focused_measure) notes = &focused_measure->notes;
+      }
+
       // locate and build the appropriate transform
       switch(Framework::current_event->keyboard.keycode)
       {
@@ -155,8 +163,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_FULLSTOP:
          {
-            Transform::AddDot add_dot_transform;
-            transform = &add_dot_transform;
+            Action::AddDotTransform add_dot_transform_action(notes);
+            add_dot_transform_action.execute();
          }
          break;
       case ALLEGRO_KEY_COMMA:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -5,6 +5,7 @@
 #include <fullscore/fullscore_application_controller.h>
 
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
+#include <fullscore/actions/transforms/half_duration_transform_action.h>
 #include <fullscore/actions/transforms/remove_dot_transform_action.h>
 #include <fullscore/actions/transforms/transpose_transform_action.h>
 #include <fullscore/actions/move_cursor_down_action.h>
@@ -20,7 +21,6 @@
 #include <fullscore/converters/measure_grid_file_converter.h>
 #include <fullscore/transforms/double_duration_transform.h>
 #include <fullscore/transforms/erase_note_transform.h>
-#include <fullscore/transforms/half_duration_transform.h>
 #include <fullscore/transforms/insert_note_transform.h>
 #include <fullscore/transforms/invert_transform.h>
 #include <fullscore/transforms/retrograde_transform.h>
@@ -138,8 +138,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_A:
          {
-            Transform::HalfDuration half_duration_transform;
-            transform = &half_duration_transform;
+            Action::HalfDurationTransform half_duration_transform_action(notes);
+            half_duration_transform_action.execute();
          }
          break;
       case ALLEGRO_KEY_D:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -5,6 +5,7 @@
 #include <fullscore/fullscore_application_controller.h>
 
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
+#include <fullscore/actions/transforms/remove_dot_transform_action.h>
 #include <fullscore/actions/move_cursor_down_action.h>
 #include <fullscore/actions/move_cursor_left_action.h>
 #include <fullscore/actions/move_cursor_right_action.h>
@@ -22,7 +23,6 @@
 #include <fullscore/transforms/half_duration_transform.h>
 #include <fullscore/transforms/insert_note_transform.h>
 #include <fullscore/transforms/invert_transform.h>
-#include <fullscore/transforms/remove_dot_transform.h>
 #include <fullscore/transforms/retrograde_transform.h>
 #include <fullscore/transforms/transpose_transform.h>
 #include <fullscore/transforms/toggle_rest_transform.h>
@@ -181,8 +181,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_COMMA:
          {
-            Transform::RemoveDot remove_dot_transform;
-            transform = &remove_dot_transform;
+            Action::RemoveDotTransform remove_dot_transform_action(notes);
+            remove_dot_transform_action.execute();
          }
          break;
       case ALLEGRO_KEY_N:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -188,22 +188,6 @@ void FullscoreApplicationController::key_down_func()
             insert_note_transform_action.execute();
          }
          break;
-      default:
-         break;
-      }
-
-      if (single_note && !single_note_as_array.empty())
-      {
-         *single_note = single_note_as_array.at(0);
-      }
-
-
-      //
-      // NON-SCORE EDITING COMMANDS
-      //
-
-      switch(Framework::current_event->keyboard.keycode)
-      {
       case ALLEGRO_KEY_F1:
          {
             if (showing_help_menu)
@@ -339,6 +323,11 @@ void FullscoreApplicationController::key_down_func()
       case ALLEGRO_KEY_TAB:
          score_editor->toggle_input_mode();
          break;
+      }
+
+      if (single_note && !single_note_as_array.empty())
+      {
+         *single_note = single_note_as_array.at(0);
       }
    }
 }

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -25,7 +25,6 @@
 #include <fullscore/actions/toggle_command_bar_action.h>
 #include <fullscore/actions/yank_measure_to_buffer_action.h>
 #include <fullscore/converters/measure_grid_file_converter.h>
-#include <fullscore/transforms/insert_note_transform.h>
 
 
 
@@ -100,8 +99,6 @@ void FullscoreApplicationController::key_down_func()
       //
       // SCORE EDITING COMMANDS
       //
-
-      Transform::Base *transform = nullptr;
 
       std::vector<Note> *notes = nullptr;
       Note *single_note = nullptr;
@@ -200,26 +197,6 @@ void FullscoreApplicationController::key_down_func()
          *single_note = single_note_as_array.at(0);
       }
 
-      if (transform)
-      {
-         std::vector<Note> *notes = nullptr;
-         Note *note = nullptr;
-         // find the note/notes to transform
-         if (score_editor->is_measure_mode())
-         {
-            Measure *focused_measure = score_editor->get_measure_at_cursor();
-            if (focused_measure) notes = &focused_measure->notes;
-         }
-         else
-         {
-            Note *focused_note = score_editor->get_note_at_cursor();
-            if (focused_note) note = focused_note;
-         }
-
-         // perform the actual transformation
-         if (note) *note = transform->transform({*note})[0];
-         else if (notes) *notes = transform->transform(*notes);
-      }
 
       //
       // NON-SCORE EDITING COMMANDS

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -6,6 +6,7 @@
 
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
 #include <fullscore/actions/transforms/double_duration_transform_action.h>
+#include <fullscore/actions/transforms/erase_note_action.h>
 #include <fullscore/actions/transforms/half_duration_transform_action.h>
 #include <fullscore/actions/transforms/remove_dot_transform_action.h>
 #include <fullscore/actions/transforms/toggle_rest_action.h>
@@ -21,7 +22,6 @@
 #include <fullscore/actions/toggle_command_bar_action.h>
 #include <fullscore/actions/yank_measure_to_buffer_action.h>
 #include <fullscore/converters/measure_grid_file_converter.h>
-#include <fullscore/transforms/erase_note_transform.h>
 #include <fullscore/transforms/insert_note_transform.h>
 #include <fullscore/transforms/invert_transform.h>
 #include <fullscore/transforms/retrograde_transform.h>
@@ -156,8 +156,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_E:
          {
-            Transform::EraseNote erase_note_transform(score_editor->note_cursor_x);
-            transform = &erase_note_transform;
+            Action::EraseNote erase_note_action(notes, score_editor->note_cursor_x);
+            erase_note_action.execute();
          }
          break;
       case ALLEGRO_KEY_I:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -321,7 +321,7 @@ void FullscoreApplicationController::key_down_func()
          }
          break;
       case ALLEGRO_KEY_TAB:
-         score_editor->toggle_input_mode();
+         score_editor->toggle_edit_mode_target();
          break;
       }
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -10,6 +10,7 @@
 #include <fullscore/actions/transforms/half_duration_transform_action.h>
 #include <fullscore/actions/transforms/invert_action.h>
 #include <fullscore/actions/transforms/remove_dot_transform_action.h>
+#include <fullscore/actions/transforms/retrograde_action.h>
 #include <fullscore/actions/transforms/toggle_rest_action.h>
 #include <fullscore/actions/transforms/transpose_transform_action.h>
 #include <fullscore/actions/move_cursor_down_action.h>
@@ -24,7 +25,6 @@
 #include <fullscore/actions/yank_measure_to_buffer_action.h>
 #include <fullscore/converters/measure_grid_file_converter.h>
 #include <fullscore/transforms/insert_note_transform.h>
-#include <fullscore/transforms/retrograde_transform.h>
 
 
 
@@ -168,8 +168,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_G:
          {
-            Transform::Retrograde retrograde_transform;
-            transform = &retrograde_transform;
+            Action::Transform::Retrograde retrograde_action(notes);
+            retrograde_action.execute();
          }
          break;
       case ALLEGRO_KEY_FULLSTOP:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -17,7 +17,6 @@
 #include <fullscore/actions/toggle_command_bar_action.h>
 #include <fullscore/actions/yank_measure_to_buffer_action.h>
 #include <fullscore/converters/measure_grid_file_converter.h>
-#include <fullscore/transforms/add_dot_transform.h>
 #include <fullscore/transforms/double_duration_transform.h>
 #include <fullscore/transforms/erase_note_transform.h>
 #include <fullscore/transforms/half_duration_transform.h>

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -8,6 +8,7 @@
 #include <fullscore/actions/transforms/double_duration_transform_action.h>
 #include <fullscore/actions/transforms/erase_note_action.h>
 #include <fullscore/actions/transforms/half_duration_transform_action.h>
+#include <fullscore/actions/transforms/insert_note_action.h>
 #include <fullscore/actions/transforms/invert_action.h>
 #include <fullscore/actions/transforms/remove_dot_transform_action.h>
 #include <fullscore/actions/transforms/retrograde_action.h>
@@ -186,8 +187,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_N:
          {
-            Transform::InsertNote insert_note_transform(score_editor->note_cursor_x, Note());
-            transform = &insert_note_transform;
+            Action::InsertNoteTransform insert_note_transform_action(notes, score_editor->note_cursor_x, Note());
+            insert_note_transform_action.execute();
          }
          break;
       default:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -5,6 +5,7 @@
 #include <fullscore/fullscore_application_controller.h>
 
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
+#include <fullscore/actions/transforms/double_duration_transform_action.h>
 #include <fullscore/actions/transforms/half_duration_transform_action.h>
 #include <fullscore/actions/transforms/remove_dot_transform_action.h>
 #include <fullscore/actions/transforms/transpose_transform_action.h>
@@ -19,7 +20,6 @@
 #include <fullscore/actions/toggle_command_bar_action.h>
 #include <fullscore/actions/yank_measure_to_buffer_action.h>
 #include <fullscore/converters/measure_grid_file_converter.h>
-#include <fullscore/transforms/double_duration_transform.h>
 #include <fullscore/transforms/erase_note_transform.h>
 #include <fullscore/transforms/insert_note_transform.h>
 #include <fullscore/transforms/invert_transform.h>
@@ -144,8 +144,8 @@ void FullscoreApplicationController::key_down_func()
          break;
       case ALLEGRO_KEY_D:
          {
-            Transform::DoubleDuration double_duration_transform;
-            transform = &double_duration_transform;
+            Action::DoubleDurationTransform double_duration_transform_action(notes);
+            double_duration_transform_action.execute();
          }
          break;
       case ALLEGRO_KEY_R:

--- a/src/gui_score_editor.cpp
+++ b/src/gui_score_editor.cpp
@@ -27,7 +27,7 @@ GUIScoreEditor::GUIScoreEditor(UIWidget *parent, Display *display, PlaybackDevic
    , showing_debug_data(false)
    , STAFF_HEIGHT(80)
    , FULL_MEASURE_WIDTH(music_engraver.music_notation.get_quarter_note_spacing()*4)
-   , input_mode(false)
+   , edit_mode_target(MEASURE_TARGET)
 {
    attr.set(UI_ATTR__UI_WIDGET_TYPE, "UIScoreEditor");
    attr.set("id", "UIScoreEditor" + tostring(UIWidget::get_num_created_widgets()));
@@ -290,9 +290,10 @@ int GUIScoreEditor::move_note_cursor_x(int delta)
 
 
 
-void GUIScoreEditor::toggle_input_mode()
+void GUIScoreEditor::toggle_edit_mode_target()
 {
-   input_mode = !input_mode;
+   if (edit_mode_target == NOTE_TARGET) edit_mode_target = MEASURE_TARGET;
+   else if (edit_mode_target == MEASURE_TARGET) edit_mode_target = NOTE_TARGET;
 }
 
 
@@ -300,7 +301,7 @@ void GUIScoreEditor::toggle_input_mode()
 
 bool GUIScoreEditor::is_measure_mode()
 {
-   return input_mode;
+   return edit_mode_target == MEASURE_TARGET;
 }
 
 
@@ -308,7 +309,7 @@ bool GUIScoreEditor::is_measure_mode()
 
 bool GUIScoreEditor::is_note_mode()
 {
-   return !input_mode;
+   return edit_mode_target == NOTE_TARGET;
 }
 
 

--- a/src/tools/generate.cpp
+++ b/src/tools/generate.cpp
@@ -3,12 +3,16 @@
 
 
 #include <iostream>
+#include <vector>
+#include <string>
 
 
 
-
-int main(int, char**)
+int main(int argv, char **argc)
 {
+   std::vector<std::string> args;
+   for (int i=0; i<argv; i++) args.push_back(argc[i]);
+
    std::cout << "WORKING!" << std::endl;
    return 0;
 }

--- a/src/tools/generate.cpp
+++ b/src/tools/generate.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <vector>
 #include <string>
+#include <allegro5/allegro.h>
 
 
 
@@ -12,6 +13,11 @@ int main(int argv, char **argc)
 {
    std::vector<std::string> args;
    for (int i=0; i<argv; i++) args.push_back(argc[i]);
+
+   if (!al_init()) std::cerr << "al_init() failed" << std::endl;
+   ALLEGRO_PATH *resource_path = al_get_standard_path(ALLEGRO_RESOURCES_PATH);
+   al_change_directory(al_path_cstr(resource_path, ALLEGRO_NATIVE_PATH_SEP));
+   al_destroy_path(resource_path);
 
    std::cout << "WORKING!" << std::endl;
    return 0;

--- a/src/tools/generate.cpp
+++ b/src/tools/generate.cpp
@@ -1,0 +1,18 @@
+
+
+
+
+#include <iostream>
+
+
+
+
+int main(int, char**)
+{
+   std::cout << "WORKING!" << std::endl;
+   return 0;
+}
+
+
+
+


### PR DESCRIPTION
### Situation

Continuing from https://github.com/MarkOates/fullscore/pull/9, this PR refactors the remaining `Transforms::` that are used in the main application controller, and wraps them into a Command pattern.

### Note

The style conventions are inconsistent.  Some of them use `Action::Transform::[Name]`, while others are `Action::[Name]`, while others are `Action::[Name]Transform`, some filenames are `[name]_action.h`, while others are `[name]_transform_action.h`. There wasn't a clear best-practice, so I chose to keep all three class naming conventions and both filename conventions for the time being, until a more obvious winner can be chosen later.