### PR TITLE
Add name property to MeasureGrid::Row

### DIFF
--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -3,11 +3,10 @@
 
 
 
-
 #include <vector>
+#include <string>
 #include <fullscore/models/measure.h>
 #include <fullscore/models/time_signature.h>
-
 
 
 
@@ -20,6 +19,7 @@ private:
    class Row
    {
    public:
+      std::string name;
       std::vector<Measure> measures;
       Row(int num_measures);
       Measure &operator[](unsigned int index);
@@ -43,10 +43,12 @@ public:
    bool delete_measure(int index);
    void append_measure();
 
+   bool set_voice_name(int row_number, std::string name);
+   std::string get_voice_name(int row_number);
+
    bool set_time_signature(int index, TimeSignature time_signature);
    TimeSignature get_time_signature(int index);
 };
-
 
 
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -151,6 +151,25 @@ void MeasureGrid::append_measure()
 
 
 
+bool MeasureGrid::set_voice_name(int row_number, std::string name)
+{
+   if (row_number < 0) return "";
+   if (row_number >= voices.size()) return "";
+   voices[row_number].name = name;
+   return true;
+}
+
+
+
+std::string MeasureGrid::get_voice_name(int row_number)
+{
+   if (row_number < 0) return "";
+   if (row_number >= voices.size()) return "";
+   return voices[row_number].name;
+}
+
+
+
 bool MeasureGrid::set_time_signature(int index, TimeSignature time_signature)
 {
    if (index < 0) return false;

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -1,0 +1,25 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/measure_grid.h>
+#include <fullscore/models/note.h>
+
+
+
+TEST(MeasureGridTest, creates_successfully)
+{
+   MeasureGrid measure_grid(1, 1);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -15,6 +15,22 @@ TEST(MeasureGridTest, creates_successfully)
 
 
 
+TEST(MeasureGridTest, sets_and_gets_the_name_of_a_row)
+{
+   MeasureGrid measure_grid(1, 3);
+
+   EXPECT_EQ(true, measure_grid.set_voice_name(0, "Trombone"));
+   EXPECT_EQ("Trombone", measure_grid.get_voice_name(0));
+
+   EXPECT_EQ(true, measure_grid.set_voice_name(2, "Euphonium"));
+   EXPECT_EQ("Euphonium", measure_grid.get_voice_name(2));
+
+   EXPECT_EQ(true, measure_grid.set_voice_name(2, "Tuba"));
+   EXPECT_EQ("Tuba", measure_grid.get_voice_name(2));
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Problem

When viewing a `MeasureGrid`, there are no clues to what instrument voices are present on that row.  There are no labels, etc.

## Solution

Add a `name` property to the `MeasureGrid`.

## Also

- This also adds a test file `tests/measure_grid_test.cpp`.
 - Note this does _not_ add rendering of the name to the screen.