### PR TITLE
Draw Row name in Score

### DIFF
--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -71,7 +71,9 @@ void MeasureGridRenderComponent::render()
       int y_pos = y * staff_height;
 
       // draw the row name
-      al_draw_text(text_font, color::black, -20, y_pos, ALLEGRO_ALIGN_RIGHT, measure_grid->get_voice_name(y).c_str());
+      float row_middle_y = y_pos + staff_height * 0.5;
+      float label_text_top_y = row_middle_y - al_get_font_line_height(text_font) * 0.5;
+      al_draw_text(text_font, color::black, -30, label_text_top_y, ALLEGRO_ALIGN_RIGHT, measure_grid->get_voice_name(y).c_str());
 
       // draw the measures
       for (int x=0; x<measure_grid->get_num_measures(); x++)

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -66,18 +66,24 @@ void MeasureGridRenderComponent::render()
 
    // draw the notes and measures
    for (int y=0; y<measure_grid->get_num_staves(); y++)
+   {
+      ALLEGRO_FONT *text_font = Framework::font("DroidSans.ttf 20");
+      int y_pos = y * staff_height;
+
+      // draw the row name
+      al_draw_text(text_font, color::black, -20, y_pos, ALLEGRO_ALIGN_RIGHT, measure_grid->get_voice_name(y).c_str());
+
+      // draw the measures
       for (int x=0; x<measure_grid->get_num_measures(); x++)
       {
          Measure *measure = measure_grid->get_measure(x,y);
          float x_pos = MeasureGridHelper::get_length_to_measure(*measure_grid, x) * full_measure_width;
-         int y_pos = y * staff_height;
          music_engraver->draw(measure, x_pos, y_pos + staff_height/2, full_measure_width);
 
          // draw debug info on the note
          if (showing_debug_data)
          {
             float x_cursor = x_pos;
-            ALLEGRO_FONT *text_font = Framework::font("DroidSans.ttf 20");
 
             for (unsigned i=0; i<measure->notes.size(); i++)
             {
@@ -91,6 +97,7 @@ void MeasureGridRenderComponent::render()
             }
          }
       }
+   }
 }
 
 

--- a/src/factories/measure_grid_factory.cpp
+++ b/src/factories/measure_grid_factory.cpp
@@ -4,6 +4,7 @@
 #include <fullscore/factories/measure_grid_factory.h>
 #include <fullscore/models/note.h>
 #include <fullscore/models/measure.h>
+#include <allegro_flare/useful.h>
 #include <iostream>
 
 
@@ -29,6 +30,9 @@ MeasureGrid MeasureGridFactory::twinkle_twinkle_little_star()
    measure_grid.get_measure(3,0)->notes.push_back(Note(-2+3));
    measure_grid.get_measure(3,0)->notes.push_back(Note(-3+3, 2));
 
+   for (int i=0; i<measure_grid.get_num_staves(); i++)
+      measure_grid.set_voice_name(i, tostring("Voice ") + tostring(i));
+
    return measure_grid;
 }
 
@@ -37,6 +41,10 @@ MeasureGrid MeasureGridFactory::twinkle_twinkle_little_star()
 MeasureGrid MeasureGridFactory::big_score()
 {
    MeasureGrid measure_grid(60, 12);
+
+   for (int i=0; i<measure_grid.get_num_staves(); i++)
+      measure_grid.set_voice_name(i, tostring("Voice ") + tostring(i));
+
    return measure_grid;
 }
 


### PR DESCRIPTION
## Problem

Instrument names do not display on the score.

## Solution

Draw them!

![fullscore 2017-07-09 13-28-50](https://user-images.githubusercontent.com/772949/27996176-92bab9ce-64aa-11e7-9f42-7e718d41aa96.png)

## Note

- Add automatic `"Voice x"` names for `twinkle_twinkle_little_star` and `big_score` from the `MeasureGridFactory`.