### PR TITLE
Resolve friend class dependencies in Measure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,11 @@ tests: $(TESTS)
 
 
 
+run_tests: tests
+	find bin/tests -type f -exec {} \;
+
+
+
 bin/tests/%: tests/%.cpp $(OBJECTS)
 	@mkdir -p $(@D)
 	@printf "compiling test \e[1m\e[36m$<\033[0m..."

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -15,7 +15,6 @@ class Note;
 class Measure
 {
 private:
-   friend class FullscoreApplicationController;
    friend class GUIScoreEditor;
 
    std::vector<Note> notes;
@@ -31,6 +30,7 @@ public:
 
    bool set_notes(std::vector<Note> notes);
    std::vector<Note> get_notes_copy();
+   std::vector<Note> *get_notes_pointer();
 };
 
 

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -15,7 +15,6 @@ class Note;
 class Measure
 {
 private:
-   friend class MeasureGridFileConverter;
    friend class MeasureGridFactory;
    friend class FullscoreApplicationController;
    friend class GUIScoreEditor;

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -32,7 +32,7 @@ public:
    int extension;
 
    bool set_notes(std::vector<Note> notes);
-   std::vector<Note> get_notes();
+   std::vector<Note> get_notes_copy();
 };
 
 

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -15,8 +15,6 @@ class Note;
 class Measure
 {
 private:
-   friend class GUIScoreEditor;
-
    std::vector<Note> notes;
 
 public:

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -15,7 +15,6 @@ class Note;
 class Measure
 {
 private:
-   friend class MeasureGridFactory;
    friend class FullscoreApplicationController;
    friend class GUIScoreEditor;
 

--- a/include/fullscore/models/measure/base.h
+++ b/include/fullscore/models/measure/base.h
@@ -7,7 +7,7 @@
 
 
 
-namespace Measure
+namespace Measure2
 {
    class Base
    {
@@ -20,7 +20,8 @@ namespace Measure
       std::string get_type();
       bool is_type(std::string measure_type);
 
-      virtual std::vector<Note> get_notes() = 0;
+      virtual std::vector<Note> get_notes_copy() = 0;
+      virtual bool set_notes(std::vector<Note>) = 0;
    };
 };
 

--- a/include/fullscore/models/measure/base.h
+++ b/include/fullscore/models/measure/base.h
@@ -22,6 +22,7 @@ namespace Measure2
 
       virtual std::vector<Note> get_notes_copy() = 0;
       virtual bool set_notes(std::vector<Note>) = 0;
+      virtual std::vector<Note> *get_notes_pointer();
    };
 };
 

--- a/src/actions/paste_measure_from_buffer_action.cpp
+++ b/src/actions/paste_measure_from_buffer_action.cpp
@@ -30,7 +30,7 @@ Action::PasteMeasureFromBuffer::~PasteMeasureFromBuffer()
 bool Action::PasteMeasureFromBuffer::execute()
 {
    if (!yank_measure_buffer || !destination_measure) return false;
-   destination_measure->set_notes(yank_measure_buffer->get_notes());
+   destination_measure->set_notes(yank_measure_buffer->get_notes_copy());
    return true;
 }
 

--- a/src/actions/yank_measure_to_buffer_action.cpp
+++ b/src/actions/yank_measure_to_buffer_action.cpp
@@ -30,7 +30,7 @@ Action::YankMeasureToBuffer::~YankMeasureToBuffer()
 bool Action::YankMeasureToBuffer::execute()
 {
    if (!yank_measure_buffer || !source_measure) return false;
-   yank_measure_buffer->set_notes(source_measure->get_notes());
+   yank_measure_buffer->set_notes(source_measure->get_notes_copy());
    return true;
 }
 

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -87,7 +87,7 @@ void MeasureGridRenderComponent::render()
          {
             float x_cursor = x_pos;
 
-            for (auto &note : measure->get_notes())
+            for (auto &note : measure->get_notes_copy())
             {
                float width = DurationHelper::get_length(note.duration.denominator, note.duration.dots) * full_measure_width;
 

--- a/src/converters/measure_grid_file_converter.cpp
+++ b/src/converters/measure_grid_file_converter.cpp
@@ -46,13 +46,15 @@ bool MeasureGridFileConverter::save()
       for (int x=0; x<measure_grid->get_num_measures(); x++)
       {
          Measure *measure = measure_grid->get_measure(x, y);
-         if (!measure || measure->notes.empty()) continue;
+         if (!measure) continue;
+         std::vector<Note> measure_notes = measure->get_notes_copy();
+         if (measure_notes.empty()) continue;
          std::string val = "";
          std::vector<std::string> notes_strs;
-         for (int n=0; n<(int)measure->notes.size(); n++)
+         for (int n=0; n<(int)measure_notes.size(); n++)
          {
             // grab the note
-            Note note = measure->notes[n];
+            Note note = measure_notes[n];
 
             // build the note into a string
             NoteStringConverter note_string_converter(&note);
@@ -133,6 +135,8 @@ bool MeasureGridFileConverter::load()
       // get the notes
       std::vector<std::string> notes = php::explode(";", it->second);
 
+      std::vector<Note> final_measure_notes = {};
+
       for (unsigned i=0; i<notes.size(); i++)
       {
          // create a new note
@@ -146,8 +150,10 @@ bool MeasureGridFileConverter::load()
          }
 
          // put the note into the measure
-         measure->notes.push_back(new_note);
+         final_measure_notes.push_back(new_note);
       }
+
+      measure->set_notes(final_measure_notes);
    }
 
    return true;

--- a/src/factories/measure_grid_factory.cpp
+++ b/src/factories/measure_grid_factory.cpp
@@ -14,21 +14,10 @@ MeasureGrid MeasureGridFactory::twinkle_twinkle_little_star()
    MeasureGrid measure_grid(4, 2);
 
    // twinkle twinkle, little star
-   measure_grid.get_measure(0,0)->notes.push_back(Note(0));
-   measure_grid.get_measure(0,0)->notes.push_back(Note(0));
-   measure_grid.get_measure(0,0)->notes.push_back(Note(4));
-   measure_grid.get_measure(0,0)->notes.push_back(Note(4));
-   measure_grid.get_measure(1,0)->notes.push_back(Note(5));
-   measure_grid.get_measure(1,0)->notes.push_back(Note(5));
-   measure_grid.get_measure(1,0)->notes.push_back(Note(4, Duration::HALF));
-
-   measure_grid.get_measure(2,0)->notes.push_back(Note(0+3));
-   measure_grid.get_measure(2,0)->notes.push_back(Note(0+3));
-   measure_grid.get_measure(2,0)->notes.push_back(Note(-1+3));
-   measure_grid.get_measure(2,0)->notes.push_back(Note(-1+3));
-   measure_grid.get_measure(3,0)->notes.push_back(Note(-2+3));
-   measure_grid.get_measure(3,0)->notes.push_back(Note(-2+3));
-   measure_grid.get_measure(3,0)->notes.push_back(Note(-3+3, Duration::HALF));
+   measure_grid.get_measure(0,0)->set_notes({ Note(0), Note(0), Note(4), Note(4) });
+   measure_grid.get_measure(1,0)->set_notes({ Note(5), Note(5), Note(4, Duration::HALF) });
+   measure_grid.get_measure(2,0)->set_notes({ Note(3), Note(3), Note(2), Note(2) });
+   measure_grid.get_measure(3,0)->set_notes({ Note(1), Note(1), Note(0, Duration::HALF) });
 
    for (int i=0; i<measure_grid.get_num_staves(); i++)
       measure_grid.set_voice_name(i, tostring("Voice ") + tostring(i));

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -69,7 +69,7 @@ FullscoreApplicationController::FullscoreApplicationController(Display *display)
    set_current_gui_score_editor(create_new_score_editor("big_score"));
 
    Measure *m = current_gui_score_editor->measure_grid.get_measure(0, 0);
-   m->notes = {Note(2), Note(0), Note(1)};
+   m->set_notes({Note(2), Note(0), Note(1)});
 
    Measure *dm = current_gui_score_editor->measure_grid.get_measure(0, 1);
    Transform::Reference reference_transform(&current_gui_score_editor->measure_grid, 0, 0);
@@ -192,12 +192,12 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
    {
       single_note = current_gui_score_editor->get_note_at_cursor();
       focused_measure = current_gui_score_editor->get_measure_at_cursor();
-      if (focused_measure) notes = &focused_measure->notes;
+      if (focused_measure && focused_measure->get_notes_pointer()) notes = focused_measure->get_notes_pointer();
    }
    if (current_gui_score_editor->is_measure_target_mode())
    {
       focused_measure = current_gui_score_editor->get_measure_at_cursor();
-      if (focused_measure) notes = &focused_measure->notes;
+      if (focused_measure && focused_measure->get_notes_pointer()) notes = focused_measure->get_notes_pointer();
    }
 
    if (action_name == "transpose_up")

--- a/src/gui_score_editor.cpp
+++ b/src/gui_score_editor.cpp
@@ -159,9 +159,10 @@ Note *GUIScoreEditor::get_note_at_cursor()
    Measure *focused_measure = get_measure_at_cursor();
    if (!focused_measure) return NULL;
 
-   if (note_cursor_x < 0 || note_cursor_x >= focused_measure->notes.size()) return nullptr;
+   std::vector<Note> *notes = focused_measure->get_notes_pointer();
+   if (!notes || note_cursor_x < 0 || note_cursor_x >= notes->size()) return nullptr;
 
-   return &focused_measure->notes[note_cursor_x];
+   return &notes->at(note_cursor_x);
 }
 
 
@@ -186,20 +187,23 @@ float GUIScoreEditor::get_measure_cursor_real_y()
 float GUIScoreEditor::get_measure_length_to_note(Measure &measure, int note_index)
 {
    float sum = 0;
-   if (note_index < 0 || note_index >= measure.notes.size()) return 0;
+   std::vector<Note> notes = measure.get_notes_copy();  // TODO: ineffecient use of get_notes_copy()
+
+   if (note_index < 0 || note_index >= notes.size()) return 0;
 
    for (int i=0; i<note_index; i++)
-      sum += DurationHelper::get_length(measure.notes[i].duration.denominator, measure.notes[i].duration.dots);
+      sum += DurationHelper::get_length(notes[i].duration.denominator, notes[i].duration.dots);
    return sum;
 }
 
 
 
 
-float GUIScoreEditor::get_measure_width(Measure &m)
+float GUIScoreEditor::get_measure_width(Measure &m)  // TODO: should probably use a helper
 {
    float sum = 0;
-   for (auto &note : m.notes) sum += DurationHelper::get_length(note.duration.denominator, note.duration.dots);
+   for (auto &note : m.get_notes_copy())  // TODO: ineffecient use of get_notes_copy()
+      sum += DurationHelper::get_length(note.duration.denominator, note.duration.dots);
    return sum;
 }
 
@@ -235,7 +239,7 @@ int GUIScoreEditor::move_note_cursor_x(int delta)
    }
    else
    {
-      int num_notes = current_measure->notes.size();
+      int num_notes = current_measure->get_notes_copy().size();  // TODO: ineffecient use of get_notes_copy()
       note_cursor_x = limit<int>(0, num_notes-1, note_cursor_x + delta);
    }
    return note_cursor_x;

--- a/src/models/measure.cpp
+++ b/src/models/measure.cpp
@@ -50,7 +50,7 @@ bool Measure::set_notes(std::vector<Note> notes)
 
 
 
-std::vector<Note> Measure::get_notes()
+std::vector<Note> Measure::get_notes_copy()
 {
    return notes;
 }

--- a/src/models/measure.cpp
+++ b/src/models/measure.cpp
@@ -57,3 +57,10 @@ std::vector<Note> Measure::get_notes_copy()
 
 
 
+std::vector<Note> *Measure::get_notes_pointer()
+{
+   return &notes;
+}
+
+
+

--- a/src/models/measure/base.cpp
+++ b/src/models/measure/base.cpp
@@ -30,3 +30,10 @@ bool Measure2::Base::is_type(std::string measure_type)
 
 
 
+std::vector<Note> *Measure2::Base::get_notes_pointer()
+{
+   return nullptr;
+}
+
+
+

--- a/src/models/measure/base.cpp
+++ b/src/models/measure/base.cpp
@@ -5,25 +5,25 @@
 
 
 
-Measure::Base::Base(std::string type)
+Measure2::Base::Base(std::string type)
    : type(type)
 {}
 
 
 
-Measure::Base::~Base()
+Measure2::Base::~Base()
 {}
 
 
 
-std::string Measure::Base::get_type()
+std::string Measure2::Base::get_type()
 {
    return type;
 }
 
 
 
-bool Measure::Base::is_type(std::string measure_type)
+bool Measure2::Base::is_type(std::string measure_type)
 {
    return type == measure_type;
 }

--- a/src/music_engraver.cpp
+++ b/src/music_engraver.cpp
@@ -54,7 +54,7 @@ std::string MusicEngraver::translate_note_to_str(const Note &note)
 void MusicEngraver::draw(Measure *measure, float x, float y, const float whole_note_width)
 {
 	int cursor_x = 0;
-   std::vector<Note> notes = measure->get_notes();
+   std::vector<Note> notes = measure->get_notes_copy();
 	for (unsigned i=0; i<notes.size(); i++)
 	{
 		music_notation.draw(x + cursor_x, y, translate_note_to_str(notes[i]));

--- a/src/transforms/copy.cpp
+++ b/src/transforms/copy.cpp
@@ -30,7 +30,7 @@ std::vector<Note> Transform::Copy::transform(std::vector<Note> n)
       throw std::runtime_error(error_message.str());
    }
 
-   return measure->get_notes();
+   return measure->get_notes_copy();
 }
 
 

--- a/src/transforms/reference.cpp
+++ b/src/transforms/reference.cpp
@@ -30,7 +30,7 @@ std::vector<Note> Transform::Reference::transform(std::vector<Note> n)
       throw std::runtime_error(error_message.str());
    }
 
-   return measure->get_notes();
+   return measure->get_notes_copy();
 }
 
 

--- a/tests/models/measure/base_test.cpp
+++ b/tests/models/measure/base_test.cpp
@@ -9,16 +9,26 @@
 
 class TestDerivedClass : public Measure2::Base
 {
+private:
+   std::vector<Note> notes;
+
 public:
-   TestDerivedClass() : Measure2::Base("test_derived_class") {}
+   TestDerivedClass()
+      : Measure2::Base("test_derived_class")
+      , notes({ Note(0, Duration::HALF), Note(3, Duration::SIXTEENTH) })
+   {}
    virtual std::vector<Note> get_notes_copy() override
    {
-      std::vector<Note> notes;
       return notes;
    }
    virtual bool set_notes(std::vector<Note> notes) override
    {
-      return false;
+      this->notes = notes;
+      return true;
+   }
+   virtual std::vector<Note> *get_notes_pointer() override
+   {
+      return &notes;
    }
 };
 
@@ -51,6 +61,32 @@ TEST(MeasureBaseTest, returns_false_if_does_not_matche_type)
 {
    TestDerivedClass measure_base;
    ASSERT_EQ(false, measure_base.is_type("definitely_not_this_type"));
+}
+
+
+
+TEST(MeasureBaseTest, returns_a_copy_of_its_notes)
+{
+   TestDerivedClass measure_base;
+   std::vector<Note> expected_notes = { Note(0, Duration::HALF), Note(3, Duration::SIXTEENTH) };
+   std::vector<Note> returned_notes = measure_base.get_notes_copy();
+
+   ASSERT_EQ(expected_notes, returned_notes);
+}
+
+
+
+TEST(MeasureBaseTest, returns_a_pointer_to_its_notes)
+{
+   TestDerivedClass measure_base;
+   std::vector<Note> expected_notes = { Note(0, Duration::HALF), Note(3, Duration::SIXTEENTH) };
+   std::vector<Note> *returned_notes = measure_base.get_notes_pointer();
+
+   ASSERT_EQ(2, returned_notes->size());
+   ASSERT_EQ(expected_notes.size(), returned_notes->size());
+
+   for (unsigned i=0; i<returned_notes->size(); i++)
+      ASSERT_EQ(expected_notes[i], (*returned_notes).at(i));
 }
 
 

--- a/tests/models/measure/base_test.cpp
+++ b/tests/models/measure/base_test.cpp
@@ -7,10 +7,10 @@
 
 
 
-class TestDerivedClass : public Measure::Base
+class TestDerivedClass : public Measure2::Base
 {
 public:
-   TestDerivedClass() : Measure::Base("test_derived_class") {}
+   TestDerivedClass() : Measure2::Base("test_derived_class") {}
    virtual std::vector<Note> get_notes() override
    {
       std::vector<Note> notes;

--- a/tests/models/measure/base_test.cpp
+++ b/tests/models/measure/base_test.cpp
@@ -11,10 +11,14 @@ class TestDerivedClass : public Measure2::Base
 {
 public:
    TestDerivedClass() : Measure2::Base("test_derived_class") {}
-   virtual std::vector<Note> get_notes() override
+   virtual std::vector<Note> get_notes_copy() override
    {
       std::vector<Note> notes;
       return notes;
+   }
+   virtual bool set_notes(std::vector<Note> notes) override
+   {
+      return false;
    }
 };
 

--- a/tests/models/measure_test.cpp
+++ b/tests/models/measure_test.cpp
@@ -33,7 +33,7 @@ TEST(MeasureTest, can_get_and_set_notes)
 
    ASSERT_EQ(true, measure.set_notes(expected_notes));
 
-   std::vector<Note> returned_notes = measure.get_notes();
+   std::vector<Note> returned_notes = measure.get_notes_copy();
 
    ASSERT_EQ(3, returned_notes.size());
    ASSERT_EQ(expected_notes, returned_notes);
@@ -52,7 +52,7 @@ TEST(MeasureTest, with_genesis_populates_its_notes)
    ASSERT_EQ(true, measure.refresh());
 
    std::vector<Note> expected_notes = { Note(), Note(), Note() };
-   std::vector<Note> measure_notes = measure.get_notes();
+   std::vector<Note> measure_notes = measure.get_notes_copy();
 
    ASSERT_EQ(expected_notes, measure_notes);
 }


### PR DESCRIPTION
## Problem

In order for the magical day of having `class Measure` inherit from `Measure::Base`, we need to resolve some dependencies on the legacy `Measure`.  Particularly there are a lot of cases when other classes need to reach into `Measure` to get `notes`, and then act on them.

## Solution

For the most part, we want to avoid having other classes act on `notes`.  In most cases, these problems can be resolved by using a new `get_notes_copy()` and `set_notes()`.  An external class can get a copy of the notes, modify them, then write them back to the measure.

In some other cases, we want to modify specific notes in the `Measure`.  For this, we provide a `get_notes_pointer()` method.  It should be used sparingly.

## Bonus

Huge!  Can now build _and run **all tests**_ with `make run_tests`.  Huge! ❤️ it! 🎉 