### PR TITLE
Allow setting a new Measure::Basic into a MeasureGrid

### DIFF
--- a/bin/tools/new_action.rb
+++ b/bin/tools/new_action.rb
@@ -41,8 +41,8 @@ header_code.gsub!(/SNAKECASE_ACTION_NAME/, class_name.underscore)
 
 
 # save the file with a new filename
-source_filename = "src/actions/#{class_name.underscore}_action.cpp"
-header_filename = "include/fullscore/actions/#{class_name.underscore}_action.h"
+source_filename = "../src/actions/#{class_name.underscore}_action.cpp"
+header_filename = "../include/fullscore/actions/#{class_name.underscore}_action.h"
 IO.write(source_filename, source_code)
 IO.write(header_filename, header_code)
 

--- a/bin/tools/templates/__action_template.cpp
+++ b/bin/tools/templates/__action_template.cpp
@@ -1,9 +1,7 @@
 
 
 
-
 #include <fullscore/actions/SNAKECASE_ACTION_NAME_action.h>
-
 
 
 
@@ -13,10 +11,8 @@ Action::CLASS_NAME::CLASS_NAME()
 
 
 
-
 Action::CLASS_NAME::~CLASS_NAME()
 {}
-
 
 
 
@@ -25,7 +21,6 @@ bool Action::CLASS_NAME::execute()
    // unimplemented
    return false;
 }
-
 
 
 

--- a/bin/tools/templates/__action_template.h
+++ b/bin/tools/templates/__action_template.h
@@ -2,9 +2,7 @@
 
 
 
-
 #include <fullscore/actions/action_base.h>
-
 
 
 
@@ -19,7 +17,6 @@ namespace Action
       bool execute() override;
    };
 };
-
 
 
 

--- a/bin/tools/templates/__transform_action_template.cpp
+++ b/bin/tools/templates/__transform_action_template.cpp
@@ -1,12 +1,10 @@
 
 
 
-
 #include <fullscore/actions/transforms/SNAKECASE_ACTION_NAME_action.h>
 
 #include <fullscore/transforms/SNAKECASE_ACTION_NAME_transform.h>
 #include <fullscore/models/note.h>
-
 
 
 
@@ -17,10 +15,8 @@ Action::CLASS_NAME::CLASS_NAME(std::vector<Note> *notes)
 
 
 
-
 Action::CLASS_NAME::~CLASS_NAME()
 {}
-
 
 
 
@@ -31,7 +27,6 @@ bool Action::CLASS_NAME::execute()
    // unimplemented
    return false;
 }
-
 
 
 

--- a/bin/tools/templates/__transform_action_template.h
+++ b/bin/tools/templates/__transform_action_template.h
@@ -2,10 +2,8 @@
 
 
 
-
 #include <vector>
 #include <fullscore/actions/action_base.h>
-
 
 
 
@@ -25,7 +23,6 @@ namespace Action
       bool execute() override;
    };
 };
-
 
 
 

--- a/include/fullscore/actions/set_basic_measure_action.h
+++ b/include/fullscore/actions/set_basic_measure_action.h
@@ -1,0 +1,33 @@
+#pragma once
+
+
+
+
+#include <fullscore/actions/action_base.h>
+
+
+
+class MeasureGrid;
+
+
+
+namespace Action
+{
+   class SetBasicMeasure : public Base
+   {
+   private:
+      MeasureGrid *measure_grid;
+      int measure_x;
+      int staff_y;
+
+   public:
+      SetBasicMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y);
+      ~SetBasicMeasure();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/actions/set_basic_measure_action.h
+++ b/include/fullscore/actions/set_basic_measure_action.h
@@ -2,7 +2,6 @@
 
 
 
-
 #include <fullscore/actions/action_base.h>
 
 
@@ -27,7 +26,6 @@ namespace Action
       bool execute() override;
    };
 };
-
 
 
 

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -31,6 +31,7 @@ private:
 public:
    MeasureGrid(int num_x_measures, int num_y_staves);
    Measure::Base *get_measure(int x_measure, int y_staff);
+   bool set_measure(int x_measure, int y_staff, Measure::Base *measure);
 
    int get_num_staves() const;
    int get_num_measures() const;

--- a/include/fullscore/models/measures/basic.h
+++ b/include/fullscore/models/measures/basic.h
@@ -26,6 +26,7 @@ namespace Measure
       bool references_source();
 
       Basic();
+      Basic(std::vector<Note> notes);
 
       int extension;
 

--- a/src/actions/move_cursor_left_action.cpp
+++ b/src/actions/move_cursor_left_action.cpp
@@ -36,7 +36,7 @@ bool Action::MoveCursorLeft::execute()
    }
    else if (score_editor->is_note_target_mode()) score_editor->move_note_cursor_x(-1);
 
-   return false;
+   return true;
 }
 
 

--- a/src/actions/move_cursor_right_action.cpp
+++ b/src/actions/move_cursor_right_action.cpp
@@ -36,7 +36,7 @@ bool Action::MoveCursorRight::execute()
    }
    else if (score_editor->is_note_target_mode()) score_editor->move_note_cursor_x(1);
 
-   return false;
+   return true;
 }
 
 

--- a/src/actions/set_basic_measure_action.cpp
+++ b/src/actions/set_basic_measure_action.cpp
@@ -1,7 +1,6 @@
 
 
 
-
 #include <fullscore/actions/set_basic_measure_action.h>
 
 #include <fullscore/models/measures/basic.h>
@@ -18,10 +17,8 @@ Action::SetBasicMeasure::SetBasicMeasure(MeasureGrid *measure_grid, int measure_
 
 
 
-
 Action::SetBasicMeasure::~SetBasicMeasure()
 {}
-
 
 
 
@@ -43,7 +40,6 @@ bool Action::SetBasicMeasure::execute()
 
    return true;
 }
-
 
 
 

--- a/src/actions/set_basic_measure_action.cpp
+++ b/src/actions/set_basic_measure_action.cpp
@@ -1,0 +1,49 @@
+
+
+
+
+#include <fullscore/actions/set_basic_measure_action.h>
+
+#include <fullscore/models/measures/basic.h>
+#include <fullscore/models/measure_grid.h>
+
+
+
+Action::SetBasicMeasure::SetBasicMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y)
+   : Base("set_basic_measure")
+   , measure_grid(measure_grid)
+   , measure_x(measure_x)
+   , staff_y(staff_y)
+{}
+
+
+
+
+Action::SetBasicMeasure::~SetBasicMeasure()
+{}
+
+
+
+
+bool Action::SetBasicMeasure::execute()
+{
+   if (!measure_grid) throw std::runtime_error("Cannot set Measure::Basic on a nullptr measure_grid");
+
+   Measure::Basic *new_basic_measure = new Measure::Basic();
+
+   bool measure_set_successfully = measure_grid->set_measure(measure_x, staff_y, new_basic_measure);
+
+   if (!measure_set_successfully)
+   {
+      delete new_basic_measure;
+      std::stringstream error_message;
+      error_message << "Could not set a Measure::Basic the measure in the measure grid at (" << measure_x << ", " << staff_y << ")";
+      throw std::runtime_error(error_message.str());
+   }
+
+   return true;
+}
+
+
+
+

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -50,9 +50,6 @@ void MeasureGridRenderComponent::render()
    TimeSignature previous_time_signature = TimeSignature(0, Duration());
    for (int x=0; x<measure_grid->get_num_measures(); x++)
    {
-      Measure::Base *measure = measure_grid->get_measure(x, 0);
-      if (!measure) continue;
-
       float x_pos = MeasureGridHelper::get_length_to_measure(*measure_grid, x) * full_measure_width;
       TimeSignature time_signature = measure_grid->get_time_signature(x);
       TimeSignatureRenderComponent time_signature_render_component(&time_signature);

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -51,6 +51,8 @@ void MeasureGridRenderComponent::render()
    for (int x=0; x<measure_grid->get_num_measures(); x++)
    {
       Measure::Base *measure = measure_grid->get_measure(x, 0);
+      if (!measure) continue;
+
       float x_pos = MeasureGridHelper::get_length_to_measure(*measure_grid, x) * full_measure_width;
       TimeSignature time_signature = measure_grid->get_time_signature(x);
       TimeSignatureRenderComponent time_signature_render_component(&time_signature);
@@ -79,6 +81,8 @@ void MeasureGridRenderComponent::render()
       for (int x=0; x<measure_grid->get_num_measures(); x++)
       {
          Measure::Base *measure = measure_grid->get_measure(x,y);
+         if (!measure) continue;
+
          float x_pos = MeasureGridHelper::get_length_to_measure(*measure_grid, x) * full_measure_width;
          music_engraver->draw(measure, x_pos, y_pos + staff_height/2, full_measure_width);
 

--- a/src/converters/measure_grid_file_converter.cpp
+++ b/src/converters/measure_grid_file_converter.cpp
@@ -131,6 +131,7 @@ bool MeasureGridFileConverter::load()
       std::vector<std::string> parts = php::explode(",", it->first);
       if (parts.size() != 2) continue;
       Measure::Base *measure = measure_grid->get_measure(atoi(parts[0].c_str()), atoi(parts[1].c_str()));
+      if (!measure) continue;
 
       // get the notes
       std::vector<std::string> notes = php::explode(";", it->second);

--- a/src/factories/measure_grid_factory.cpp
+++ b/src/factories/measure_grid_factory.cpp
@@ -14,10 +14,14 @@ MeasureGrid MeasureGridFactory::twinkle_twinkle_little_star()
    MeasureGrid measure_grid(4, 2);
 
    // twinkle twinkle, little star
-   measure_grid.get_measure(0,0)->set_notes({ Note(0), Note(0), Note(4), Note(4) });
-   measure_grid.get_measure(1,0)->set_notes({ Note(5), Note(5), Note(4, Duration::HALF) });
-   measure_grid.get_measure(2,0)->set_notes({ Note(3), Note(3), Note(2), Note(2) });
-   measure_grid.get_measure(3,0)->set_notes({ Note(1), Note(1), Note(0, Duration::HALF) });
+   measure_grid.set_measure(0,0, new Measure::Basic({ Note(0), Note(0), Note(4), Note(4) }));
+   //measure_grid.get_measure(0,0)->set_notes({ Note(0), Note(0), Note(4), Note(4) });
+   measure_grid.set_measure(1,0, new Measure::Basic({ Note(5), Note(5), Note(4, Duration::HALF) }));
+   //measure_grid.get_measure(1,0)->set_notes({ Note(5), Note(5), Note(4, Duration::HALF) });
+   measure_grid.set_measure(2,0, new Measure::Basic({ Note(3), Note(3), Note(2), Note(2) }));
+   //measure_grid.get_measure(2,0)->set_notes({ Note(3), Note(3), Note(2), Note(2) });
+   measure_grid.set_measure(3,0, new Measure::Basic({ Note(1), Note(1), Note(0, Duration::HALF) }));
+   //measure_grid.get_measure(3,0)->set_notes({ Note(1), Note(1), Note(0, Duration::HALF) });
 
    for (int i=0; i<measure_grid.get_num_staves(); i++)
       measure_grid.set_voice_name(i, tostring("Voice ") + tostring(i));

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -68,16 +68,20 @@ FullscoreApplicationController::FullscoreApplicationController(Display *display)
    create_new_score_editor("");
    set_current_gui_score_editor(create_new_score_editor("big_score"));
 
+   current_gui_score_editor->measure_grid.set_measure(0, 0, new Measure::Basic({Note(2), Note(0), Note(1)}));
    Measure::Base *m = current_gui_score_editor->measure_grid.get_measure(0, 0);
-   m->set_notes({Note(2), Note(0), Note(1)});
+   if (!m) throw std::runtime_error("hmm, ApplicationController not able to set/get a measure from the MeasureGrid (0, 0)");
 
-   Measure::Base *dm = current_gui_score_editor->measure_grid.get_measure(0, 1);
+   current_gui_score_editor->measure_grid.set_measure(0, 1, new Measure::Basic());
+   Measure::Basic *dm = static_cast<Measure::Basic *>(current_gui_score_editor->measure_grid.get_measure(0, 1));
+   if (!dm) throw std::runtime_error("hmm, ApplicationController not able to set/get a measure from the MeasureGrid (0, 1)");
+
    Transform::Reference reference_transform(&current_gui_score_editor->measure_grid, 0, 0);
    Transform::DoubleDuration double_duration_transform;
-   //dm->genesis = new Transform::Stack();
-   //dm->genesis->add_transform(&reference_transform);
-   //dm->genesis->add_transform(&double_duration_transform);
-   //dm->refresh();
+   dm->genesis = new Transform::Stack();
+   dm->genesis->add_transform(&reference_transform);
+   dm->genesis->add_transform(&double_duration_transform);
+   dm->refresh();
 
    follow_camera.target.position.y = 200;
    follow_camera.target.position.x = 200;

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -355,7 +355,19 @@ void FullscoreApplicationController::key_down_func()
 
    if (action)
    {
-      action->execute();
+      try
+      {
+         if (!action->execute()) throw std::runtime_error("Generic could-not-execute-action exception");
+      }
+      catch (const std::runtime_error& e)
+      {
+         std::cout << "Exception caught while trying to run action "
+                   << action->get_action_name()
+                   << " with the following message \""
+                   << e.what()
+                   << "\""
+                   << std::endl;
+      }
       delete action;
    }
 }

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -36,6 +36,7 @@
 #include <fullscore/actions/queue_action.h>
 #include <fullscore/actions/reset_playback_action.h>
 #include <fullscore/actions/save_measure_grid_action.h>
+#include <fullscore/actions/set_basic_measure_action.h>
 #include <fullscore/actions/set_camera_target_action.h>
 #include <fullscore/actions/set_current_gui_score_editor_action.h>
 #include <fullscore/actions/set_score_zoom_action.h>
@@ -136,6 +137,7 @@ std::string FullscoreApplicationController::find_action_identifier(GUIScoreEdito
       case ALLEGRO_KEY_J: return "move_cursor_down"; break;
       case ALLEGRO_KEY_K: return "move_cursor_up"; break;
       case ALLEGRO_KEY_L: return "move_cursor_right"; break;
+      case ALLEGRO_KEY_M: return "set_basic_measure"; break;
       case ALLEGRO_KEY_Y: return "yank_measure_to_buffer"; break;
       case ALLEGRO_KEY_P: return "paste_measure_from_buffer"; break;
       case ALLEGRO_KEY_O: return "octatonic_1_transform"; break;
@@ -273,7 +275,7 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
    else if (action_name == "erase_note")
    {
       if (current_gui_score_editor->is_note_target_mode()) action = new Action::EraseNote(notes, current_gui_score_editor->note_cursor_x);
-      else if (current_gui_score_editor->is_measure_target_mode()) action = new Action::Transform::ClearMeasure(notes);
+      else if (current_gui_score_editor->is_measure_target_mode()) action = new Action::Transform::ClearMeasure(notes); // TODO this should be changed to SetMeasure(nullptr) or something to that effect
    }
    else if (action_name == "invert")
       action = new Action::Transform::Invert(single_note, 0);
@@ -321,6 +323,8 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
    else if (action_name == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(current_gui_score_editor);
+   else if (action_name == "set_basic_measure")
+      action = new Action::SetBasicMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
    else if (action_name == "insert_measure")
       action = new Action::InsertMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x);
    else if (action_name == "delete_measure")

--- a/src/gui_score_editor.cpp
+++ b/src/gui_score_editor.cpp
@@ -70,56 +70,55 @@ void GUIScoreEditor::on_draw()
    float CACHED_get_measure_cursor_real_x = get_measure_cursor_real_x();
    float CACHED_get_measure_cursor_real_y = get_measure_cursor_real_y();
 
-   if (measure)
-   {
-      float measure_width = get_measure_width(measure) * FULL_MEASURE_WIDTH;
+   // draw the measure
 
-      // measure box fill
-      al_draw_filled_rounded_rectangle(CACHED_get_measure_cursor_real_x, measure_cursor_y*STAFF_HEIGHT,
+   float measure_width = get_measure_width(measure) * FULL_MEASURE_WIDTH;
+
+   // measure box fill
+   al_draw_filled_rounded_rectangle(CACHED_get_measure_cursor_real_x, measure_cursor_y*STAFF_HEIGHT,
+      CACHED_get_measure_cursor_real_x+measure_width, measure_cursor_y*STAFF_HEIGHT+STAFF_HEIGHT,
+      4, 4, color::color(color::aliceblue, 0.2));
+
+   // measure box outline
+   if (is_measure_target_mode())
+      al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, measure_cursor_y*STAFF_HEIGHT,
          CACHED_get_measure_cursor_real_x+measure_width, measure_cursor_y*STAFF_HEIGHT+STAFF_HEIGHT,
-         4, 4, color::color(color::aliceblue, 0.2));
+         4, 4, color::color(color::aliceblue, 0.7), 2.0);
 
-      // measure box outline
-      if (is_measure_target_mode())
-         al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, measure_cursor_y*STAFF_HEIGHT,
-            CACHED_get_measure_cursor_real_x+measure_width, measure_cursor_y*STAFF_HEIGHT+STAFF_HEIGHT,
-            4, 4, color::color(color::aliceblue, 0.7), 2.0);
+   // left bar
+   al_draw_line(CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y,
+         CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y+STAFF_HEIGHT,
+         color::white, 3.0);
 
-      // left bar
-      al_draw_line(CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y,
-            CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y+STAFF_HEIGHT,
-            color::white, 3.0);
+   // draw a hilight box at the focused note
+   if (note)
+   {
+      float note_real_offset_x = get_measure_length_to_note(measure, note_cursor_x) * FULL_MEASURE_WIDTH;
+      float real_note_width = DurationHelper::get_length(note->duration.denominator, note->duration.dots) * FULL_MEASURE_WIDTH;
 
-      // draw a hilight box at the focused note
-      if (note)
-      {
-         float note_real_offset_x = get_measure_length_to_note(measure, note_cursor_x) * FULL_MEASURE_WIDTH;
-         float real_note_width = DurationHelper::get_length(note->duration.denominator, note->duration.dots) * FULL_MEASURE_WIDTH;
+      // note box fill
+      al_draw_filled_rounded_rectangle(
+            CACHED_get_measure_cursor_real_x + note_real_offset_x,
+            CACHED_get_measure_cursor_real_y,
+            CACHED_get_measure_cursor_real_x + note_real_offset_x + real_note_width,
+            CACHED_get_measure_cursor_real_y + STAFF_HEIGHT,
+            6,
+            6,
+            color::color(color::pink, 0.4)
+         );
 
-         // note box fill
-         al_draw_filled_rounded_rectangle(
+      // note box outline
+      if (is_note_target_mode())
+         al_draw_rounded_rectangle(
                CACHED_get_measure_cursor_real_x + note_real_offset_x,
                CACHED_get_measure_cursor_real_y,
                CACHED_get_measure_cursor_real_x + note_real_offset_x + real_note_width,
                CACHED_get_measure_cursor_real_y + STAFF_HEIGHT,
                6,
                6,
-               color::color(color::pink, 0.4)
+               color::mix(color::color(color::pink, 0.8), color::black, 0.3),
+               2.0
             );
-
-         // note box outline
-         if (is_note_target_mode())
-            al_draw_rounded_rectangle(
-                  CACHED_get_measure_cursor_real_x + note_real_offset_x,
-                  CACHED_get_measure_cursor_real_y,
-                  CACHED_get_measure_cursor_real_x + note_real_offset_x + real_note_width,
-                  CACHED_get_measure_cursor_real_y + STAFF_HEIGHT,
-                  6,
-                  6,
-                  color::mix(color::color(color::pink, 0.8), color::black, 0.3),
-                  2.0
-               );
-      }
    }
 
    // draw the playhead
@@ -188,7 +187,8 @@ float GUIScoreEditor::get_measure_cursor_real_y()
 float GUIScoreEditor::get_measure_length_to_note(Measure::Base *measure, int note_index)
 {
    float sum = 0;
-   std::vector<Note> notes = measure->get_notes_copy();  // TODO: ineffecient use of get_notes_copy()
+   std::vector<Note> notes;
+   if (measure) notes = measure->get_notes_copy();  // TODO: ineffecient use of get_notes_copy()
 
    if (note_index < 0 || note_index >= notes.size()) return 0;
 
@@ -202,6 +202,7 @@ float GUIScoreEditor::get_measure_length_to_note(Measure::Base *measure, int not
 
 float GUIScoreEditor::get_measure_width(Measure::Base *m)  // TODO: should probably use a helper
 {
+   if (!m) return 0;
    float sum = 0;
    for (auto &note : m->get_notes_copy())  // TODO: ineffecient use of get_notes_copy()
       sum += DurationHelper::get_length(note.duration.denominator, note.duration.dots);

--- a/src/gui_score_editor.cpp
+++ b/src/gui_score_editor.cpp
@@ -65,6 +65,7 @@ void GUIScoreEditor::on_draw()
 
    // draw a hilight box under the focused measure
    Measure::Base *measure = get_measure_at_cursor();
+
    Note *note = get_note_at_cursor();
    float CACHED_get_measure_cursor_real_x = get_measure_cursor_real_x();
    float CACHED_get_measure_cursor_real_y = get_measure_cursor_real_y();

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -10,7 +10,7 @@
 
 MeasureGrid::Row::Row(int num_measures) : measures()
 {
-   for (unsigned i=0; i<num_measures; i++) measures.push_back(new Measure::Basic());
+   for (unsigned i=0; i<num_measures; i++) measures.push_back(nullptr);
 }
 
 
@@ -126,7 +126,7 @@ void MeasureGrid::insert_measure(int index)
       {
          // WARNING: this assumes all staves have the same
          // number of measures (they should)
-         voices[i].measures.insert(voices[i].measures.begin() + index, new Measure::Basic());
+         voices[i].measures.insert(voices[i].measures.begin() + index, nullptr);
       }
    }
 }
@@ -159,7 +159,7 @@ void MeasureGrid::append_measure()
    // append measure to each row
    for (unsigned i=0; i<voices.size(); i++)
    {
-      voices[i].measures.push_back(new Measure::Basic());
+      voices[i].measures.push_back(nullptr);
    }
 }
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -44,6 +44,20 @@ Measure::Base *MeasureGrid::get_measure(int x_measure, int y_staff)
 
 
 
+bool MeasureGrid::set_measure(int x_measure, int y_staff, Measure::Base *measure)
+{
+   // bounds check
+   if (x_measure < 0 || x_measure >= this->get_num_measures() || this->get_num_measures() == 0) return false;
+   if (y_staff < 0 || y_staff >= this->get_num_staves() || this->get_num_staves() == 0) return false;
+
+   Measure::Base *existing_measure = get_measure(x_measure, y_staff);
+   if (existing_measure) delete existing_measure;
+   voices[y_staff].measures[x_measure] = measure;
+   return true;
+}
+
+
+
 int MeasureGrid::get_num_measures() const
 {
    if (voices.empty()) return 0;

--- a/src/models/measures/basic.cpp
+++ b/src/models/measures/basic.cpp
@@ -16,6 +16,17 @@ Measure::Basic::Basic()
 
 
 
+Measure::Basic::Basic(std::vector<Note> notes)
+   : Base("basic")
+   , genesis(nullptr)
+   , extension(12)
+   , notes()
+{
+   set_notes(notes);
+}
+
+
+
 bool Measure::Basic::refresh()
 {
    if (genesis)

--- a/src/models/measures/basic.cpp
+++ b/src/models/measures/basic.cpp
@@ -9,7 +9,7 @@
 
 
 Measure::Basic::Basic()
-   : Measure::Base("measure")
+   : Base("basic")
    , genesis(nullptr)
    , extension(12)
 {}

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -18,7 +18,6 @@ TEST(MeasureGridTest, creates_successfully)
 TEST(MeasureGridTest, returns_the_number_of_staves)
 {
    MeasureGrid measure_grid(17, 13);
-
    EXPECT_EQ(13, measure_grid.get_num_staves());
 }
 
@@ -27,7 +26,6 @@ TEST(MeasureGridTest, returns_the_number_of_staves)
 TEST(MeasureGridTest, returns_the_number_of_measures)
 {
    MeasureGrid measure_grid(17, 3);
-
    EXPECT_EQ(17, measure_grid.get_num_measures());
 }
 
@@ -45,6 +43,26 @@ TEST(MeasureGridTest, sets_and_gets_the_name_of_a_row)
 
    EXPECT_EQ(true, measure_grid.set_voice_name(2, "Tuba"));
    EXPECT_EQ("Tuba", measure_grid.get_voice_name(2));
+}
+
+
+
+TEST(MeasureGridTest, sets_and_gets_a_measure_to_a_coordinate)
+{
+   MeasureGrid measure_grid(17, 13);
+
+   Measure::Basic *basic_measure = new Measure::Basic();
+
+   EXPECT_TRUE(measure_grid.set_measure(3, 7, basic_measure));
+
+   Measure::Base *retrieved_measure = measure_grid.get_measure(3, 7);
+   ASSERT_NE(nullptr, retrieved_measure);
+   ASSERT_TRUE(retrieved_measure->is_type("basic"));
+
+   int expected_id = basic_measure->get_id();
+   int returned_id = retrieved_measure->get_id();
+
+   EXPECT_EQ(expected_id, returned_id);
 }
 
 

--- a/tests/transforms/copy_test.cpp
+++ b/tests/transforms/copy_test.cpp
@@ -22,8 +22,9 @@ TEST(CopyTransformTest, copies_a_set_of_notes_from_a_measure_grid_and_coordinate
    std::vector<Note> source_notes = {};
 
    MeasureGrid measure_grid(1, 1);
+   measure_grid.set_measure(0, 0, new Measure::Basic({ Note(2), Note(0), Note(1) }));
    Measure::Base *measure = measure_grid.get_measure(0, 0);
-   measure->set_notes({ Note(2), Note(0), Note(1) });
+   ASSERT_NE(nullptr, measure);
 
    Transform::Copy copy_transform(&measure_grid, 0, 0);
 

--- a/tests/transforms/reference_test.cpp
+++ b/tests/transforms/reference_test.cpp
@@ -22,8 +22,9 @@ TEST(ReferenceTransformTest, copies_a_set_of_notes_from_a_measure_grid_and_coord
    std::vector<Note> source_notes = {};
 
    MeasureGrid measure_grid(1, 1);
+   measure_grid.set_measure(0, 0, new Measure::Basic({ Note(2), Note(0), Note(1) }));
    Measure::Base *measure = measure_grid.get_measure(0, 0);
-   measure->set_notes({ Note(2), Note(0), Note(1) });
+   ASSERT_NE(nullptr, measure);
 
    Transform::Reference reference_transform(&measure_grid, 0, 0);
 


### PR DESCRIPTION
## Problem

A recent change to `Measure::Base` as a base class for all measures means there is still some code that needs to be modified in the general app.  `Measure`s, of any type, still can not be created and the program cannot, say, insert notes into a `MeasureGrid` because there are no `Measure`s in place.

## Solution

Allow setting a new measure on the measure grid, specifically a `Measure::Basic`.  This is performed through an action.

Also:

- When an action executes in `FullscoreApplicationController` and fails, it will raise an exception, get caught, and be reported to `std::cout`.
- There are a lot of `Action`s (basically all except one) that upon failure will only return false.  These should be updated to throw meaningful exception messages.