### PR TITLE
Add New Features Towards Live Measures

### DIFF
--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -17,6 +17,7 @@ class Measure
 public:
    Transform::Stack *genesis;
    bool refresh();
+   bool references_source();
 
    Measure();
 

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -16,7 +16,7 @@ class Measure
 {
 public:
    Transform::Stack *genesis;
-   bool end_of_the_line();
+   bool refresh();
 
    Measure();
 

--- a/include/fullscore/transforms/base.h
+++ b/include/fullscore/transforms/base.h
@@ -14,8 +14,11 @@ namespace Transform
 {
    class Base
    {
+   private:
+      std::string identifier;
+
    public:
-      Base();
+      Base(std::string identifier);
       ~Base();
       virtual std::vector<Note> transform(std::vector<Note> source);
    };

--- a/include/fullscore/transforms/base.h
+++ b/include/fullscore/transforms/base.h
@@ -21,6 +21,7 @@ namespace Transform
       Base(std::string identifier);
       ~Base();
       virtual std::vector<Note> transform(std::vector<Note> source);
+      std::string get_identifier();
    };
 };
 

--- a/include/fullscore/transforms/reference.h
+++ b/include/fullscore/transforms/reference.h
@@ -1,0 +1,30 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+
+
+class MeasureGrid;
+
+
+
+namespace Transform
+{
+   class Reference : public Base
+   {
+   private:
+      MeasureGrid *measure_grid;
+      int source_x;
+      int source_y;
+
+   public:
+      Reference(MeasureGrid *measure_grid, int source_x, int source_y);
+
+      virtual std::vector<Note> transform(std::vector<Note> n) override;
+   };
+};
+
+
+

--- a/include/fullscore/transforms/stack.h
+++ b/include/fullscore/transforms/stack.h
@@ -20,6 +20,7 @@ namespace Transform
       bool clear();
 
       virtual std::vector<Note> transform(std::vector<Note> notes) override;
+      std::vector<Transform::Base *> get_transformations();
    };
 };
 

--- a/include/fullscore/transforms/stack.h
+++ b/include/fullscore/transforms/stack.h
@@ -21,6 +21,7 @@ namespace Transform
 
       virtual std::vector<Note> transform(std::vector<Note> notes) override;
       std::vector<Transform::Base *> get_transformations();
+      bool includes_reference();
    };
 };
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -77,7 +77,7 @@ FullscoreApplicationController::FullscoreApplicationController(Display *display)
    dm->genesis = new Transform::Stack();
    dm->genesis->add_transform(&copy_transform);
    dm->genesis->add_transform(&double_duration_transform);
-   dm->end_of_the_line();
+   dm->refresh();
 
    follow_camera.target.position.y = 200;
    follow_camera.target.position.x = 200;

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -4,7 +4,7 @@
 
 #include <fullscore/fullscore_application_controller.h>
 
-#include <fullscore/transforms/copy.h>
+#include <fullscore/transforms/reference.h>
 #include <fullscore/transforms/double_duration.h>
 
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
@@ -72,10 +72,10 @@ FullscoreApplicationController::FullscoreApplicationController(Display *display)
    m->notes = {Note(2), Note(0), Note(1)};
 
    Measure *dm = current_gui_score_editor->measure_grid.get_measure(0, 1);
-   Transform::Copy copy_transform(&current_gui_score_editor->measure_grid, 0, 0);
+   Transform::Reference reference_transform(&current_gui_score_editor->measure_grid, 0, 0);
    Transform::DoubleDuration double_duration_transform;
    dm->genesis = new Transform::Stack();
-   dm->genesis->add_transform(&copy_transform);
+   dm->genesis->add_transform(&reference_transform);
    dm->genesis->add_transform(&double_duration_transform);
    dm->refresh();
 

--- a/src/models/measure.cpp
+++ b/src/models/measure.cpp
@@ -23,7 +23,7 @@ Note *Measure::operator[](int index)
 
 
 
-bool Measure::end_of_the_line()
+bool Measure::refresh()
 {
    if (genesis)
    {

--- a/src/models/measure.cpp
+++ b/src/models/measure.cpp
@@ -43,3 +43,10 @@ bool Measure::refresh()
 
 
 
+bool Measure::references_source()
+{
+   return genesis && genesis->includes_reference();
+}
+
+
+

--- a/src/transforms/add_dot.cpp
+++ b/src/transforms/add_dot.cpp
@@ -8,6 +8,7 @@
 
 
 Transform::AddDot::AddDot()
+   : Base("add_dot")
 {
 }
 

--- a/src/transforms/base.cpp
+++ b/src/transforms/base.cpp
@@ -30,4 +30,10 @@ std::vector<Note> Transform::Base::transform(std::vector<Note> source)
 
 
 
+std::string Transform::Base::get_identifier()
+{
+   return identifier;
+}
+
+
 

--- a/src/transforms/base.cpp
+++ b/src/transforms/base.cpp
@@ -7,7 +7,8 @@
 
 
 
-Transform::Base::Base()
+Transform::Base::Base(std::string identifier)
+   : identifier(identifier)
 {
 }
 

--- a/src/transforms/clear_measure.cpp
+++ b/src/transforms/clear_measure.cpp
@@ -6,6 +6,7 @@
 
 
 Transform::ClearMeasure::ClearMeasure()
+   : Base("clear_measure")
 {}
 
 

--- a/src/transforms/copy.cpp
+++ b/src/transforms/copy.cpp
@@ -9,7 +9,8 @@
 
 
 Transform::Copy::Copy(MeasureGrid *measure_grid, int source_x, int source_y)
-   : measure_grid(measure_grid)
+   : Base("copy")
+   , measure_grid(measure_grid)
    , source_x(source_x)
    , source_y(source_y)
 {}

--- a/src/transforms/double_duration.cpp
+++ b/src/transforms/double_duration.cpp
@@ -11,7 +11,8 @@
 
 
 Transform::DoubleDuration::DoubleDuration()
-   : maximum_duration(Duration::WHOLE)
+   : Base("double_duration")
+   , maximum_duration(Duration::WHOLE)
 {
 }
 

--- a/src/transforms/erase_note.cpp
+++ b/src/transforms/erase_note.cpp
@@ -10,7 +10,8 @@
 
 
 Transform::EraseNote::EraseNote(int index_num)
-   : index_num(index_num)
+   : Base("erase_note")
+   , index_num(index_num)
 {
 }
 

--- a/src/transforms/half_duration.cpp
+++ b/src/transforms/half_duration.cpp
@@ -11,7 +11,8 @@
 
 
 Transform::HalfDuration::HalfDuration()
-   : minimum_duration(Duration::THIRTYSECOND)
+   : Base("half_duration")
+   , minimum_duration(Duration::THIRTYSECOND)
 {
 }
 

--- a/src/transforms/insert_note.cpp
+++ b/src/transforms/insert_note.cpp
@@ -10,7 +10,8 @@
 
 
 Transform::InsertNote::InsertNote(int position, Note note)
-   : position(position)
+   : Base("insert_note")
+   , position(position)
    , note(note)
 {
 }

--- a/src/transforms/invert.cpp
+++ b/src/transforms/invert.cpp
@@ -8,7 +8,8 @@
 
 
 Transform::Invert::Invert(int axis)
-   : axis(axis)
+   : Base("invert")
+   , axis(axis)
 {
 }
 

--- a/src/transforms/octatonic_1.cpp
+++ b/src/transforms/octatonic_1.cpp
@@ -6,6 +6,7 @@
 
 
 Transform::Octatonic1::Octatonic1()
+   : Base("ocatatonic_1")
 {}
 
 

--- a/src/transforms/reference.cpp
+++ b/src/transforms/reference.cpp
@@ -1,0 +1,36 @@
+
+
+
+#include <fullscore/transforms/reference.h>
+
+#include <fullscore/models/measure_grid.h>
+#include <sstream>
+
+
+
+Transform::Reference::Reference(MeasureGrid *measure_grid, int source_x, int source_y)
+   : measure_grid(measure_grid)
+   , source_x(source_x)
+   , source_y(source_y)
+{}
+
+
+
+std::vector<Note> Transform::Reference::transform(std::vector<Note> n)
+{
+   if (!measure_grid) throw std::runtime_error("cannot reference measure from empty measure_grid");
+
+   Measure *measure = measure_grid->get_measure(source_x, source_y);
+
+   if (!measure)
+   {
+      std::stringstream error_message;
+      error_message << "measure does not exist at (" << source_x << ", " << source_y << ")" << std::endl;
+      throw std::runtime_error(error_message.str());
+   }
+
+   return measure->notes;
+}
+
+
+

--- a/src/transforms/reference.cpp
+++ b/src/transforms/reference.cpp
@@ -9,7 +9,8 @@
 
 
 Transform::Reference::Reference(MeasureGrid *measure_grid, int source_x, int source_y)
-   : measure_grid(measure_grid)
+   : Base("reference")
+   , measure_grid(measure_grid)
    , source_x(source_x)
    , source_y(source_y)
 {}

--- a/src/transforms/remove_dot.cpp
+++ b/src/transforms/remove_dot.cpp
@@ -8,6 +8,7 @@
 
 
 Transform::RemoveDot::RemoveDot()
+   : Base("remove_dot")
 {
 }
 

--- a/src/transforms/retrograde.cpp
+++ b/src/transforms/retrograde.cpp
@@ -8,6 +8,7 @@
 
 
 Transform::Retrograde::Retrograde()
+   : Base("retrograde")
 {
 }
 

--- a/src/transforms/stack.cpp
+++ b/src/transforms/stack.cpp
@@ -6,7 +6,8 @@
 
 
 Transform::Stack::Stack(std::vector<Transform::Base *> transformations)
-   : transformations(transformations)
+   : Base("stack")
+   , transformations(transformations)
 {}
 
 

--- a/src/transforms/stack.cpp
+++ b/src/transforms/stack.cpp
@@ -45,3 +45,12 @@ std::vector<Transform::Base *> Transform::Stack::get_transformations()
 
 
 
+bool Transform::Stack::includes_reference()
+{
+   for(auto &transform : transformations)
+      if (transform->get_identifier() == "reference") return true;
+   return false;
+}
+
+
+

--- a/src/transforms/stack.cpp
+++ b/src/transforms/stack.cpp
@@ -38,3 +38,10 @@ std::vector<Note> Transform::Stack::transform(std::vector<Note> notes)
 
 
 
+std::vector<Transform::Base *> Transform::Stack::get_transformations()
+{
+   return transformations;
+}
+
+
+

--- a/src/transforms/toggle_rest.cpp
+++ b/src/transforms/toggle_rest.cpp
@@ -8,6 +8,7 @@
 
 
 Transform::ToggleRest::ToggleRest()
+   : Base("toggle_rest")
 {
 }
 

--- a/src/transforms/transpose.cpp
+++ b/src/transforms/transpose.cpp
@@ -8,7 +8,8 @@
 
 
 Transform::Transpose::Transpose(int transposition)
-   : transposition(transposition)
+   : Base("transpose")
+   , transposition(transposition)
 {
 }
 

--- a/tests/models/measure_test.cpp
+++ b/tests/models/measure_test.cpp
@@ -6,6 +6,7 @@
 #include <fullscore/models/measure.h>
 
 #include <fullscore/transforms/insert_note.h>
+#include <fullscore/transforms/reference.h>
 #include <fullscore/transforms/stack.h>
 
 
@@ -39,6 +40,40 @@ TEST(MeasureTest, with_genesis_populates_its_notes)
    std::vector<Note> measure_notes = measure.notes;
 
    ASSERT_EQ(expected_notes, measure_notes);
+}
+
+
+
+TEST(MeasureTest, returns_true_if_references_a_source_in_its_genesis)
+{
+   Measure measure;
+
+   measure.genesis = new Transform::Stack();
+   Transform::Reference reference_transform(nullptr, 0, 0);
+   measure.genesis->add_transform(&reference_transform);
+
+   ASSERT_EQ(true, measure.references_source());
+}
+
+
+
+TEST(MeasureTest, returns_false_if_it_does_not_reference_a_source_in_its_genesis__test_1)
+{
+   Measure measure;
+   ASSERT_EQ(false, measure.references_source());
+}
+
+
+
+TEST(MeasureTest, returns_false_if_it_does_not_reference_a_source_in_its_genesis__test_2)
+{
+   Measure measure;
+
+   measure.genesis = new Transform::Stack();
+   Transform::InsertNote insert_note_transform(0, Note());
+   for (unsigned i=0; i<3; i++) measure.genesis->add_transform(&insert_note_transform);
+
+   ASSERT_EQ(false, measure.references_source());
 }
 
 

--- a/tests/models/measure_test.cpp
+++ b/tests/models/measure_test.cpp
@@ -33,7 +33,7 @@ TEST(MeasureTest, with_genesis_populates_its_notes)
    Transform::InsertNote insert_note_transform(0, Note());
    for (unsigned i=0; i<3; i++) measure.genesis->add_transform(&insert_note_transform);
 
-   ASSERT_EQ(true, measure.end_of_the_line());
+   ASSERT_EQ(true, measure.refresh());
 
    std::vector<Note> expected_notes = { Note(), Note(), Note() };
    std::vector<Note> measure_notes = measure.notes;

--- a/tests/transforms/reference_test.cpp
+++ b/tests/transforms/reference_test.cpp
@@ -1,0 +1,64 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/transforms/reference.h>
+
+#include <fullscore/models/measure_grid.h>
+
+
+
+TEST(ReferenceTransformTest, can_be_created)
+{
+   MeasureGrid measure_grid(1, 1);
+   Transform::Reference reference_transform(&measure_grid, 0, 0);
+}
+
+
+
+TEST(ReferenceTransformTest, copies_a_set_of_notes_from_a_measure_grid_and_coordinates)
+{
+   std::vector<Note> source_notes = {};
+
+   MeasureGrid measure_grid(1, 1);
+   Measure *measure = measure_grid.get_measure(0, 0);
+   measure->notes = { Note(2), Note(0), Note(1) };
+
+   Transform::Reference reference_transform(&measure_grid, 0, 0);
+
+   std::vector<Note> expected_notes = { Note(2), Note(0), Note(1) };
+   std::vector<Note> returned_notes = reference_transform.transform(source_notes);
+
+   EXPECT_EQ(expected_notes, returned_notes);
+}
+
+
+
+TEST(ReferenceTransformTest, when_referencing_a_measure_grid_that_does_not_exist__raises_an_exception)
+{
+   Transform::Reference reference_transform(nullptr, 0, 0);
+
+   ASSERT_THROW(reference_transform.transform({}), std::runtime_error);
+}
+
+
+
+TEST(ReferenceTransformTest, transform__with_coordinates_that_are_outside_the_grid__raises_an_exception)
+{
+   MeasureGrid measure_grid(1, 1);
+   Transform::Reference reference_transform(&measure_grid, 9999, 9999);
+
+   ASSERT_THROW(reference_transform.transform({}), std::runtime_error);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/transforms/stack_test.cpp
+++ b/tests/transforms/stack_test.cpp
@@ -6,6 +6,8 @@
 #include <fullscore/transforms/stack.h>
 
 #include <fullscore/transforms/insert_note.h>
+#include <fullscore/transforms/retrograde.h>
+#include <fullscore/transforms/toggle_rest.h>
 
 
 
@@ -38,6 +40,28 @@ TEST(TransformStackTest, executes_the_sequence_of_transforms)
    std::vector<Note> returned_notes = transform_stack.transform(source_notes);
 
    EXPECT_EQ(expected_notes, returned_notes);
+}
+
+
+
+TEST(TransformStackTest, returns_a_list_of_transforms)
+{
+   Transform::Stack transform_stack;
+
+   Transform::InsertNote insert_note_transform(0, Note());
+   Transform::ToggleRest toggle_rest_transform;
+   Transform::Retrograde retrograde_transform;
+
+   transform_stack.add_transform(&insert_note_transform);
+   transform_stack.add_transform(&toggle_rest_transform);
+   transform_stack.add_transform(&retrograde_transform);
+
+   std::vector<Transform::Base *> transforms = transform_stack.get_transformations();
+
+   EXPECT_EQ(3, transforms.size());
+   EXPECT_EQ("insert_note", transforms[0]->get_identifier());
+   EXPECT_EQ("toggle_rest", transforms[1]->get_identifier());
+   EXPECT_EQ("retrograde", transforms[2]->get_identifier());
 }
 
 

--- a/tests/transforms/stack_test.cpp
+++ b/tests/transforms/stack_test.cpp
@@ -6,6 +6,7 @@
 #include <fullscore/transforms/stack.h>
 
 #include <fullscore/transforms/insert_note.h>
+#include <fullscore/transforms/reference.h>
 #include <fullscore/transforms/retrograde.h>
 #include <fullscore/transforms/toggle_rest.h>
 
@@ -62,6 +63,28 @@ TEST(TransformStackTest, returns_a_list_of_transforms)
    EXPECT_EQ("insert_note", transforms[0]->get_identifier());
    EXPECT_EQ("toggle_rest", transforms[1]->get_identifier());
    EXPECT_EQ("retrograde", transforms[2]->get_identifier());
+}
+
+
+
+TEST(TransformStackTest, returns_true_if_it_includes_a_reference)
+{
+   Transform::Stack transform_stack;
+
+   Transform::Reference reference_transform(nullptr, 0, 0);
+
+   transform_stack.add_transform(&reference_transform);
+
+   EXPECT_EQ(true, transform_stack.includes_reference());
+}
+
+
+
+TEST(TransformStackTest, returns_false_if_it_does_not_include_a_reference)
+{
+   Transform::Stack transform_stack;
+
+   EXPECT_EQ(false, transform_stack.includes_reference());
 }
 
 

--- a/tests/transforms/stack_test.cpp
+++ b/tests/transforms/stack_test.cpp
@@ -16,6 +16,14 @@ TEST(TransformStackTest, can_be_created)
 
 
 
+TEST(TransformStackTest, has_an_identifier_of_stack)
+{
+   Transform::Stack transform_stack;
+   EXPECT_EQ("stack", transform_stack.get_identifier());
+}
+
+
+
 TEST(TransformStackTest, executes_the_sequence_of_transforms)
 {
    std::vector<Note> source_notes = {};


### PR DESCRIPTION
## In this PR

- Adds `identifier` to transforms, can be retrieved with `get_identifier()`;
- Introduces a `Transform::Reference` transform

A `Transform::Reference` is identical to `Transform::Copy` in implementation.  But, it's conceptually different in that a `Transform::Reference` should be updated in "real time" whenever the source measure is modified.  The live updating will be added in a future PR.