### PR TITLE
Add essential transforms for cross grid composition

### DIFF
--- a/bin/tests/models/.gitignore
+++ b/bin/tests/models/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/bin/tests/transforms/.gitignore
+++ b/bin/tests/transforms/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -1,6 +1,4 @@
-#ifndef __FULLSCORE_MEASURE_HEADER
-#define __FULLSCORE_MEASURE_HEADER
-
+#pragma once
 
 
 
@@ -8,9 +6,7 @@
 
 
 
-
 class Note;
-
 
 
 
@@ -18,11 +14,9 @@ class Measure
 {
 public:
    int extension;
-	std::vector<Note> notes;
+   std::vector<Note> notes;
    Note *operator[](int index);
 };
 
 
 
-
-#endif

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -17,6 +17,7 @@ class Note;
 class Measure
 {
 public:
+   int extension;
 	std::vector<Note> notes;
    Note *operator[](int index);
 };

--- a/include/fullscore/transforms/copy.h
+++ b/include/fullscore/transforms/copy.h
@@ -1,0 +1,30 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+
+
+class MeasureGrid;
+
+
+
+namespace Transform
+{
+   class Copy : public Base
+   {
+   private:
+      MeasureGrid *measure_grid;
+      int source_x;
+      int source_y;
+
+   public:
+      Copy(MeasureGrid *measure_grid, int source_x, int source_y);
+
+      virtual std::vector<Note> transform(std::vector<Note> n) override;
+   };
+};
+
+
+

--- a/include/fullscore/transforms/stack.h
+++ b/include/fullscore/transforms/stack.h
@@ -1,0 +1,27 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+
+
+namespace Transform
+{
+   class Stack : public Transform::Base
+   {
+   private:
+      std::vector<Transform::Base *> transformations;
+
+   public:
+      Stack(std::vector<Transform::Base *> transformations = {});
+
+      bool add_transform(Transform::Base *transform);
+      bool clear();
+
+      virtual std::vector<Note> transform(std::vector<Note> notes) override;
+   };
+};
+
+
+

--- a/src/models/measure.cpp
+++ b/src/models/measure.cpp
@@ -10,8 +10,8 @@
 
 Note *Measure::operator[](int index)
 {
-	if (index < 0 || notes.empty() || index >= notes.size()) return NULL;
-	return &notes[index];
+   if (index < 0 || notes.empty() || index >= notes.size()) return NULL;
+   return &notes[index];
 }
 
 

--- a/src/transforms/copy.cpp
+++ b/src/transforms/copy.cpp
@@ -1,0 +1,36 @@
+
+
+
+#include <fullscore/transforms/copy.h>
+
+#include <fullscore/models/measure_grid.h>
+#include <sstream>
+
+
+
+Transform::Copy::Copy(MeasureGrid *measure_grid, int source_x, int source_y)
+   : measure_grid(measure_grid)
+   , source_x(source_x)
+   , source_y(source_y)
+{}
+
+
+
+std::vector<Note> Transform::Copy::transform(std::vector<Note> n)
+{
+   if (!measure_grid) throw std::runtime_error("cannot copy measure from empty measure_grid");
+
+   Measure *measure = measure_grid->get_measure(source_x, source_y);
+
+   if (!measure)
+   {
+      std::stringstream error_message;
+      error_message << "measure does not exist at (" << source_x << ", " << source_y << ")" << std::endl;
+      throw std::runtime_error(error_message.str());
+   }
+
+   return measure->notes;
+}
+
+
+

--- a/src/transforms/stack.cpp
+++ b/src/transforms/stack.cpp
@@ -1,0 +1,39 @@
+
+
+
+#include <fullscore/transforms/stack.h>
+
+
+
+Transform::Stack::Stack(std::vector<Transform::Base *> transformations)
+   : transformations(transformations)
+{}
+
+
+
+bool Transform::Stack::add_transform(Transform::Base *transform)
+{
+   transformations.push_back(transform);
+   return true;
+}
+
+
+
+bool Transform::Stack::clear()
+{
+   transformations.clear();
+   return true;
+}
+
+
+
+std::vector<Note> Transform::Stack::transform(std::vector<Note> notes)
+{
+   for(auto &transform : transformations)
+      notes = transform->transform(notes);
+
+   return notes;
+}
+
+
+

--- a/tests/transforms/copy_test.cpp
+++ b/tests/transforms/copy_test.cpp
@@ -1,0 +1,27 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/transforms/copy.h>
+
+#include <fullscore/models/measure_grid.h>
+
+
+
+TEST(CopyTransformTest, can_be_created)
+{
+   MeasureGrid measure_grid(1, 1);
+   Transform::Copy copy_transform(&measure_grid, 0, 0);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/transforms/copy_test.cpp
+++ b/tests/transforms/copy_test.cpp
@@ -44,6 +44,16 @@ TEST(CopyTransformTest, when_referencing_a_measure_grid_that_does_not_exist__rai
 
 
 
+TEST(CopyTransformTest, transform__with_coordinates_that_are_outside_the_grid__raises_an_exception)
+{
+   MeasureGrid measure_grid(1, 1);
+   Transform::Copy copy_transform(&measure_grid, 9999, 9999);
+
+   ASSERT_THROW(copy_transform.transform({}), std::runtime_error);
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/transforms/copy_test.cpp
+++ b/tests/transforms/copy_test.cpp
@@ -35,6 +35,15 @@ TEST(CopyTransformTest, copies_a_set_of_notes_from_a_measure_grid_and_coordinate
 
 
 
+TEST(CopyTransformTest, when_referencing_a_measure_grid_that_does_not_exist__raises_an_exception)
+{
+   Transform::Copy copy_transform(nullptr, 0, 0);
+
+   ASSERT_THROW(copy_transform.transform({}), std::runtime_error);
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/transforms/copy_test.cpp
+++ b/tests/transforms/copy_test.cpp
@@ -17,6 +17,24 @@ TEST(CopyTransformTest, can_be_created)
 
 
 
+TEST(CopyTransformTest, copies_a_set_of_notes_from_a_measure_grid_and_coordinates)
+{
+   std::vector<Note> source_notes = {};
+
+   MeasureGrid measure_grid(1, 1);
+   Measure *measure = measure_grid.get_measure(0, 0);
+   measure->notes = { Note(2), Note(0), Note(1) };
+
+   Transform::Copy copy_transform(&measure_grid, 0, 0);
+
+   std::vector<Note> expected_notes = { Note(2), Note(0), Note(1) };
+   std::vector<Note> returned_notes = copy_transform.transform(source_notes);
+
+   EXPECT_EQ(expected_notes, returned_notes);
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/transforms/stack_test.cpp
+++ b/tests/transforms/stack_test.cpp
@@ -1,0 +1,44 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/transforms/stack.h>
+
+#include <fullscore/transforms/insert_note.h>
+
+
+
+TEST(TransformStackTest, can_be_created)
+{
+   Transform::Stack transform_stack;
+}
+
+
+
+TEST(TransformStackTest, executes_the_sequence_of_transforms)
+{
+   std::vector<Note> source_notes = {};
+   Transform::Stack transform_stack;
+
+   Transform::InsertNote insert_note_transform(0, Note());
+
+   for (unsigned i=0; i<3; i++)
+      transform_stack.add_transform(&insert_note_transform);
+
+   std::vector<Note> expected_notes = { Note(), Note(), Note() };
+   std::vector<Note> returned_notes = transform_stack.transform(source_notes);
+
+   EXPECT_EQ(expected_notes, returned_notes);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
## Problem

A `Measure` will eventually need to be able to reference another measure, and through transforms, generate its own referenced content.

## Solution

- Add `Transform::Copy`, which takes a `MeasureGrid` and an `x` and `y` coordinate, and duplicates its notes.
- Add `Transform::Stack`, which can perform a sequence of transforms and output the result.