### PR TITLE
Save and Load TimeSignatures When Saving/Loading Score

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ OBJS=command_bar fullscore_application_controller follow_camera gui_score_editor
 OBJS+=$(addprefix actions/,$(basename $(notdir $(wildcard source/actions/*.cpp))))
 OBJS+=$(addprefix actions/transforms/,$(basename $(notdir $(wildcard source/actions/transforms/*.cpp))))
 OBJS+=components/time_signature_render_component
-OBJS+=converters/measure_grid_file_converter converters/note_string_converter
+OBJS+=converters/measure_grid_file_converter converters/note_string_converter converters/time_signature_string_converter
 OBJS+=models/measure models/measure_grid models/note models/note_playback_info models/time_signature
 OBJS+=transforms/add_dot_transform transforms/double_duration_transform transforms/erase_note_transform transforms/half_duration_transform transforms/remove_dot_transform transforms/retrograde_transform transforms/insert_note_transform transforms/invert_transform transforms/toggle_rest_transform transforms/transform_base transforms/transpose_transform
 

--- a/include/fullscore/converters/time_signature_string_converter.h
+++ b/include/fullscore/converters/time_signature_string_converter.h
@@ -12,10 +12,10 @@
 class TimeSignatureStringConverter
 {
 private:
-   TimeSignature *time_signature;
+   TimeSignature time_signature;
 
 public:
-   TimeSignatureStringConverter(TimeSignature *time_signature);
+   TimeSignatureStringConverter(TimeSignature time_signature);
 
    bool read(std::string);
    std::string write();

--- a/include/fullscore/converters/time_signature_string_converter.h
+++ b/include/fullscore/converters/time_signature_string_converter.h
@@ -1,0 +1,26 @@
+#pragma once
+
+
+
+
+#include <string>
+#include <fullscore/models/time_signature.h>
+
+
+
+
+class TimeSignatureStringConverter
+{
+private:
+   TimeSignature *time_signature;
+
+public:
+   TimeSignatureStringConverter(TimeSignature *time_signature);
+
+   bool read(std::string);
+   std::string write();
+};
+
+
+
+

--- a/include/fullscore/converters/time_signature_string_converter.h
+++ b/include/fullscore/converters/time_signature_string_converter.h
@@ -12,10 +12,10 @@
 class TimeSignatureStringConverter
 {
 private:
-   TimeSignature time_signature;
+   TimeSignature *time_signature;
 
 public:
-   TimeSignatureStringConverter(TimeSignature time_signature);
+   TimeSignatureStringConverter(TimeSignature *time_signature);
 
    bool read(std::string);
    std::string write();

--- a/include/fullscore/models/time_signature.h
+++ b/include/fullscore/models/time_signature.h
@@ -8,6 +8,7 @@ class TimeSignature
 {
 private:
    friend class TimeSignatureRenderComponent;
+   friend class TimeSignatureStringConverter;
 
    int numerator;
    int denominator_duration;

--- a/source/converters/measure_grid_file_converter.cpp
+++ b/source/converters/measure_grid_file_converter.cpp
@@ -41,6 +41,7 @@ bool MeasureGridFileConverter::save()
    }
    state.set("time_signatures", php::implode(";", time_signature_strings));
 
+   // build the measures as "x,y = [notes]" string
    for (int y=0; y<measure_grid->get_num_staves(); y++)
       for (int x=0; x<measure_grid->get_num_measures(); x++)
       {
@@ -98,13 +99,13 @@ bool MeasureGridFileConverter::load()
    int grid_width = atoi(state.get("grid_width").c_str());
    measure_grid->voices.resize(grid_height, MeasureGrid::Row(grid_width));
 
-   // for now, remove those two elements.  The rest of the data in `state` is measure data
+   // for now, remove those elements.  The rest of the data in `state` is measure data
    state.remove("grid_height");
    state.remove("grid_width");
    state.remove("time_signatures");
    state.remove("file_format_version");
 
-   // get the
+   // get the notes for each measure
    std::map<std::string, std::string> data = state.get_copy();
    for (std::map<std::string, std::string>::iterator it = data.begin(); it!=data.end(); it++)
    {

--- a/source/converters/measure_grid_file_converter.cpp
+++ b/source/converters/measure_grid_file_converter.cpp
@@ -99,6 +99,22 @@ bool MeasureGridFileConverter::load()
    int grid_width = atoi(state.get("grid_width").c_str());
    measure_grid->voices.resize(grid_height, MeasureGrid::Row(grid_width));
 
+   // grab and parse the time_signatures string
+   measure_grid->time_signatures.clear();
+   std::string time_signatures_string = state.get("time_signatures");
+   std::vector<std::string> time_signature_string_tokens = php::explode(";", time_signatures_string);
+   for (auto &time_signature_string : time_signature_string_tokens)
+   {
+      TimeSignature t = TimeSignature(0, 0, 0);
+      measure_grid->time_signatures.push_back(t);
+      TimeSignatureStringConverter converter(&measure_grid->time_signatures.back());
+
+      if (!converter.read(time_signature_string))
+      {
+         std::cout << "There was an error parsing the time signature \"" << time_signature_string << "\"" << std::endl;
+      }
+   }
+
    // for now, remove those elements.  The rest of the data in `state` is measure data
    state.remove("grid_height");
    state.remove("grid_width");

--- a/source/converters/measure_grid_file_converter.cpp
+++ b/source/converters/measure_grid_file_converter.cpp
@@ -7,6 +7,7 @@
 #include <allegro_flare/data_attr.h>
 #include <allegro_flare/useful_php.h>
 #include <fullscore/converters/note_string_converter.h>
+#include <fullscore/converters/time_signature_string_converter.h>
 #include <fullscore/models/measure_grid.h>
 
 
@@ -30,6 +31,15 @@ bool MeasureGridFileConverter::save()
    state.set("grid_height", tostring(measure_grid->get_num_staves()));
    state.set("grid_width", tostring(measure_grid->get_num_measures()));
    state.set("file_format_version", "v0.0.1");
+
+   // build a time signatures string
+   std::vector<std::string> time_signature_strings;
+   for (auto &time_signature : measure_grid->time_signatures)
+   {
+      TimeSignatureStringConverter converter(&time_signature);
+      time_signature_strings.push_back(converter.write());
+   }
+   state.set("time_signatures", php::implode(";", time_signature_strings));
 
    for (int y=0; y<measure_grid->get_num_staves(); y++)
       for (int x=0; x<measure_grid->get_num_measures(); x++)
@@ -91,6 +101,7 @@ bool MeasureGridFileConverter::load()
    // for now, remove those two elements.  The rest of the data in `state` is measure data
    state.remove("grid_height");
    state.remove("grid_width");
+   state.remove("time_signatures");
    state.remove("file_format_version");
 
    // get the

--- a/source/converters/time_signature_string_converter.cpp
+++ b/source/converters/time_signature_string_converter.cpp
@@ -1,0 +1,45 @@
+
+
+
+
+#include <fullscore/converters/time_signature_string_converter.h>
+
+#include <sstream>
+
+
+
+
+TimeSignatureStringConverter::TimeSignatureStringConverter(TimeSignature *time_signature)
+   : time_signature(time_signature)
+{}
+
+
+
+
+bool TimeSignatureStringConverter::read(std::string str)
+{
+   if (!time_signature) return false;
+
+   std::stringstream ss;
+   ss << str;
+   ss >> time_signature->numerator >> time_signature->denominator_duration >> time_signature->denominator_dots;
+
+   return true;
+}
+
+
+
+
+std::string TimeSignatureStringConverter::write()
+{
+   if (!time_signature) return "";
+
+   std::stringstream ss;
+   ss << time_signature->numerator << " " << time_signature->denominator_duration << " " << time_signature->denominator_dots;
+
+   return ss.str();
+}
+
+
+
+

--- a/source/converters/time_signature_string_converter.cpp
+++ b/source/converters/time_signature_string_converter.cpp
@@ -9,7 +9,7 @@
 
 
 
-TimeSignatureStringConverter::TimeSignatureStringConverter(TimeSignature *time_signature)
+TimeSignatureStringConverter::TimeSignatureStringConverter(TimeSignature time_signature)
    : time_signature(time_signature)
 {}
 
@@ -18,11 +18,9 @@ TimeSignatureStringConverter::TimeSignatureStringConverter(TimeSignature *time_s
 
 bool TimeSignatureStringConverter::read(std::string str)
 {
-   if (!time_signature) return false;
-
    std::stringstream ss;
    ss << str;
-   ss >> time_signature->numerator >> time_signature->denominator_duration >> time_signature->denominator_dots;
+   ss >> time_signature.numerator >> time_signature.denominator_duration >> time_signature.denominator_dots;
 
    return true;
 }
@@ -32,10 +30,8 @@ bool TimeSignatureStringConverter::read(std::string str)
 
 std::string TimeSignatureStringConverter::write()
 {
-   if (!time_signature) return "";
-
    std::stringstream ss;
-   ss << time_signature->numerator << " " << time_signature->denominator_duration << " " << time_signature->denominator_dots;
+   ss << time_signature.numerator << " " << time_signature.denominator_duration << " " << time_signature.denominator_dots;
 
    return ss.str();
 }

--- a/source/converters/time_signature_string_converter.cpp
+++ b/source/converters/time_signature_string_converter.cpp
@@ -9,7 +9,7 @@
 
 
 
-TimeSignatureStringConverter::TimeSignatureStringConverter(TimeSignature time_signature)
+TimeSignatureStringConverter::TimeSignatureStringConverter(TimeSignature *time_signature)
    : time_signature(time_signature)
 {}
 
@@ -18,9 +18,11 @@ TimeSignatureStringConverter::TimeSignatureStringConverter(TimeSignature time_si
 
 bool TimeSignatureStringConverter::read(std::string str)
 {
+   if (!time_signature) return false;
+
    std::stringstream ss;
    ss << str;
-   ss >> time_signature.numerator >> time_signature.denominator_duration >> time_signature.denominator_dots;
+   ss >> time_signature->numerator >> time_signature->denominator_duration >> time_signature->denominator_dots;
 
    return true;
 }
@@ -30,8 +32,10 @@ bool TimeSignatureStringConverter::read(std::string str)
 
 std::string TimeSignatureStringConverter::write()
 {
+   if (!time_signature) return "";
+
    std::stringstream ss;
-   ss << time_signature.numerator << " " << time_signature.denominator_duration << " " << time_signature.denominator_dots;
+   ss << time_signature->numerator << " " << time_signature->denominator_duration << " " << time_signature->denominator_dots;
 
    return ss.str();
 }


### PR DESCRIPTION
This PR adds a `TimeSignatureStringConverter` and adds the feature to properly parse time signatures when saving and loading the score (`MeasureGrid`) to file.

The current implementation of `save()` and `load()` in the `MeasureGridFileConverter` is still fungly.  For the time being, this PR follows that existing style and technique.  Refactoring all of that is for another PR. 