### PR TITLE
Add ClearMeasure Transform

### DIFF
--- a/include/fullscore/actions/transforms/clear_measure_transform_action.h
+++ b/include/fullscore/actions/transforms/clear_measure_transform_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+
+
+
+class Note;
+
+namespace Action
+{
+   namespace Transform
+   {
+      class ClearMeasure : public Base
+      {
+      private:
+         std::vector<Note> *notes;
+
+      public:
+         ClearMeasure(std::vector<Note> *notes);
+         ~ClearMeasure();
+
+         bool execute() override;
+      };
+   };
+};
+
+
+

--- a/include/fullscore/transforms/clear_measure.h
+++ b/include/fullscore/transforms/clear_measure.h
@@ -1,0 +1,21 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+
+
+namespace Transform
+{
+   class ClearMeasure : public Transform::Base
+   {
+   public:
+      ClearMeasure();
+      ~ClearMeasure();
+      virtual std::vector<Note> transform(std::vector<Note> notes) override;
+   };
+};
+
+
+

--- a/src/actions/transforms/clear_measure_transform_action.cpp
+++ b/src/actions/transforms/clear_measure_transform_action.cpp
@@ -1,0 +1,34 @@
+
+
+
+#include <fullscore/actions/transforms/clear_measure_transform_action.h>
+
+#include <fullscore/transforms/clear_measure.h>
+#include <fullscore/models/note.h>
+
+
+
+Action::Transform::ClearMeasure::ClearMeasure(std::vector<Note> *notes)
+   : Base("clear_measure")
+   , notes(notes)
+{}
+
+
+
+Action::Transform::ClearMeasure::~ClearMeasure()
+{}
+
+
+
+bool Action::Transform::ClearMeasure::execute()
+{
+   if (!notes) return false;
+
+   ::Transform::ClearMeasure clear_measure_transform;
+   *notes = clear_measure_transform.transform(*notes);
+
+   return true;
+}
+
+
+

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -5,6 +5,7 @@
 #include <fullscore/fullscore_application_controller.h>
 
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
+#include <fullscore/actions/transforms/clear_measure_transform_action.h>
 #include <fullscore/actions/transforms/double_duration_transform_action.h>
 #include <fullscore/actions/transforms/erase_note_action.h>
 #include <fullscore/actions/transforms/half_duration_transform_action.h>
@@ -176,6 +177,8 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
    if (current_gui_score_editor->is_note_target_mode())
    {
       single_note = current_gui_score_editor->get_note_at_cursor();
+      focused_measure = current_gui_score_editor->get_measure_at_cursor();
+      if (focused_measure) notes = &focused_measure->notes;
    }
    if (current_gui_score_editor->is_measure_target_mode())
    {
@@ -249,6 +252,11 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
          return action_queue;
       }
    }
+   else if (action_name == "erase_note")
+   {
+      if (current_gui_score_editor->is_note_target_mode()) action = new Action::EraseNote(notes, current_gui_score_editor->note_cursor_x);
+      else if (current_gui_score_editor->is_measure_target_mode()) action = new Action::Transform::ClearMeasure(notes);
+   }
    else if (action_name == "invert")
       action = new Action::Transform::Invert(single_note, 0);
    else if (action_name == "add_dot")
@@ -259,8 +267,6 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       action = new Action::SetCommandMode(current_gui_score_editor, command_bar);
    else if (action_name == "set_normal_mode")
       action = new Action::SetNormalMode(current_gui_score_editor, command_bar);
-   else if (action_name == "erase_note")
-      action = new Action::EraseNote(notes, current_gui_score_editor->note_cursor_x);
    else if (action_name == "retrograde")
       action = new Action::Transform::Retrograde(notes);
    else if (action_name == "octatonic_1_transform")

--- a/src/transforms/clear_measure.cpp
+++ b/src/transforms/clear_measure.cpp
@@ -1,0 +1,24 @@
+
+
+
+#include <fullscore/transforms/clear_measure.h>
+
+
+
+Transform::ClearMeasure::ClearMeasure()
+{}
+
+
+
+Transform::ClearMeasure::~ClearMeasure()
+{}
+
+
+
+std::vector<Note> Transform::ClearMeasure::transform(std::vector<Note> source)
+{
+   return std::vector<Note>();
+}
+
+
+


### PR DESCRIPTION
## Problem

You can only clear a note when in measure mode, and it's not possible to clear a measure.

## Solution

Add a `ClearMeasure` transform.  Use it when in measure-target mode 🎉 and delete notes from a measure while in note-target mode. 🙂