### PR TITLE
Accidentals in Projections

### DIFF
--- a/include/fullscore/models/projection_pitch.h
+++ b/include/fullscore/models/projection_pitch.h
@@ -6,8 +6,9 @@ class ProjectionPitch
 {
 public:
    int pitch;
+   int accidental;
 
-   ProjectionPitch(int pitch);
+   ProjectionPitch(int pitch, int accidental=0);
 
    bool operator==(const ProjectionPitch &other) const;
 };

--- a/source/models/projection_pitch.cpp
+++ b/source/models/projection_pitch.cpp
@@ -5,8 +5,9 @@
 
 
 
-ProjectionPitch::ProjectionPitch(int pitch)
+ProjectionPitch::ProjectionPitch(int pitch, int accidental)
    : pitch(pitch)
+   , accidental(accidental)
 {}
 
 

--- a/source/pitch_projector.cpp
+++ b/source/pitch_projector.cpp
@@ -28,7 +28,9 @@ IndexSet PitchProjector::get_projection()
       while (scale_degree < 0) { scale_degree += cardinality; extension--; }
       while (scale_degree >= cardinality) { scale_degree -= cardinality; extension++; }
 
-      pitch.pitch = projection_set.pitches[scale_degree].pitch + extension * projection_set.extension;
+      ProjectionPitch &projected_pitch = projection_set.pitches[scale_degree];
+      pitch.pitch = projected_pitch.pitch + extension * projection_set.extension;
+      pitch.accidental = projected_pitch.accidental + index_element.accidental;
 
       result.pitches.push_back(pitch);
    }

--- a/source/tools/projection_calculator.cpp
+++ b/source/tools/projection_calculator.cpp
@@ -12,17 +12,40 @@
 
 
 
+int only_ints_to_int(std::string str)
+{
+   std::string result = "";
+
+   std::size_t found = str.find_first_of("0123456789");
+   while (found!=std::string::npos)
+   {
+      result.push_back(str[found]);
+      found = str.find_first_of("0123456789",found+1);
+   }
+
+   found = str.find_first_of("-");
+   int result_int = atoi(result.c_str()) * (found == std::string::npos ? 1 : -1);
+
+   return result_int;
+}
+
+
+
 IndexSet str_to_index_set(std::string str)
 {
    IndexSet result({});
 
    std::vector<std::string> tokens = php::explode(" ", str);
-   std::vector<int> ints;
    for (auto &token : tokens)
-      if (!token.empty()) ints.push_back(atoi(token.c_str()));
+   {
+      if (token.empty()) continue;
 
-   for (auto &i : ints)
-      result.pitches.push_back(ProjectionPitch(i));
+      int num_flats = std::count(token.begin(), token.end(), 'b');
+      int num_sharps = std::count(token.begin(), token.end(), '#');
+      int ints_only_int = only_ints_to_int(token);
+
+      result.pitches.push_back(ProjectionPitch(ints_only_int, num_sharps-num_flats));
+   }
 
    return result;
 }
@@ -51,12 +74,16 @@ ProjectionSet str_to_projection_set(std::string str, std::string extension_str)
    ProjectionSet result({}, extension);
 
    std::vector<std::string> tokens = php::explode(" ", str);
-   std::vector<int> ints;
    for (auto &token : tokens)
-      if (!token.empty()) ints.push_back(atoi(token.c_str()));
+   {
+      if (token.empty()) continue;
 
-   for (auto &i : ints)
-      result.pitches.push_back(ProjectionPitch(i));
+      int num_flats = std::count(token.begin(), token.end(), 'b');
+      int num_sharps = std::count(token.begin(), token.end(), '#');
+      int ints_only_int = only_ints_to_int(token);
+
+      result.pitches.push_back(ProjectionPitch(ints_only_int, num_sharps-num_flats));
+   }
 
    return result;
 }

--- a/source/tools/projection_calculator.cpp
+++ b/source/tools/projection_calculator.cpp
@@ -29,11 +29,16 @@ IndexSet str_to_index_set(std::string str)
 
 
 
-std::string index_set_to_engraver_str(IndexSet &index_set)
+std::string index_set_to_engraver_str(IndexSet &set)
 {
    std::stringstream ss;
-   for (auto &pitch : index_set.pitches)
+   ss << "  ";
+   for (auto &pitch : set.pitches)
+   {
+      ss << (pitch.accidental < 0 ? "-" : pitch.accidental > 0 ? "+" : "");
       ss << "(" << pitch.pitch << ")";
+   }
+   ss << "  ";
    return ss.str();
 }
 
@@ -58,12 +63,15 @@ ProjectionSet str_to_projection_set(std::string str, std::string extension_str)
 
 
 
-std::string projection_set_to_engraver_str(ProjectionSet &index_set)
+std::string projection_set_to_engraver_str(ProjectionSet &set)
 {
    std::stringstream ss;
    ss << "  ";
-   for (auto &pitch : index_set.pitches)
+   for (auto &pitch : set.pitches)
+   {
+      ss << (pitch.accidental < 0 ? "-" : pitch.accidental > 0 ? "+" : "");
       ss << "(" << pitch.pitch << ")";
+   }
    ss << "  ";
    return ss.str();
 }


### PR DESCRIPTION
## Problem

Currently, it is not possible to project from a chromatic 12-note set into a diatonic 7-note set without a loss of precision.

## Solution

Add accidentals to pitches and handle them appropriately when being processed through projections. 

![example](https://cloud.githubusercontent.com/assets/772949/20651436/964d8794-b4b3-11e6-8494-c54bc2e98493.png)
