### PR TITLE
Remove unnecessary time sig friend classes

### DIFF
--- a/include/fullscore/models/time_signature.h
+++ b/include/fullscore/models/time_signature.h
@@ -21,6 +21,9 @@ public:
    TimeSignature(int numerator, Duration denominator);
    ~TimeSignature();
 
+   int get_numerator();
+   Duration get_denominator();
+
    bool set_numerator(int numerator);
    bool set_denominator(Duration denominator);
 

--- a/include/fullscore/models/time_signature.h
+++ b/include/fullscore/models/time_signature.h
@@ -17,8 +17,8 @@ public:
    TimeSignature(int numerator, Duration denominator);
    ~TimeSignature();
 
-   int get_numerator();
-   Duration get_denominator();
+   int get_numerator() const;
+   Duration get_denominator() const;
 
    bool set_numerator(int numerator);
    bool set_denominator(Duration denominator);

--- a/include/fullscore/models/time_signature.h
+++ b/include/fullscore/models/time_signature.h
@@ -10,10 +10,6 @@
 class TimeSignature
 {
 private:
-   friend class TimeSignatureRenderComponent;
-   friend class TimeSignatureStringConverter;
-   friend class DurationHelper;
-
    int numerator;
    Duration denominator;
 

--- a/src/components/time_signature_render_component.cpp
+++ b/src/components/time_signature_render_component.cpp
@@ -41,8 +41,8 @@ void TimeSignatureRenderComponent::render(float x, float y)
    ALLEGRO_FONT *bravura = Framework::font("Bravura.otf 40");
    float ascent = al_get_font_ascent(bravura);
 
-   draw_unicode_char(bravura, color::black, __number_to_unicode(time_signature->numerator), ALLEGRO_ALIGN_CENTER, x, y-ascent - 10);
-   draw_unicode_char(bravura, color::black, __number_to_unicode(time_signature->denominator.denominator), ALLEGRO_ALIGN_CENTER, x, y-ascent + 10);
+   draw_unicode_char(bravura, color::black, __number_to_unicode(time_signature->get_numerator()), ALLEGRO_ALIGN_CENTER, x, y-ascent - 10);
+   draw_unicode_char(bravura, color::black, __number_to_unicode(time_signature->get_denominator().denominator), ALLEGRO_ALIGN_CENTER, x, y-ascent + 10);
 }
 
 

--- a/src/converters/time_signature_string_converter.cpp
+++ b/src/converters/time_signature_string_converter.cpp
@@ -21,8 +21,15 @@ bool TimeSignatureStringConverter::read(std::string str)
    if (!time_signature) return false;
 
    std::stringstream ss;
+   int numerator = 0;
+   int denominator_denominator = 0;
+   int denominator_dots = 0;
+
    ss << str;
-   ss >> time_signature->numerator >> time_signature->denominator.denominator >> time_signature->denominator.dots;
+   ss >> numerator >> denominator_denominator >> denominator_dots;
+
+   time_signature->set_numerator(numerator);
+   time_signature->set_denominator(Duration(denominator_denominator, denominator_dots));
 
    return true;
 }
@@ -35,7 +42,7 @@ std::string TimeSignatureStringConverter::write()
    if (!time_signature) return "";
 
    std::stringstream ss;
-   ss << time_signature->numerator << " " << time_signature->denominator.denominator << " " << time_signature->denominator.dots;
+   ss << time_signature->get_numerator() << " " << time_signature->get_denominator().denominator << " " << time_signature->get_denominator().dots;
 
    return ss.str();
 }

--- a/src/helpers/duration_helper.cpp
+++ b/src/helpers/duration_helper.cpp
@@ -28,8 +28,8 @@ float DurationHelper::get_length(int duration, int dots)
 
 float DurationHelper::get_length(const TimeSignature &time_signature)
 {
-   float denominator_duration_width = get_length(time_signature.denominator.denominator, time_signature.denominator.dots);
-   return denominator_duration_width * time_signature.numerator;
+   float denominator_duration_width = get_length(time_signature.get_denominator().denominator, time_signature.get_denominator().dots);
+   return denominator_duration_width * time_signature.get_numerator();
 }
 
 

--- a/src/models/time_signature.cpp
+++ b/src/models/time_signature.cpp
@@ -22,14 +22,14 @@ TimeSignature::~TimeSignature()
 
 
 
-int TimeSignature::get_numerator()
+int TimeSignature::get_numerator() const
 {
    return numerator;
 }
 
 
 
-Duration TimeSignature::get_denominator()
+Duration TimeSignature::get_denominator() const
 {
    return denominator;
 }

--- a/src/models/time_signature.cpp
+++ b/src/models/time_signature.cpp
@@ -22,6 +22,20 @@ TimeSignature::~TimeSignature()
 
 
 
+int TimeSignature::get_numerator()
+{
+   return numerator;
+}
+
+
+
+Duration TimeSignature::get_denominator()
+{
+   return denominator;
+}
+
+
+
 bool TimeSignature::set_numerator(int numerator)
 {
    if (numerator <= 0) return false;


### PR DESCRIPTION
## Problem

`TimeSignature` has a little more dependent code with friend classes.  These dependencies can be removed by simply adding getter functions.