### PR TITLE
Fix Action Robustness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,4 +71,5 @@ tools: src/tools/generate.cpp
 clean:
 	rm ./obj/*.o
 	rm ./obj/*/*.o
+	rm ./obj/*/*/*.o
 	rm ./bin/fullscore

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ tools: src/tools/generate.cpp
 #
 
 clean:
-	rm ./obj/*.o
-	rm ./obj/*/*.o
-	rm ./obj/*/*/*.o
-	rm ./bin/fullscore
+	-rm ./obj/*.o
+	-rm ./obj/*/*.o
+	-rm ./obj/*/*/*.o
+	-rm ./bin/fullscore

--- a/include/fullscore/actions/action_base.h
+++ b/include/fullscore/actions/action_base.h
@@ -18,7 +18,7 @@ namespace Action
 
    public:
       Base(std::string action_name);
-      ~Base();
+      virtual ~Base();
       virtual bool execute() = 0;
       std::string get_action_name();
    };

--- a/include/fullscore/actions/transforms/add_dot_transform_action.h
+++ b/include/fullscore/actions/transforms/add_dot_transform_action.h
@@ -16,10 +16,10 @@ namespace Action
    class AddDotTransform : public Base
    {
    private:
-      std::vector<Note> *notes;
+      Note *note;
 
    public:
-      AddDotTransform(std::vector<Note> *notes);
+      AddDotTransform(Note *note);
       ~AddDotTransform();
 
       bool execute() override;

--- a/include/fullscore/actions/transforms/double_duration_transform_action.h
+++ b/include/fullscore/actions/transforms/double_duration_transform_action.h
@@ -16,10 +16,10 @@ namespace Action
    class DoubleDurationTransform : public Base
    {
    private:
-      std::vector<Note> *notes;
+      Note *note;
 
    public:
-      DoubleDurationTransform(std::vector<Note> *notes);
+      DoubleDurationTransform(Note *note);
       ~DoubleDurationTransform();
 
       bool execute() override;

--- a/include/fullscore/actions/transforms/half_duration_transform_action.h
+++ b/include/fullscore/actions/transforms/half_duration_transform_action.h
@@ -16,10 +16,10 @@ namespace Action
    class HalfDurationTransform : public Base
    {
    private:
-      std::vector<Note> *notes;
+      Note *note;
 
    public:
-      HalfDurationTransform(std::vector<Note> *notes);
+      HalfDurationTransform(Note *note);
       ~HalfDurationTransform();
 
       bool execute() override;

--- a/include/fullscore/actions/transforms/invert_action.h
+++ b/include/fullscore/actions/transforms/invert_action.h
@@ -18,11 +18,11 @@ namespace Action
       class Invert : public Base
       {
       private:
-         std::vector<Note> *notes;
+         Note *note;
          int axis;
 
       public:
-         Invert(std::vector<Note> *notes, int axis=0);
+         Invert(Note *note, int axis=0);
          ~Invert();
 
          bool execute() override;

--- a/include/fullscore/actions/transforms/remove_dot_transform_action.h
+++ b/include/fullscore/actions/transforms/remove_dot_transform_action.h
@@ -16,10 +16,10 @@ namespace Action
    class RemoveDotTransform : public Base
    {
    private:
-      std::vector<Note> *notes;
+      Note *note;
 
    public:
-      RemoveDotTransform(std::vector<Note> *notes);
+      RemoveDotTransform(Note *note);
       ~RemoveDotTransform();
 
       bool execute() override;

--- a/include/fullscore/actions/transforms/toggle_rest_action.h
+++ b/include/fullscore/actions/transforms/toggle_rest_action.h
@@ -16,10 +16,10 @@ namespace Action
    class ToggleRest : public Base
    {
    private:
-      std::vector<Note> *notes;
+      Note *note;
 
    public:
-      ToggleRest(std::vector<Note> *notes);
+      ToggleRest(Note *note);
       ~ToggleRest();
 
       bool execute() override;

--- a/include/fullscore/actions/transforms/transpose_transform_action.h
+++ b/include/fullscore/actions/transforms/transpose_transform_action.h
@@ -16,11 +16,11 @@ namespace Action
    class TransposeTransform : public Base
    {
    private:
-      std::vector<Note> *notes;
+      Note *note;
       int transposition;
 
    public:
-      TransposeTransform(std::vector<Note> *notes, int transposition);
+      TransposeTransform(Note *note, int transposition);
       ~TransposeTransform();
 
       bool execute() override;

--- a/include/fullscore/fullscore_application_controller.h
+++ b/include/fullscore/fullscore_application_controller.h
@@ -36,7 +36,7 @@ public:
    void execute_command_mode_action_for_key(int al_keycode);
    void execute_edit_mode_action_for_key(int al_keycode);
 
-   std::string find_action_identifier_by_keycode(int al_keycode);
+   std::string find_action_identifier_by_keycode(int al_keycode, bool shift=false, bool alt=false);
 };
 
 

--- a/include/fullscore/fullscore_application_controller.h
+++ b/include/fullscore/fullscore_application_controller.h
@@ -35,6 +35,8 @@ public:
    void execute_normal_mode_action_for_key(int al_keycode);
    void execute_command_mode_action_for_key(int al_keycode);
    void execute_edit_mode_action_for_key(int al_keycode);
+
+   std::string find_action_identifier_by_keycode(int al_keycode);
 };
 
 

--- a/include/fullscore/fullscore_application_controller.h
+++ b/include/fullscore/fullscore_application_controller.h
@@ -6,6 +6,7 @@
 
 #include <allegro_flare/screens/simple_notification_screen.h>
 
+#include <fullscore/actions/action_base.h>
 #include <fullscore/command_bar.h>
 #include <fullscore/gui_score_editor.h>
 #include <fullscore/mixer.h>
@@ -32,7 +33,7 @@ public:
    void key_down_func() override;
    void on_message(UIWidget *sender, std::string message) override;
 
-   void execute_normal_mode_action_for_key(int al_keycode);
+   Action::Base *create_normal_mode_action(std::string action_name);
    void execute_command_mode_action_for_key(int al_keycode);
    void execute_edit_mode_action_for_key(int al_keycode);
 

--- a/include/fullscore/fullscore_application_controller.h
+++ b/include/fullscore/fullscore_application_controller.h
@@ -36,7 +36,7 @@ public:
    void execute_command_mode_action_for_key(int al_keycode);
    void execute_edit_mode_action_for_key(int al_keycode);
 
-   std::string find_action_identifier_by_keycode(int al_keycode, bool shift=false, bool alt=false);
+   std::string find_action_identifier_by_normal_mode_keycode(int al_keycode, bool shift=false, bool alt=false);
 };
 
 

--- a/src/actions/transforms/add_dot_transform_action.cpp
+++ b/src/actions/transforms/add_dot_transform_action.cpp
@@ -10,9 +10,9 @@
 
 
 
-Action::AddDotTransform::AddDotTransform(std::vector<Note> *notes)
+Action::AddDotTransform::AddDotTransform(Note *note)
    : Base("add_dot_transform")
-   , notes(notes)
+   , note(note)
 {}
 
 
@@ -26,10 +26,15 @@ Action::AddDotTransform::~AddDotTransform()
 
 bool Action::AddDotTransform::execute()
 {
-   if (!notes) return false;
+   if (!note) return false;
+
+   std::vector<Note> single_note_as_array;
+   single_note_as_array.push_back(*note);
 
    Transform::AddDot add_dot_transform;
-   *notes = add_dot_transform.transform(*notes);
+   single_note_as_array = add_dot_transform.transform(single_note_as_array);
+
+   *note = single_note_as_array.at(0);
 
    return true;
 }

--- a/src/actions/transforms/double_duration_transform_action.cpp
+++ b/src/actions/transforms/double_duration_transform_action.cpp
@@ -10,9 +10,9 @@
 
 
 
-Action::DoubleDurationTransform::DoubleDurationTransform(std::vector<Note> *notes)
+Action::DoubleDurationTransform::DoubleDurationTransform(Note *note)
    : Base("double_duration")
-   , notes(notes)
+   , note(note)
 {}
 
 
@@ -26,10 +26,15 @@ Action::DoubleDurationTransform::~DoubleDurationTransform()
 
 bool Action::DoubleDurationTransform::execute()
 {
-   if (!notes) return false;
+   if (!note) return false;
+
+   std::vector<Note> single_note_as_array;
+   single_note_as_array.push_back(*note);
 
    Transform::DoubleDuration double_duration_transform;
-   *notes = double_duration_transform.transform(*notes);
+   single_note_as_array = double_duration_transform.transform(single_note_as_array);
+
+   *note = single_note_as_array.at(0);
 
    return true;
 }

--- a/src/actions/transforms/half_duration_transform_action.cpp
+++ b/src/actions/transforms/half_duration_transform_action.cpp
@@ -10,9 +10,9 @@
 
 
 
-Action::HalfDurationTransform::HalfDurationTransform(std::vector<Note> *notes)
+Action::HalfDurationTransform::HalfDurationTransform(Note *note)
    : Base("half_duration")
-   , notes(notes)
+   , note(note)
 {}
 
 
@@ -26,10 +26,15 @@ Action::HalfDurationTransform::~HalfDurationTransform()
 
 bool Action::HalfDurationTransform::execute()
 {
-   if (!notes) return false;
+   if (!note) return false;
+
+   std::vector<Note> single_note_as_array;
+   single_note_as_array.push_back(*note);
 
    Transform::HalfDuration half_duration_transform;
-   *notes = half_duration_transform.transform(*notes);
+   single_note_as_array = half_duration_transform.transform(single_note_as_array);
+
+   *note = single_note_as_array.at(0);
 
    return true;
 }

--- a/src/actions/transforms/invert_action.cpp
+++ b/src/actions/transforms/invert_action.cpp
@@ -10,9 +10,9 @@
 
 
 
-Action::Transform::Invert::Invert(std::vector<Note> *notes, int axis)
+Action::Transform::Invert::Invert(Note *note, int axis)
    : Base("invert")
-   , notes(notes)
+   , note(note)
    , axis(axis)
 {}
 
@@ -27,10 +27,15 @@ Action::Transform::Invert::~Invert()
 
 bool Action::Transform::Invert::execute()
 {
-   if (!notes) return false;
+   if (!note) return false;
+
+   std::vector<Note> single_note_as_array;
+   single_note_as_array.push_back(*note);
 
    ::Transform::Invert invert_transform(axis);
-   *notes = invert_transform.transform(*notes);
+   single_note_as_array = invert_transform.transform(single_note_as_array);
+
+   *note = single_note_as_array.at(0);
 
    return true;
 }

--- a/src/actions/transforms/remove_dot_transform_action.cpp
+++ b/src/actions/transforms/remove_dot_transform_action.cpp
@@ -10,9 +10,9 @@
 
 
 
-Action::RemoveDotTransform::RemoveDotTransform(std::vector<Note> *notes)
+Action::RemoveDotTransform::RemoveDotTransform(Note *note)
    : Base("remove_dot_transform")
-   , notes(notes)
+   , note(note)
 {}
 
 
@@ -26,10 +26,15 @@ Action::RemoveDotTransform::~RemoveDotTransform()
 
 bool Action::RemoveDotTransform::execute()
 {
-   if (!notes) return false;
+   if (!note) return false;
+
+   std::vector<Note> single_note_as_array;
+   single_note_as_array.push_back(*note);
 
    Transform::RemoveDot remove_dot_transform;
-   *notes = remove_dot_transform.transform(*notes);
+   single_note_as_array = remove_dot_transform.transform(single_note_as_array);
+
+   *note = single_note_as_array.at(0);
 
    return true;
 }

--- a/src/actions/transforms/toggle_rest_action.cpp
+++ b/src/actions/transforms/toggle_rest_action.cpp
@@ -10,9 +10,9 @@
 
 
 
-Action::ToggleRest::ToggleRest(std::vector<Note> *notes)
+Action::ToggleRest::ToggleRest(Note *note)
    : Base("toggle_rest")
-   , notes(notes)
+   , note(note)
 {}
 
 
@@ -26,10 +26,16 @@ Action::ToggleRest::~ToggleRest()
 
 bool Action::ToggleRest::execute()
 {
-   if (!notes) return false;
+   if (!note) return false;
+
+   std::vector<Note> single_note_as_array;
+   single_note_as_array.push_back(*note);
 
    Transform::ToggleRest toggle_rest_transform;
-   *notes = toggle_rest_transform.transform(*notes);
+   single_note_as_array = toggle_rest_transform.transform(single_note_as_array);
+
+   *note = single_note_as_array.at(0);
+
    return true;
 }
 

--- a/src/actions/transforms/transpose_transform_action.cpp
+++ b/src/actions/transforms/transpose_transform_action.cpp
@@ -10,9 +10,9 @@
 
 
 
-Action::TransposeTransform::TransposeTransform(std::vector<Note> *notes, int transposition)
+Action::TransposeTransform::TransposeTransform(Note *note, int transposition)
    : Base("transpose")
-   , notes(notes)
+   , note(note)
    , transposition(transposition)
 {}
 
@@ -27,10 +27,15 @@ Action::TransposeTransform::~TransposeTransform()
 
 bool Action::TransposeTransform::execute()
 {
-   if (!notes) return false;
+   if (!note) return false;
+
+   std::vector<Note> single_note_as_array;
+   single_note_as_array.push_back(*note);
 
    Transform::Transpose transpose_transform(transposition);
-   *notes = transpose_transform.transform(*notes);
+   single_note_as_array = transpose_transform.transform(single_note_as_array);
+
+   *note = single_note_as_array.at(0);
 
    return true;
 }

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -136,8 +136,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::ToggleRest(notes);
       break;
    case ALLEGRO_KEY_I:
-      // ####### //
-      action = new Action::Transform::Invert(notes, 0);
+      action = new Action::Transform::Invert(single_note, 0);
       break;
    case ALLEGRO_KEY_FULLSTOP:
       action = new Action::AddDotTransform(single_note);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -137,7 +137,7 @@ std::string FullscoreApplicationController::find_action_identifier_by_normal_mod
 
 
 
-void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_keycode)
+Action::Base *FullscoreApplicationController::create_normal_mode_action(std::string action_name)
 {
    //
    // SCORE EDITING COMMANDS
@@ -157,8 +157,6 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       focused_measure = score_editor->get_measure_at_cursor();
       if (focused_measure) notes = &focused_measure->notes;
    }
-
-   std::string action_name = "";
 
    if (action_name == "XXXtranspose_up")
       action = new Action::TransposeTransform(single_note, Framework::key_shift ? 7 : 1);
@@ -224,11 +222,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::ToggleEditModeTarget(score_editor);
 
 
-   if (action)
-   {
-      action->execute();
-      delete action;
-   }
+   return action;
 }
 
 
@@ -269,7 +263,17 @@ void FullscoreApplicationController::key_down_func()
    switch(score_editor->mode)
    {
    case GUIScoreEditor::NORMAL_MODE:
-      execute_normal_mode_action_for_key(key);
+      {
+         std::string identifier = find_action_identifier_by_normal_mode_keycode(key, Framework::key_shift, Framework::key_alt);
+
+         Action::Base *action = create_normal_mode_action(identifier);
+
+         if (action)
+         {
+            action->execute();
+            delete action;
+         }
+      }
       break;
    case GUIScoreEditor::INSERT_MODE:
       execute_edit_mode_action_for_key(key);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -302,18 +302,23 @@ void FullscoreApplicationController::on_message(UIWidget *sender, std::string me
 {
    std::cout << "message: " << message << std::endl;
 
-   Action::Base *action = create_normal_mode_action(message);
+   if (!message.empty() && message[0] == ':')
+   {
+      std::string action_identifier = message.substr(1);
 
-   if (action)
-   {
-      action->execute();
-      delete action;
-   }
-   else
-   {
-      std::string error_message = "Unfound action: ";
-      error_message += message;
-      simple_notification_screen->spawn_notification(error_message);
+      Action::Base *action = create_normal_mode_action(action_identifier);
+
+      if (action)
+      {
+         action->execute();
+         delete action;
+      }
+      else
+      {
+         std::string error_message = "Unfound action: ";
+         error_message += action_identifier;
+         simple_notification_screen->spawn_notification(error_message);
+      }
    }
 }
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -220,32 +220,32 @@ Action::Base *FullscoreApplicationController::create_normal_mode_action(std::str
       action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
    else if (action_name == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(score_editor);
-   if (action_name == "insert_measure")
+   else if (action_name == "insert_measure")
    {
       Action::InsertMeasure insert_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
       insert_measure_action.execute();
    }
-   if (action_name == "delete_measure")
+   else if (action_name == "delete_measure")
    {
       Action::DeleteMeasure delete_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
       delete_measure_action.execute();
    }
-   if (action_name == "insert_staff")
+   else if (action_name == "insert_staff")
    {
       Action::InsertStaff insert_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
       insert_staff_action.execute();
    }
-   if (action_name == "delete_staff")
+   else if (action_name == "delete_staff")
    {
       Action::DeleteStaff delete_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
       delete_staff_action.execute();
    }
-   if (action_name == "append_measure")
+   else if (action_name == "append_measure")
    {
       Action::AppendMeasure append_measure_action(&score_editor->measure_grid);
       append_measure_action.execute();
    }
-   if (action_name == "append_staff")
+   else if (action_name == "append_staff")
    {
       Action::AppendStaff append_staff_action(&score_editor->measure_grid);
       append_staff_action.execute();

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -128,8 +128,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::HalfDurationTransform(notes);
       break;
    case ALLEGRO_KEY_D:
-      // ####### //
-      action = new Action::DoubleDurationTransform(notes);
+      action = new Action::DoubleDurationTransform(single_note);
       break;
    case ALLEGRO_KEY_R:
       action = new Action::ToggleRest(single_note);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -315,6 +315,9 @@ void FullscoreApplicationController::on_message(UIWidget *sender, std::string me
             simple_notification_screen->spawn_notification(action->get_action_name());
             action->execute();
             delete action;
+
+            Action::SetMode return_to_normal_mode(score_editor, command_bar, GUIScoreEditor::NORMAL_MODE);
+            return_to_normal_mode.execute();
          }
          else
          {

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -322,6 +322,12 @@ void FullscoreApplicationController::on_message(UIWidget *sender, std::string me
             simple_notification_screen->spawn_notification(error_message);
          }
       }
+      else
+      {
+         std::string error_message = "Unrecognized input: ";
+         error_message += message;
+         simple_notification_screen->spawn_notification(error_message);
+      }
    }
 }
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -140,8 +140,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::Transform::Invert(notes, 0);
       break;
    case ALLEGRO_KEY_FULLSTOP:
-      // ####### //
-      action = new Action::AddDotTransform(notes);
+      action = new Action::AddDotTransform(single_note);
       break;
    case ALLEGRO_KEY_COMMA:
       // ####### //

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -309,6 +309,12 @@ void FullscoreApplicationController::on_message(UIWidget *sender, std::string me
       action->execute();
       delete action;
    }
+   else
+   {
+      std::string error_message = "Unfound action: ";
+      error_message += message;
+      simple_notification_screen->spawn_notification(error_message);
+   }
 }
 
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -104,7 +104,6 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
 
    std::vector<Note> *notes = nullptr;
    Note *single_note = score_editor->get_note_at_cursor();
-   std::vector<Note> single_note_as_array;
    Measure *focused_measure = nullptr;
 
    if (score_editor->is_measure_target_mode())

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -143,8 +143,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::AddDotTransform(single_note);
       break;
    case ALLEGRO_KEY_COMMA:
-      // ####### //
-      action = new Action::RemoveDotTransform(notes);
+      action = new Action::RemoveDotTransform(single_note);
       break;
    case ALLEGRO_KEY_SEMICOLON:
       action = new Action::SetMode(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -116,9 +116,6 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    // locate and build the appropriate transform
    switch(al_keycode)
    {
-   case ALLEGRO_KEY_SEMICOLON:
-      action = new Action::SetMode(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);
-      break;
    case ALLEGRO_KEY_W:
       // ####### //
       action = new Action::TransposeTransform(notes, Framework::key_shift ? 7 : 1);
@@ -139,15 +136,9 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       // ####### //
       action = new Action::ToggleRest(notes);
       break;
-   case ALLEGRO_KEY_E:
-      action = new Action::EraseNote(notes, score_editor->note_cursor_x);
-      break;
    case ALLEGRO_KEY_I:
       // ####### //
       action = new Action::Transform::Invert(notes, 0);
-      break;
-   case ALLEGRO_KEY_G:
-      action = new Action::Transform::Retrograde(notes);
       break;
    case ALLEGRO_KEY_FULLSTOP:
       // ####### //
@@ -156,6 +147,15 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    case ALLEGRO_KEY_COMMA:
       // ####### //
       action = new Action::RemoveDotTransform(notes);
+      break;
+   case ALLEGRO_KEY_SEMICOLON:
+      action = new Action::SetMode(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);
+      break;
+   case ALLEGRO_KEY_E:
+      action = new Action::EraseNote(notes, score_editor->note_cursor_x);
+      break;
+   case ALLEGRO_KEY_G:
+      action = new Action::Transform::Retrograde(notes);
       break;
    case ALLEGRO_KEY_N:
       action = new Action::InsertNoteTransform(notes, score_editor->note_cursor_x, Note());

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -132,8 +132,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::DoubleDurationTransform(notes);
       break;
    case ALLEGRO_KEY_R:
-      // ####### //
-      action = new Action::ToggleRest(notes);
+      action = new Action::ToggleRest(single_note);
       break;
    case ALLEGRO_KEY_I:
       action = new Action::Transform::Invert(single_note, 0);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -100,6 +100,8 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    // SCORE EDITING COMMANDS
    //
 
+   Action::Base *action = nullptr;
+
    std::vector<Note> *notes = nullptr;
    Note *single_note = nullptr;
    std::vector<Note> single_note_as_array;
@@ -124,204 +126,178 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    {
    case ALLEGRO_KEY_SEMICOLON:
       {
-         Action::SetMode set_mode_action(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);
-         set_mode_action.execute();
+         action = new Action::SetMode(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);
       }
       break;
    case ALLEGRO_KEY_W:
       {
-         Action::TransposeTransform transpose_transform_action(notes, Framework::key_shift ? 7 : 1);
-         transpose_transform_action.execute();
+         action = new Action::TransposeTransform(notes, Framework::key_shift ? 7 : 1);
       }
       break;
    case ALLEGRO_KEY_S:
       {
-         Action::TransposeTransform transpose_transform_action(notes, Framework::key_shift ? -7 : -1);
-         transpose_transform_action.execute();
+         action = new Action::TransposeTransform(notes, Framework::key_shift ? -7 : -1);
       }
       break;
    case ALLEGRO_KEY_A:
       {
-         Action::HalfDurationTransform half_duration_transform_action(notes);
-         half_duration_transform_action.execute();
+         action = new Action::HalfDurationTransform(notes);
       }
       break;
    case ALLEGRO_KEY_D:
       {
-         Action::DoubleDurationTransform double_duration_transform_action(notes);
-         double_duration_transform_action.execute();
+         action = new Action::DoubleDurationTransform(notes);
       }
       break;
    case ALLEGRO_KEY_R:
       {
-         Action::ToggleRest toggle_rest_action(notes);
-         toggle_rest_action.execute();
+         action = new Action::ToggleRest(notes);
       }
       break;
    case ALLEGRO_KEY_E:
       {
-         Action::EraseNote erase_note_action(notes, score_editor->note_cursor_x);
-         erase_note_action.execute();
+         action = new Action::EraseNote(notes, score_editor->note_cursor_x);
       }
       break;
    case ALLEGRO_KEY_I:
       {
-         Action::Transform::Invert invert_action(0);
-         invert_action.execute();
+         action = new Action::Transform::Invert(0);
       }
       break;
    case ALLEGRO_KEY_G:
       {
-         Action::Transform::Retrograde retrograde_action(notes);
-         retrograde_action.execute();
+         action = new Action::Transform::Retrograde(notes);
       }
       break;
    case ALLEGRO_KEY_FULLSTOP:
       {
-         Action::AddDotTransform add_dot_transform_action(notes);
-         add_dot_transform_action.execute();
+         action = new Action::AddDotTransform(notes);
       }
       break;
    case ALLEGRO_KEY_COMMA:
       {
-         Action::RemoveDotTransform remove_dot_transform_action(notes);
-         remove_dot_transform_action.execute();
+         action = new Action::RemoveDotTransform(notes);
       }
       break;
    case ALLEGRO_KEY_N:
       {
-         Action::InsertNoteTransform insert_note_transform_action(notes, score_editor->note_cursor_x, Note());
-         insert_note_transform_action.execute();
+         action = new Action::InsertNoteTransform(notes, score_editor->note_cursor_x, Note());
       }
       break;
    case ALLEGRO_KEY_F1:
       {
-         Action::ToggleHelpWindow toggle_help_window_action(&Framework::motion(), this);
-         toggle_help_window_action.execute();
+         action = new Action::ToggleHelpWindow(&Framework::motion(), this);
       }
       break;
    case ALLEGRO_KEY_F2:
       {
-         Action::ToggleShowDebugData toggle_show_debug_data_action(score_editor);
-         toggle_show_debug_data_action.execute();
+         action = new Action::ToggleShowDebugData(score_editor);
       }
       break;
    case ALLEGRO_KEY_SPACE:
       {
-         Action::TogglePlayback toggle_playback_action(score_editor, gui_mixer);
-         toggle_playback_action.execute();
+         action = new Action::TogglePlayback(score_editor, gui_mixer);
       }
       break;
    case ALLEGRO_KEY_Q:
       {
-         Action::ResetPlayback reset_playback_action(score_editor);
-         reset_playback_action.execute();
+         action = new Action::ResetPlayback(score_editor);
       }
       break;
    case ALLEGRO_KEY_F7:
       {
-         Action::SaveMeasureGrid save_measure_grid_action(&score_editor->measure_grid, "score_filename.fs");
-         save_measure_grid_action.execute();
+         action = new Action::SaveMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
       }
       break;
    case ALLEGRO_KEY_F8:
       {
-         Action::LoadMeasureGrid load_measure_grid_action(&score_editor->measure_grid, "score_filename.fs");
-         load_measure_grid_action.execute();
+         action = new Action::LoadMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
       }
       break;
    case ALLEGRO_KEY_UP:
       {
-         Action::StartMotion start_motion_action(&Framework::motion(),
+         action = new Action::StartMotion(&Framework::motion(),
             &score_editor->place.position.y, score_editor->place.position.y+200, 0.4);
-         start_motion_action.execute();
       }
       break;
    case ALLEGRO_KEY_DOWN:
       {
-         Action::StartMotion start_motion_action(&Framework::motion(),
+         action = new Action::StartMotion(&Framework::motion(),
             &score_editor->place.position.y, score_editor->place.position.y-200, 0.4);
-         start_motion_action.execute();
       }
       break;
    case ALLEGRO_KEY_RIGHT:
       {
-         Action::StartMotion start_motion_action(&Framework::motion(),
+         action = new Action::StartMotion(&Framework::motion(),
             &score_editor->place.position.x, score_editor->place.position.x-200, 0.4);
-         start_motion_action.execute();
       }
       break;
    case ALLEGRO_KEY_LEFT:
       {
-         Action::StartMotion start_motion_action(&Framework::motion(),
+         action = new Action::StartMotion(&Framework::motion(),
             &score_editor->place.position.x, score_editor->place.position.x+200, 0.4);
-         start_motion_action.execute();
       }
       break;
    case ALLEGRO_KEY_EQUALS:
       {
          if (Framework::key_shift)
          {
-            Action::SetScoreZoom set_score_zoom_action(score_editor, &Framework::motion(), 1, 0.3);
-            set_score_zoom_action.execute();
+            action = new Action::SetScoreZoom(score_editor, &Framework::motion(), 1, 0.3);
          }
          else
          {
-            Action::SetScoreZoom set_score_zoom_action(score_editor, &Framework::motion(), score_editor->place.scale.x + 0.1, 0.3);
-            set_score_zoom_action.execute();
+            action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x + 0.1, 0.3);
          }
       }
       break;
    case ALLEGRO_KEY_MINUS:
       {
-         Action::SetScoreZoom set_score_zoom_action(score_editor, &Framework::motion(), score_editor->place.scale.x - 0.1, 0.3);
-         set_score_zoom_action.execute();
+         action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x - 0.1, 0.3);
       }
       break;
    case ALLEGRO_KEY_H:
       {
-         Action::MoveCursorLeft move_cursor_left_action(score_editor);
-         move_cursor_left_action.execute();
+         action = new Action::MoveCursorLeft(score_editor);
       }
       break;
    case ALLEGRO_KEY_J:
       {
-         Action::MoveCursorDown move_cursor_down_action(score_editor);
-         move_cursor_down_action.execute();
+         action = new Action::MoveCursorDown(score_editor);
       }
       break;
    case ALLEGRO_KEY_K:
       {
-         Action::MoveCursorUp move_cursor_up_action(score_editor);
-         move_cursor_up_action.execute();
+         action = new Action::MoveCursorUp(score_editor);
       }
       break;
    case ALLEGRO_KEY_L:
       {
-         Action::MoveCursorRight move_cursor_right_action(score_editor);
-         move_cursor_right_action.execute();
+         action = new Action::MoveCursorRight(score_editor);
       }
       break;
    case ALLEGRO_KEY_Y:
       {
          Measure *focused_measure = score_editor->get_measure_at_cursor();
-         Action::YankMeasureToBuffer yank_measure_to_buffer_action(&yank_measure_buffer, focused_measure);
-         yank_measure_to_buffer_action.execute();
+         action = new Action::YankMeasureToBuffer(&yank_measure_buffer, focused_measure);
       }
       break;
    case ALLEGRO_KEY_P:
       {
          Measure *destination_measure = score_editor->get_measure_at_cursor();
-         Action::PasteMeasureFromBuffer paste_measure_from_buffer_action(destination_measure, &yank_measure_buffer);
-         paste_measure_from_buffer_action.execute();
+         action = new Action::PasteMeasureFromBuffer(destination_measure, &yank_measure_buffer);
       }
       break;
    case ALLEGRO_KEY_TAB:
       {
-         Action::ToggleEditModeTarget toggle_edit_mode_target_action(score_editor);
-         toggle_edit_mode_target_action.execute();
+         action = new Action::ToggleEditModeTarget(score_editor);
       }
       break;
+   }
+
+   if (action)
+   {
+      action->execute();
+      delete action;
    }
 
    if (single_note && !single_note_as_array.empty())

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -94,6 +94,14 @@ void FullscoreApplicationController::primary_timer_func()
 
 
 
+std::string FullscoreApplicationController::find_action_identifier_by_keycode(int al_keycode)
+{
+   return "";
+}
+
+
+
+
 void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_keycode)
 {
    //

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -222,33 +222,27 @@ Action::Base *FullscoreApplicationController::create_normal_mode_action(std::str
       action = new Action::ToggleEditModeTarget(score_editor);
    else if (action_name == "insert_measure")
    {
-      Action::InsertMeasure insert_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
-      insert_measure_action.execute();
+      action = new Action::InsertMeasure(&score_editor->measure_grid, score_editor->measure_cursor_x);
    }
    else if (action_name == "delete_measure")
    {
-      Action::DeleteMeasure delete_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
-      delete_measure_action.execute();
+      action = new Action::DeleteMeasure(&score_editor->measure_grid, score_editor->measure_cursor_x);
    }
    else if (action_name == "insert_staff")
    {
-      Action::InsertStaff insert_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
-      insert_staff_action.execute();
+      action = new Action::InsertStaff(&score_editor->measure_grid, score_editor->measure_cursor_y);
    }
    else if (action_name == "delete_staff")
    {
-      Action::DeleteStaff delete_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
-      delete_staff_action.execute();
+      action = new Action::DeleteStaff(&score_editor->measure_grid, score_editor->measure_cursor_y);
    }
    else if (action_name == "append_measure")
    {
-      Action::AppendMeasure append_measure_action(&score_editor->measure_grid);
-      append_measure_action.execute();
+      action = new Action::AppendMeasure(&score_editor->measure_grid);
    }
    else if (action_name == "append_staff")
    {
-      Action::AppendStaff append_staff_action(&score_editor->measure_grid);
-      append_staff_action.execute();
+      action = new Action::AppendStaff(&score_editor->measure_grid);
    }
 
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -105,10 +105,11 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    std::vector<Note> *notes = nullptr;
    Note *single_note = nullptr;
    std::vector<Note> single_note_as_array;
+   Measure *focused_measure = nullptr;
 
    if (score_editor->is_measure_target_mode())
    {
-      Measure *focused_measure = score_editor->get_measure_at_cursor();
+      focused_measure = score_editor->get_measure_at_cursor();
       if (focused_measure) notes = &focused_measure->notes;
    }
    else
@@ -277,14 +278,12 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       break;
    case ALLEGRO_KEY_Y:
       {
-         Measure *focused_measure = score_editor->get_measure_at_cursor();
          action = new Action::YankMeasureToBuffer(&yank_measure_buffer, focused_measure);
       }
       break;
    case ALLEGRO_KEY_P:
       {
-         Measure *destination_measure = score_editor->get_measure_at_cursor();
-         action = new Action::PasteMeasureFromBuffer(destination_measure, &yank_measure_buffer);
+         action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
       }
       break;
    case ALLEGRO_KEY_TAB:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -147,7 +147,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::EraseNote(notes, score_editor->note_cursor_x);
       break;
    case ALLEGRO_KEY_I:
-      action = new Action::Transform::Invert(0);
+      action = new Action::Transform::Invert(notes, 0);
       break;
    case ALLEGRO_KEY_G:
       action = new Action::Transform::Retrograde(notes);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -158,102 +158,71 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       if (focused_measure) notes = &focused_measure->notes;
    }
 
-   switch(al_keycode)
-   {
-   case ALLEGRO_KEY_W:
+   std::string action_name = "";
+
+   if (action_name == "XXXtranspose_up")
       action = new Action::TransposeTransform(single_note, Framework::key_shift ? 7 : 1);
-      break;
-   case ALLEGRO_KEY_S:
+   else if (action_name == "XXXtranspose_down")
       action = new Action::TransposeTransform(single_note, Framework::key_shift ? -7 : -1);
-      break;
-   case ALLEGRO_KEY_A:
+   else if (action_name == "half_duration")
       action = new Action::HalfDurationTransform(single_note);
-      break;
-   case ALLEGRO_KEY_D:
+   else if (action_name == "double_duration")
       action = new Action::DoubleDurationTransform(single_note);
-      break;
-   case ALLEGRO_KEY_R:
+   else if (action_name == "toggle_rest")
       action = new Action::ToggleRest(single_note);
-      break;
-   case ALLEGRO_KEY_I:
+   else if (action_name == "invert")
       action = new Action::Transform::Invert(single_note, 0);
-      break;
-   case ALLEGRO_KEY_FULLSTOP:
+   else if (action_name == "add_dot")
       action = new Action::AddDotTransform(single_note);
-      break;
-   case ALLEGRO_KEY_COMMA:
+   else if (action_name == "remove_dot")
       action = new Action::RemoveDotTransform(single_note);
-      break;
-   case ALLEGRO_KEY_SEMICOLON:
+   else if (action_name == "XXset_mode_command")
       action = new Action::SetMode(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);
-      break;
-   case ALLEGRO_KEY_E:
+   else if (action_name == "erase_note")
       action = new Action::EraseNote(notes, score_editor->note_cursor_x);
-      break;
-   case ALLEGRO_KEY_G:
+   else if (action_name == "retrograde")
       action = new Action::Transform::Retrograde(notes);
-      break;
-   case ALLEGRO_KEY_N:
+   else if (action_name == "insert_note")
       action = new Action::InsertNoteTransform(notes, score_editor->note_cursor_x, Note());
-      break;
-   case ALLEGRO_KEY_F1:
+   else if (action_name == "toggle_help_window")
       action = new Action::ToggleHelpWindow(&Framework::motion(), this);
-      break;
-   case ALLEGRO_KEY_F2:
+   else if (action_name == "toggle_show_debug_data")
       action = new Action::ToggleShowDebugData(score_editor);
-      break;
-   case ALLEGRO_KEY_SPACE:
+   else if (action_name == "toggle_playback")
       action = new Action::TogglePlayback(score_editor, gui_mixer);
-      break;
-   case ALLEGRO_KEY_Q:
+   else if (action_name == "reset_playback")
       action = new Action::ResetPlayback(score_editor);
-      break;
-   case ALLEGRO_KEY_F7:
+   else if (action_name == "save_measure_grid")
       action = new Action::SaveMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
-      break;
-   case ALLEGRO_KEY_F8:
+   else if (action_name == "load_measure_grid")
       action = new Action::LoadMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
-      break;
-   case ALLEGRO_KEY_UP:
+   else if (action_name == "XXXmove_camera_up")
       action = new Action::StartMotion(&Framework::motion(), &score_editor->place.position.y, score_editor->place.position.y+200, 0.4);
-      break;
-   case ALLEGRO_KEY_DOWN:
+   else if (action_name == "XXXmove_camera_down")
       action = new Action::StartMotion(&Framework::motion(), &score_editor->place.position.y, score_editor->place.position.y-200, 0.4);
-      break;
-   case ALLEGRO_KEY_RIGHT:
+   else if (action_name == "XXXmove_camera_right")
       action = new Action::StartMotion(&Framework::motion(), &score_editor->place.position.x, score_editor->place.position.x-200, 0.4);
-      break;
-   case ALLEGRO_KEY_LEFT:
+   else if (action_name == "XXXmove_camera_left")
       action = new Action::StartMotion(&Framework::motion(), &score_editor->place.position.x, score_editor->place.position.x+200, 0.4);
-      break;
-   case ALLEGRO_KEY_EQUALS:
+   else if (action_name == "XXXcamera_zoom")
       action = new Action::SetScoreZoom(score_editor, &Framework::motion(), Framework::key_shift ? 1 : score_editor->place.scale.x + 0.1, 0.3);
-      break;
-   case ALLEGRO_KEY_MINUS:
+   else if (action_name == "XXXcamera_zoom_out")
       action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x - 0.1, 0.3);
-      break;
-   case ALLEGRO_KEY_H:
+   else if (action_name == "move_cursor_left")
       action = new Action::MoveCursorLeft(score_editor);
-      break;
-   case ALLEGRO_KEY_J:
+   else if (action_name == "move_cursor_down")
       action = new Action::MoveCursorDown(score_editor);
-      break;
-   case ALLEGRO_KEY_K:
+   else if (action_name == "move_cursor_up")
       action = new Action::MoveCursorUp(score_editor);
-      break;
-   case ALLEGRO_KEY_L:
+   else if (action_name == "move_cursor_right")
       action = new Action::MoveCursorRight(score_editor);
-      break;
-   case ALLEGRO_KEY_Y:
+   else if (action_name == "yank_measure_buffer")
       action = new Action::YankMeasureToBuffer(&yank_measure_buffer, focused_measure);
-      break;
-   case ALLEGRO_KEY_P:
+   else if (action_name == "paste_measure_from_buffer")
       action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
-      break;
-   case ALLEGRO_KEY_TAB:
+   else if (action_name == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(score_editor);
-      break;
-   }
+
 
    if (action)
    {

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -116,12 +116,10 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    switch(al_keycode)
    {
    case ALLEGRO_KEY_W:
-      // ####### //
-      action = new Action::TransposeTransform(notes, Framework::key_shift ? 7 : 1);
+      action = new Action::TransposeTransform(single_note, Framework::key_shift ? 7 : 1);
       break;
    case ALLEGRO_KEY_S:
-      // ####### //
-      action = new Action::TransposeTransform(notes, Framework::key_shift ? -7 : -1);
+      action = new Action::TransposeTransform(single_note, Framework::key_shift ? -7 : -1);
       break;
    case ALLEGRO_KEY_A:
       action = new Action::HalfDurationTransform(single_note);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -220,6 +220,36 @@ Action::Base *FullscoreApplicationController::create_normal_mode_action(std::str
       action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
    else if (action_name == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(score_editor);
+   if (message == "insert_measure")
+   {
+      Action::InsertMeasure insert_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
+      insert_measure_action.execute();
+   }
+   if (message == "delete_measure")
+   {
+      Action::DeleteMeasure delete_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
+      delete_measure_action.execute();
+   }
+   if (message == "insert_staff")
+   {
+      Action::InsertStaff insert_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
+      insert_staff_action.execute();
+   }
+   if (message == "delete_staff")
+   {
+      Action::DeleteStaff delete_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
+      delete_staff_action.execute();
+   }
+   if (message == "append_measure")
+   {
+      Action::AppendMeasure append_measure_action(&score_editor->measure_grid);
+      append_measure_action.execute();
+   }
+   if (message == "append_staff")
+   {
+      Action::AppendStaff append_staff_action(&score_editor->measure_grid);
+      append_staff_action.execute();
+   }
 
 
    return action;
@@ -290,37 +320,6 @@ void FullscoreApplicationController::key_down_func()
 void FullscoreApplicationController::on_message(UIWidget *sender, std::string message)
 {
    std::cout << "message: " << message << std::endl;
-
-   if (message == "insert_measure")
-   {
-      Action::InsertMeasure insert_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
-      insert_measure_action.execute();
-   }
-   if (message == "delete_measure")
-   {
-      Action::DeleteMeasure delete_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
-      delete_measure_action.execute();
-   }
-   if (message == "insert_staff")
-   {
-      Action::InsertStaff insert_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
-      insert_staff_action.execute();
-   }
-   if (message == "delete_staff")
-   {
-      Action::DeleteStaff delete_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
-      delete_staff_action.execute();
-   }
-   if (message == "append_measure")
-   {
-      Action::AppendMeasure append_measure_action(&score_editor->measure_grid);
-      append_measure_action.execute();
-   }
-   if (message == "append_staff")
-   {
-      Action::AppendStaff append_staff_action(&score_editor->measure_grid);
-      append_staff_action.execute();
-   }
 }
 
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -312,6 +312,7 @@ void FullscoreApplicationController::on_message(UIWidget *sender, std::string me
 
          if (action)
          {
+            simple_notification_screen->spawn_notification(action->get_action_name());
             action->execute();
             delete action;
          }

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -180,26 +180,19 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::LoadMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
       break;
    case ALLEGRO_KEY_UP:
-      action = new Action::StartMotion(&Framework::motion(),
-         &score_editor->place.position.y, score_editor->place.position.y+200, 0.4);
+      action = new Action::StartMotion(&Framework::motion(), &score_editor->place.position.y, score_editor->place.position.y+200, 0.4);
       break;
    case ALLEGRO_KEY_DOWN:
-      action = new Action::StartMotion(&Framework::motion(),
-         &score_editor->place.position.y, score_editor->place.position.y-200, 0.4);
+      action = new Action::StartMotion(&Framework::motion(), &score_editor->place.position.y, score_editor->place.position.y-200, 0.4);
       break;
    case ALLEGRO_KEY_RIGHT:
-      action = new Action::StartMotion(&Framework::motion(),
-         &score_editor->place.position.x, score_editor->place.position.x-200, 0.4);
+      action = new Action::StartMotion(&Framework::motion(), &score_editor->place.position.x, score_editor->place.position.x-200, 0.4);
       break;
    case ALLEGRO_KEY_LEFT:
-      action = new Action::StartMotion(&Framework::motion(),
-         &score_editor->place.position.x, score_editor->place.position.x+200, 0.4);
+      action = new Action::StartMotion(&Framework::motion(), &score_editor->place.position.x, score_editor->place.position.x+200, 0.4);
       break;
    case ALLEGRO_KEY_EQUALS:
-      if (Framework::key_shift)
-         action = new Action::SetScoreZoom(score_editor, &Framework::motion(), 1, 0.3);
-      else
-         action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x + 0.1, 0.3);
+      action = new Action::SetScoreZoom(score_editor, &Framework::motion(), Framework::key_shift ? 1 : score_editor->place.scale.x + 0.1, 0.3);
       break;
    case ALLEGRO_KEY_MINUS:
       action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x - 0.1, 0.3);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -302,22 +302,25 @@ void FullscoreApplicationController::on_message(UIWidget *sender, std::string me
 {
    std::cout << "message: " << message << std::endl;
 
-   if (!message.empty() && message[0] == ':')
+   if (sender == command_bar)
    {
-      std::string action_identifier = message.substr(1);
-
-      Action::Base *action = create_normal_mode_action(action_identifier);
-
-      if (action)
+      if (!message.empty() && message[0] == ':')
       {
-         action->execute();
-         delete action;
-      }
-      else
-      {
-         std::string error_message = "Unfound action: ";
-         error_message += action_identifier;
-         simple_notification_screen->spawn_notification(error_message);
+         std::string action_identifier = message.substr(1);
+
+         Action::Base *action = create_normal_mode_action(action_identifier);
+
+         if (action)
+         {
+            action->execute();
+            delete action;
+         }
+         else
+         {
+            std::string error_message = "Unfound action: ";
+            error_message += action_identifier;
+            simple_notification_screen->spawn_notification(error_message);
+         }
       }
    }
 }

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -124,8 +124,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::TransposeTransform(notes, Framework::key_shift ? -7 : -1);
       break;
    case ALLEGRO_KEY_A:
-      // ####### //
-      action = new Action::HalfDurationTransform(notes);
+      action = new Action::HalfDurationTransform(single_note);
       break;
    case ALLEGRO_KEY_D:
       action = new Action::DoubleDurationTransform(single_note);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -94,7 +94,7 @@ void FullscoreApplicationController::primary_timer_func()
 
 
 
-std::string FullscoreApplicationController::find_action_identifier_by_keycode(int al_keycode)
+std::string FullscoreApplicationController::find_action_identifier_by_keycode(int al_keycode, bool shift, bool alt)
 {
    switch(al_keycode)
    {

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -301,6 +301,14 @@ void FullscoreApplicationController::key_down_func()
 void FullscoreApplicationController::on_message(UIWidget *sender, std::string message)
 {
    std::cout << "message: " << message << std::endl;
+
+   Action::Base *action = create_normal_mode_action(message);
+
+   if (action)
+   {
+      action->execute();
+      delete action;
+   }
 }
 
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -103,7 +103,7 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    Action::Base *action = nullptr;
 
    std::vector<Note> *notes = nullptr;
-   Note *single_note = nullptr;
+   Note *single_note = score_editor->get_note_at_cursor();
    std::vector<Note> single_note_as_array;
    Measure *focused_measure = nullptr;
 
@@ -111,15 +111,6 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    {
       focused_measure = score_editor->get_measure_at_cursor();
       if (focused_measure) notes = &focused_measure->notes;
-   }
-   else
-   {
-      single_note = score_editor->get_note_at_cursor();
-      if (single_note)
-      {
-         single_note_as_array.push_back(*single_note);
-         notes = &single_note_as_array;
-      }
    }
 
    // locate and build the appropriate transform
@@ -224,11 +215,6 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    {
       action->execute();
       delete action;
-   }
-
-   if (single_note && !single_note_as_array.empty())
-   {
-      *single_note = single_note_as_array.at(0);
    }
 }
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -96,6 +96,41 @@ void FullscoreApplicationController::primary_timer_func()
 
 std::string FullscoreApplicationController::find_action_identifier_by_keycode(int al_keycode)
 {
+   switch(al_keycode)
+   {
+   case ALLEGRO_KEY_W: break;
+   case ALLEGRO_KEY_S: break;
+   case ALLEGRO_KEY_A: break;
+   case ALLEGRO_KEY_D: break;
+   case ALLEGRO_KEY_R: break;
+   case ALLEGRO_KEY_I: break;
+   case ALLEGRO_KEY_FULLSTOP: break;
+   case ALLEGRO_KEY_COMMA: break;
+   case ALLEGRO_KEY_SEMICOLON: break;
+   case ALLEGRO_KEY_E: break;
+   case ALLEGRO_KEY_G: break;
+   case ALLEGRO_KEY_N: break;
+   case ALLEGRO_KEY_F1: break;
+   case ALLEGRO_KEY_F2: break;
+   case ALLEGRO_KEY_SPACE: break;
+   case ALLEGRO_KEY_Q: break;
+   case ALLEGRO_KEY_F7: break;
+   case ALLEGRO_KEY_F8: break;
+   case ALLEGRO_KEY_UP: break;
+   case ALLEGRO_KEY_DOWN: break;
+   case ALLEGRO_KEY_RIGHT: break;
+   case ALLEGRO_KEY_LEFT: break;
+   case ALLEGRO_KEY_EQUALS: break;
+   case ALLEGRO_KEY_MINUS: break;
+   case ALLEGRO_KEY_H: break;
+   case ALLEGRO_KEY_J: break;
+   case ALLEGRO_KEY_K: break;
+   case ALLEGRO_KEY_L: break;
+   case ALLEGRO_KEY_Y: break;
+   case ALLEGRO_KEY_P: break;
+   case ALLEGRO_KEY_TAB: break;
+   }
+
    return "";
 }
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -120,33 +120,41 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       action = new Action::SetMode(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);
       break;
    case ALLEGRO_KEY_W:
+      // ####### //
       action = new Action::TransposeTransform(notes, Framework::key_shift ? 7 : 1);
       break;
    case ALLEGRO_KEY_S:
+      // ####### //
       action = new Action::TransposeTransform(notes, Framework::key_shift ? -7 : -1);
       break;
    case ALLEGRO_KEY_A:
+      // ####### //
       action = new Action::HalfDurationTransform(notes);
       break;
    case ALLEGRO_KEY_D:
+      // ####### //
       action = new Action::DoubleDurationTransform(notes);
       break;
    case ALLEGRO_KEY_R:
+      // ####### //
       action = new Action::ToggleRest(notes);
       break;
    case ALLEGRO_KEY_E:
       action = new Action::EraseNote(notes, score_editor->note_cursor_x);
       break;
    case ALLEGRO_KEY_I:
+      // ####### //
       action = new Action::Transform::Invert(notes, 0);
       break;
    case ALLEGRO_KEY_G:
       action = new Action::Transform::Retrograde(notes);
       break;
    case ALLEGRO_KEY_FULLSTOP:
+      // ####### //
       action = new Action::AddDotTransform(notes);
       break;
    case ALLEGRO_KEY_COMMA:
+      // ####### //
       action = new Action::RemoveDotTransform(notes);
       break;
    case ALLEGRO_KEY_N:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -94,7 +94,7 @@ void FullscoreApplicationController::primary_timer_func()
 
 
 
-std::string FullscoreApplicationController::find_action_identifier_by_keycode(int al_keycode, bool shift, bool alt)
+std::string FullscoreApplicationController::find_action_identifier_by_normal_mode_keycode(int al_keycode, bool shift, bool alt)
 {
    switch(al_keycode)
    {

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -126,170 +126,104 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    switch(al_keycode)
    {
    case ALLEGRO_KEY_SEMICOLON:
-      {
-         action = new Action::SetMode(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);
-      }
+      action = new Action::SetMode(score_editor, command_bar, GUIScoreEditor::COMMAND_MODE);
       break;
    case ALLEGRO_KEY_W:
-      {
-         action = new Action::TransposeTransform(notes, Framework::key_shift ? 7 : 1);
-      }
+      action = new Action::TransposeTransform(notes, Framework::key_shift ? 7 : 1);
       break;
    case ALLEGRO_KEY_S:
-      {
-         action = new Action::TransposeTransform(notes, Framework::key_shift ? -7 : -1);
-      }
+      action = new Action::TransposeTransform(notes, Framework::key_shift ? -7 : -1);
       break;
    case ALLEGRO_KEY_A:
-      {
-         action = new Action::HalfDurationTransform(notes);
-      }
+      action = new Action::HalfDurationTransform(notes);
       break;
    case ALLEGRO_KEY_D:
-      {
-         action = new Action::DoubleDurationTransform(notes);
-      }
+      action = new Action::DoubleDurationTransform(notes);
       break;
    case ALLEGRO_KEY_R:
-      {
-         action = new Action::ToggleRest(notes);
-      }
+      action = new Action::ToggleRest(notes);
       break;
    case ALLEGRO_KEY_E:
-      {
-         action = new Action::EraseNote(notes, score_editor->note_cursor_x);
-      }
+      action = new Action::EraseNote(notes, score_editor->note_cursor_x);
       break;
    case ALLEGRO_KEY_I:
-      {
-         action = new Action::Transform::Invert(0);
-      }
+      action = new Action::Transform::Invert(0);
       break;
    case ALLEGRO_KEY_G:
-      {
-         action = new Action::Transform::Retrograde(notes);
-      }
+      action = new Action::Transform::Retrograde(notes);
       break;
    case ALLEGRO_KEY_FULLSTOP:
-      {
-         action = new Action::AddDotTransform(notes);
-      }
+      action = new Action::AddDotTransform(notes);
       break;
    case ALLEGRO_KEY_COMMA:
-      {
-         action = new Action::RemoveDotTransform(notes);
-      }
+      action = new Action::RemoveDotTransform(notes);
       break;
    case ALLEGRO_KEY_N:
-      {
-         action = new Action::InsertNoteTransform(notes, score_editor->note_cursor_x, Note());
-      }
+      action = new Action::InsertNoteTransform(notes, score_editor->note_cursor_x, Note());
       break;
    case ALLEGRO_KEY_F1:
-      {
-         action = new Action::ToggleHelpWindow(&Framework::motion(), this);
-      }
+      action = new Action::ToggleHelpWindow(&Framework::motion(), this);
       break;
    case ALLEGRO_KEY_F2:
-      {
-         action = new Action::ToggleShowDebugData(score_editor);
-      }
+      action = new Action::ToggleShowDebugData(score_editor);
       break;
    case ALLEGRO_KEY_SPACE:
-      {
-         action = new Action::TogglePlayback(score_editor, gui_mixer);
-      }
+      action = new Action::TogglePlayback(score_editor, gui_mixer);
       break;
    case ALLEGRO_KEY_Q:
-      {
-         action = new Action::ResetPlayback(score_editor);
-      }
+      action = new Action::ResetPlayback(score_editor);
       break;
    case ALLEGRO_KEY_F7:
-      {
-         action = new Action::SaveMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
-      }
+      action = new Action::SaveMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
       break;
    case ALLEGRO_KEY_F8:
-      {
-         action = new Action::LoadMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
-      }
+      action = new Action::LoadMeasureGrid(&score_editor->measure_grid, "score_filename.fs");
       break;
    case ALLEGRO_KEY_UP:
-      {
-         action = new Action::StartMotion(&Framework::motion(),
-            &score_editor->place.position.y, score_editor->place.position.y+200, 0.4);
-      }
+      action = new Action::StartMotion(&Framework::motion(),
+         &score_editor->place.position.y, score_editor->place.position.y+200, 0.4);
       break;
    case ALLEGRO_KEY_DOWN:
-      {
-         action = new Action::StartMotion(&Framework::motion(),
-            &score_editor->place.position.y, score_editor->place.position.y-200, 0.4);
-      }
+      action = new Action::StartMotion(&Framework::motion(),
+         &score_editor->place.position.y, score_editor->place.position.y-200, 0.4);
       break;
    case ALLEGRO_KEY_RIGHT:
-      {
-         action = new Action::StartMotion(&Framework::motion(),
-            &score_editor->place.position.x, score_editor->place.position.x-200, 0.4);
-      }
+      action = new Action::StartMotion(&Framework::motion(),
+         &score_editor->place.position.x, score_editor->place.position.x-200, 0.4);
       break;
    case ALLEGRO_KEY_LEFT:
-      {
-         action = new Action::StartMotion(&Framework::motion(),
-            &score_editor->place.position.x, score_editor->place.position.x+200, 0.4);
-      }
+      action = new Action::StartMotion(&Framework::motion(),
+         &score_editor->place.position.x, score_editor->place.position.x+200, 0.4);
       break;
    case ALLEGRO_KEY_EQUALS:
-      {
-         if (Framework::key_shift)
-         {
-            action = new Action::SetScoreZoom(score_editor, &Framework::motion(), 1, 0.3);
-         }
-         else
-         {
-            action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x + 0.1, 0.3);
-         }
-      }
+      if (Framework::key_shift)
+         action = new Action::SetScoreZoom(score_editor, &Framework::motion(), 1, 0.3);
+      else
+         action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x + 0.1, 0.3);
       break;
    case ALLEGRO_KEY_MINUS:
-      {
-         action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x - 0.1, 0.3);
-      }
+      action = new Action::SetScoreZoom(score_editor, &Framework::motion(), score_editor->place.scale.x - 0.1, 0.3);
       break;
    case ALLEGRO_KEY_H:
-      {
-         action = new Action::MoveCursorLeft(score_editor);
-      }
+      action = new Action::MoveCursorLeft(score_editor);
       break;
    case ALLEGRO_KEY_J:
-      {
-         action = new Action::MoveCursorDown(score_editor);
-      }
+      action = new Action::MoveCursorDown(score_editor);
       break;
    case ALLEGRO_KEY_K:
-      {
-         action = new Action::MoveCursorUp(score_editor);
-      }
+      action = new Action::MoveCursorUp(score_editor);
       break;
    case ALLEGRO_KEY_L:
-      {
-         action = new Action::MoveCursorRight(score_editor);
-      }
+      action = new Action::MoveCursorRight(score_editor);
       break;
    case ALLEGRO_KEY_Y:
-      {
-         action = new Action::YankMeasureToBuffer(&yank_measure_buffer, focused_measure);
-      }
+      action = new Action::YankMeasureToBuffer(&yank_measure_buffer, focused_measure);
       break;
    case ALLEGRO_KEY_P:
-      {
-         action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
-      }
+      action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
       break;
    case ALLEGRO_KEY_TAB:
-      {
-         action = new Action::ToggleEditModeTarget(score_editor);
-      }
+      action = new Action::ToggleEditModeTarget(score_editor);
       break;
    }
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -214,7 +214,7 @@ Action::Base *FullscoreApplicationController::create_normal_mode_action(std::str
       action = new Action::MoveCursorUp(score_editor);
    else if (action_name == "move_cursor_right")
       action = new Action::MoveCursorRight(score_editor);
-   else if (action_name == "yank_measure_buffer")
+   else if (action_name == "yank_measure_to_buffer")
       action = new Action::YankMeasureToBuffer(&yank_measure_buffer, focused_measure);
    else if (action_name == "paste_measure_from_buffer")
       action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -115,7 +115,6 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
       if (focused_measure) notes = &focused_measure->notes;
    }
 
-   // locate and build the appropriate transform
    switch(al_keycode)
    {
    case ALLEGRO_KEY_W:

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -221,30 +221,17 @@ Action::Base *FullscoreApplicationController::create_normal_mode_action(std::str
    else if (action_name == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(score_editor);
    else if (action_name == "insert_measure")
-   {
       action = new Action::InsertMeasure(&score_editor->measure_grid, score_editor->measure_cursor_x);
-   }
    else if (action_name == "delete_measure")
-   {
       action = new Action::DeleteMeasure(&score_editor->measure_grid, score_editor->measure_cursor_x);
-   }
    else if (action_name == "insert_staff")
-   {
       action = new Action::InsertStaff(&score_editor->measure_grid, score_editor->measure_cursor_y);
-   }
    else if (action_name == "delete_staff")
-   {
       action = new Action::DeleteStaff(&score_editor->measure_grid, score_editor->measure_cursor_y);
-   }
    else if (action_name == "append_measure")
-   {
       action = new Action::AppendMeasure(&score_editor->measure_grid);
-   }
    else if (action_name == "append_staff")
-   {
       action = new Action::AppendStaff(&score_editor->measure_grid);
-   }
-
 
    return action;
 }

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -98,37 +98,37 @@ std::string FullscoreApplicationController::find_action_identifier_by_keycode(in
 {
    switch(al_keycode)
    {
-   case ALLEGRO_KEY_W: break;
-   case ALLEGRO_KEY_S: break;
-   case ALLEGRO_KEY_A: break;
-   case ALLEGRO_KEY_D: break;
-   case ALLEGRO_KEY_R: break;
-   case ALLEGRO_KEY_I: break;
-   case ALLEGRO_KEY_FULLSTOP: break;
-   case ALLEGRO_KEY_COMMA: break;
-   case ALLEGRO_KEY_SEMICOLON: break;
-   case ALLEGRO_KEY_E: break;
-   case ALLEGRO_KEY_G: break;
-   case ALLEGRO_KEY_N: break;
-   case ALLEGRO_KEY_F1: break;
-   case ALLEGRO_KEY_F2: break;
-   case ALLEGRO_KEY_SPACE: break;
-   case ALLEGRO_KEY_Q: break;
-   case ALLEGRO_KEY_F7: break;
-   case ALLEGRO_KEY_F8: break;
-   case ALLEGRO_KEY_UP: break;
-   case ALLEGRO_KEY_DOWN: break;
-   case ALLEGRO_KEY_RIGHT: break;
-   case ALLEGRO_KEY_LEFT: break;
-   case ALLEGRO_KEY_EQUALS: break;
-   case ALLEGRO_KEY_MINUS: break;
-   case ALLEGRO_KEY_H: break;
-   case ALLEGRO_KEY_J: break;
-   case ALLEGRO_KEY_K: break;
-   case ALLEGRO_KEY_L: break;
-   case ALLEGRO_KEY_Y: break;
-   case ALLEGRO_KEY_P: break;
-   case ALLEGRO_KEY_TAB: break;
+   case ALLEGRO_KEY_W: return "XXXtranspose_up"; break;
+   case ALLEGRO_KEY_S: return "XXXtranspose_down"; break;
+   case ALLEGRO_KEY_A: return "half_duration"; break;
+   case ALLEGRO_KEY_D: return "double_duration"; break;
+   case ALLEGRO_KEY_R: return "toggle_rest"; break;
+   case ALLEGRO_KEY_I: return "invert"; break;
+   case ALLEGRO_KEY_FULLSTOP: return "add_dot"; break;
+   case ALLEGRO_KEY_COMMA: return "remove_dot"; break;
+   case ALLEGRO_KEY_SEMICOLON: return "XXset_mode_command"; break;
+   case ALLEGRO_KEY_E: return "erase_note"; break;
+   case ALLEGRO_KEY_G: return "retrograde"; break;
+   case ALLEGRO_KEY_N: return "insert_note"; break;
+   case ALLEGRO_KEY_F1: return "toggle_help_window"; break;
+   case ALLEGRO_KEY_F2: return "toggle_show_debug_data"; break;
+   case ALLEGRO_KEY_SPACE: return "toggle_playback"; break;
+   case ALLEGRO_KEY_Q: return "reset_playback"; break;
+   case ALLEGRO_KEY_F7: return "save_measure_grid"; break;
+   case ALLEGRO_KEY_F8: return "load_measure_grid"; break;
+   case ALLEGRO_KEY_UP: return "XXXmove_camera_up"; break;
+   case ALLEGRO_KEY_DOWN: return "XXXmove_camera_down"; break;
+   case ALLEGRO_KEY_RIGHT: return "XXXmove_camera_right"; break;
+   case ALLEGRO_KEY_LEFT: return "XXXmove_camera_left"; break;
+   case ALLEGRO_KEY_EQUALS: return "XXXcamera_zoom"; break;
+   case ALLEGRO_KEY_MINUS: return "XXXcamera_zoom_out"; break;
+   case ALLEGRO_KEY_H: return "move_cursor_left"; break;
+   case ALLEGRO_KEY_J: return "move_cursor_down"; break;
+   case ALLEGRO_KEY_K: return "move_cursor_up"; break;
+   case ALLEGRO_KEY_L: return "move_cursor_right"; break;
+   case ALLEGRO_KEY_Y: return "yank_measure_to_buffer"; break;
+   case ALLEGRO_KEY_P: return "paste_measure_from_buffer"; break;
+   case ALLEGRO_KEY_TAB: return "toggle_edit_mode_target"; break;
    }
 
    return "";

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -302,7 +302,7 @@ void FullscoreApplicationController::on_message(UIWidget *sender, std::string me
 {
    std::cout << "message: " << message << std::endl;
 
-   if (sender == command_bar)
+   if (sender == command_bar && message != "on_submit")
    {
       if (!message.empty() && message[0] == ':')
       {

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -220,32 +220,32 @@ Action::Base *FullscoreApplicationController::create_normal_mode_action(std::str
       action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
    else if (action_name == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(score_editor);
-   if (message == "insert_measure")
+   if (action_name == "insert_measure")
    {
       Action::InsertMeasure insert_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
       insert_measure_action.execute();
    }
-   if (message == "delete_measure")
+   if (action_name == "delete_measure")
    {
       Action::DeleteMeasure delete_measure_action(&score_editor->measure_grid, score_editor->measure_cursor_x);
       delete_measure_action.execute();
    }
-   if (message == "insert_staff")
+   if (action_name == "insert_staff")
    {
       Action::InsertStaff insert_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
       insert_staff_action.execute();
    }
-   if (message == "delete_staff")
+   if (action_name == "delete_staff")
    {
       Action::DeleteStaff delete_staff_action(&score_editor->measure_grid, score_editor->measure_cursor_y);
       delete_staff_action.execute();
    }
-   if (message == "append_measure")
+   if (action_name == "append_measure")
    {
       Action::AppendMeasure append_measure_action(&score_editor->measure_grid);
       append_measure_action.execute();
    }
-   if (message == "append_staff")
+   if (action_name == "append_staff")
    {
       Action::AppendStaff append_staff_action(&score_editor->measure_grid);
       append_staff_action.execute();

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -101,11 +101,14 @@ void FullscoreApplicationController::execute_normal_mode_action_for_key(int al_k
    //
 
    Action::Base *action = nullptr;
-
    std::vector<Note> *notes = nullptr;
-   Note *single_note = score_editor->get_note_at_cursor();
+   Note *single_note = nullptr;
    Measure *focused_measure = nullptr;
 
+   if (score_editor->is_note_target_mode())
+   {
+      single_note = score_editor->get_note_at_cursor();
+   }
    if (score_editor->is_measure_target_mode())
    {
       focused_measure = score_editor->get_measure_at_cursor();


### PR DESCRIPTION
### Scenario

Complete the refactor that began in #9.  This iteration:

1. Allows actions to be created by an identifier
2. Maps key codes from keyboard input to action identifiers in an isolated function
3. Allows actions to be invoked from the command bar
4. ⚠️ Disables the ability to invoke single-note actions on collections of notes (so it can later be implemented correctly)
5. Properly allows for the robust and consistent usage of the command pattern. 🎉 