### PR TITLE
Add genesis to Measure

### DIFF
--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -4,6 +4,8 @@
 
 #include <vector>
 
+#include <fullscore/transforms/stack.h>
+
 
 
 class Note;
@@ -13,6 +15,11 @@ class Note;
 class Measure
 {
 public:
+   Transform::Stack *genesis;
+   void end_of_the_line();
+
+   Measure();
+
    int extension;
    std::vector<Note> notes;
    Note *operator[](int index);

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -16,7 +16,7 @@ class Measure
 {
 public:
    Transform::Stack *genesis;
-   void end_of_the_line();
+   bool end_of_the_line();
 
    Measure();
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -4,6 +4,9 @@
 
 #include <fullscore/fullscore_application_controller.h>
 
+#include <fullscore/transforms/copy.h>
+#include <fullscore/transforms/double_duration.h>
+
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
 #include <fullscore/actions/transforms/clear_measure_transform_action.h>
 #include <fullscore/actions/transforms/double_duration_transform_action.h>
@@ -64,6 +67,17 @@ FullscoreApplicationController::FullscoreApplicationController(Display *display)
 
    create_new_score_editor("");
    set_current_gui_score_editor(create_new_score_editor("big_score"));
+
+   Measure *m = current_gui_score_editor->measure_grid.get_measure(0, 0);
+   m->notes = {Note(2), Note(0), Note(1)};
+
+   Measure *dm = current_gui_score_editor->measure_grid.get_measure(0, 1);
+   Transform::Copy copy_transform(&current_gui_score_editor->measure_grid, 0, 0);
+   Transform::DoubleDuration double_duration_transform;
+   dm->genesis = new Transform::Stack();
+   dm->genesis->add_transform(&copy_transform);
+   dm->genesis->add_transform(&double_duration_transform);
+   dm->end_of_the_line();
 
    follow_camera.target.position.y = 200;
    follow_camera.target.position.x = 200;

--- a/src/models/measure.cpp
+++ b/src/models/measure.cpp
@@ -8,10 +8,23 @@
 
 
 
+Measure::Measure()
+   : genesis(nullptr)
+{}
+
+
+
 Note *Measure::operator[](int index)
 {
    if (index < 0 || notes.empty() || index >= notes.size()) return NULL;
    return &notes[index];
+}
+
+
+
+void Measure::end_of_the_line()
+{
+   if (genesis) notes = genesis->transform({});
 }
 
 

--- a/src/models/measure.cpp
+++ b/src/models/measure.cpp
@@ -10,6 +10,7 @@
 
 Measure::Measure()
    : genesis(nullptr)
+   , extension(12)
 {}
 
 

--- a/src/models/measure.cpp
+++ b/src/models/measure.cpp
@@ -23,9 +23,22 @@ Note *Measure::operator[](int index)
 
 
 
-void Measure::end_of_the_line()
+bool Measure::end_of_the_line()
 {
-   if (genesis) notes = genesis->transform({});
+   if (genesis)
+   {
+      try
+      {
+         notes = genesis->transform({});
+         return true;
+      }
+      catch (...)
+      {
+         std::cout << "Measure genesis failed" << std::endl;
+         return false;
+      }
+   }
+   return false;
 }
 
 

--- a/tests/models/measure_test.cpp
+++ b/tests/models/measure_test.cpp
@@ -5,6 +5,9 @@
 
 #include <fullscore/models/measure.h>
 
+#include <fullscore/transforms/insert_note.h>
+#include <fullscore/transforms/stack.h>
+
 
 
 TEST(MeasureTest, can_be_created)
@@ -18,6 +21,24 @@ TEST(MeasureTest, has_a_default_extension_of_12)
 {
    Measure measure;
    ASSERT_EQ(12, measure.extension);
+}
+
+
+
+TEST(MeasureTest, with_genesis_populates_its_notes)
+{
+   Measure measure;
+
+   measure.genesis = new Transform::Stack();
+   Transform::InsertNote insert_note_transform(0, Note());
+   for (unsigned i=0; i<3; i++) measure.genesis->add_transform(&insert_note_transform);
+
+   ASSERT_EQ(true, measure.end_of_the_line());
+
+   std::vector<Note> expected_notes = { Note(), Note(), Note() };
+   std::vector<Note> measure_notes = measure.notes;
+
+   ASSERT_EQ(expected_notes, measure_notes);
 }
 
 

--- a/tests/models/measure_test.cpp
+++ b/tests/models/measure_test.cpp
@@ -1,0 +1,32 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/measure.h>
+
+
+
+TEST(MeasureTest, can_be_created)
+{
+   Measure measure;
+}
+
+
+
+TEST(MeasureTest, has_a_default_extension_of_12)
+{
+   Measure measure;
+   ASSERT_EQ(12, measure.extension);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
## Problem

While it's possible to apply a transformation on a `Measure` explicitly, there is no way that a `Measure` as relative to a transformation (or set of transformations).

## Solution

Add a `Transform::Stack` onto a measure as the attribute `genesis`.  `genesis` can be used to build  measure content via `Transform`s.

As an example, if the first transformation in a `genesis` were a `Transform::Copy` of another `Measure`, then the destination `Measure` would in effect become "pointer-like", being a clone of another `Measure` rather than being its own static set of notes.  This could be extended further so that any number of transformations could be applied on top of that initial copy.

## Example

![stacked and packed and ready to go - fullscore 2017-07-09 23-13-11 png 2017-07-09 23-32-41](https://user-images.githubusercontent.com/772949/28001972-ef80d7c0-64fe-11e7-98de-8bb0e27dce42.png)

The `pitch.scale_degree`s in the first measure of **Voice 0** are `[2, 0, 1]`.  The first measure in **Voice 1** has a `genesis` who's stack looks like this:

1. `Transform::Copy` **Voice 0**, measure 0
2. `Transform::DoubleDuration`

Here is another `genesis` stack (same as above, but with a transpose at the end).

![goodness - fullscore 2017-07-09 23-43-04 png 2017-07-09 23-43-16](https://user-images.githubusercontent.com/772949/28002156-69304f28-6500-11e7-9d7f-accc7488acca.png)

1. `Transform::Copy` **Voice 0**, measure 0
2. `Transform::DoubleDuration`
3. `Transform::Transpose`, down by 2.

## Still to Do

In the above example, the `Voice 2` measure does not auto-refresh when its sources are modified.  This can be added in the future.