### PR TITLE
Add exceptions in yank paste actions

### DIFF
--- a/include/fullscore/actions/set_reference_measure_action.h
+++ b/include/fullscore/actions/set_reference_measure_action.h
@@ -18,9 +18,12 @@ namespace Action
       MeasureGrid *measure_grid;
       int measure_x;
       int staff_y;
+      MeasureGrid *referenced_measure_grid;
+      int referenced_measure_x;
+      int referenced_staff_y;
 
    public:
-      SetReferenceMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y);
+      SetReferenceMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y, MeasureGrid *referenced_measure_grid, int referenced_measure_x, int referenced_staff_y);
       ~SetReferenceMeasure();
 
       bool execute() override;

--- a/include/fullscore/actions/set_reference_measure_action.h
+++ b/include/fullscore/actions/set_reference_measure_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+#include <fullscore/actions/action_base.h>
+
+
+
+class MeasureGrid;
+
+
+
+namespace Action
+{
+   class SetReferenceMeasure : public Base
+   {
+   private:
+      MeasureGrid *measure_grid;
+      int measure_x;
+      int staff_y;
+
+   public:
+      SetReferenceMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y);
+      ~SetReferenceMeasure();
+
+      bool execute() override;
+   };
+};
+
+
+

--- a/include/fullscore/models/measures/reference.h
+++ b/include/fullscore/models/measures/reference.h
@@ -1,0 +1,35 @@
+#pragma once
+
+
+
+#include <fullscore/models/measures/base.h>
+
+
+
+class MeasureGrid *measure_grid;
+
+
+
+namespace Measure
+{
+   class Reference : public Base
+   {
+   private:
+      MeasureGrid *measure_grid;
+      int measure_x;
+      int staff_y;
+
+   public:
+      Reference(MeasureGrid *measure_grid, int measure_x, int staff_y);
+
+      Measure::Base *get_referenced_measure();
+
+      virtual int get_num_notes() override;
+      virtual std::vector<Note> get_notes_copy() override;
+      virtual bool set_notes(std::vector<Note>) override;
+      virtual std::vector<Note> *get_notes_pointer() override;
+   };
+};
+
+
+

--- a/include/fullscore/models/measures/reference.h
+++ b/include/fullscore/models/measures/reference.h
@@ -6,7 +6,7 @@
 
 
 
-class MeasureGrid *measure_grid;
+class MeasureGrid;
 
 
 

--- a/include/fullscore/transforms/add_dot.h
+++ b/include/fullscore/transforms/add_dot.h
@@ -1,11 +1,8 @@
-#ifndef __FULLSCORE_ADD_DOT_TRANSFORM_HEADER
-#define __FULLSCORE_ADD_DOT_TRANSFORM_HEADER
-
+#pragma once
 
 
 
 #include <fullscore/transforms/base.h>
-
 
 
 
@@ -22,5 +19,3 @@ namespace Transform
 
 
 
-
-#endif

--- a/include/fullscore/transforms/base.h
+++ b/include/fullscore/transforms/base.h
@@ -1,12 +1,9 @@
-#ifndef __FULLSCORE_TRANSFORM_BASE_HEADER
-#define __FULLSCORE_TRANSFORM_BASE_HEADER
-
+#pragma once
 
 
 
 #include <vector>
 #include <fullscore/models/note.h>
-
 
 
 
@@ -28,4 +25,3 @@ namespace Transform
 
 
 
-#endif

--- a/include/fullscore/transforms/double_duration.h
+++ b/include/fullscore/transforms/double_duration.h
@@ -1,11 +1,8 @@
-#ifndef __FULLSCORE_DOUBLE_DURATION_TRANSFORM_HEADER
-#define __FULLSCORE_DOUBLE_DURATION_TRANSFORM_HEADER
-
+#pragma once
 
 
 
 #include <fullscore/transforms/base.h>
-
 
 
 
@@ -24,5 +21,3 @@ namespace Transform
 
 
 
-
-#endif

--- a/include/fullscore/transforms/erase_note.h
+++ b/include/fullscore/transforms/erase_note.h
@@ -1,11 +1,8 @@
-#ifndef __FULLSCORE_ERASE_NOTE_TRANSFORM_HEADER
-#define __FULLSCORE_ERASE_NOTE_TRANSFORM_HEADER
-
+#pragma once
 
 
 
 #include <fullscore/transforms/base.h>
-
 
 
 
@@ -23,7 +20,4 @@ namespace Transform
 }
 
 
-
-
-#endif
 

--- a/include/fullscore/transforms/half_duration.h
+++ b/include/fullscore/transforms/half_duration.h
@@ -1,11 +1,8 @@
-#ifndef __FULLSCORE_HALF_DURATION_TRANSFORM_HEADER
-#define __FULLSCORE_HALF_DURATION_TRANSFORM_HEADER
-
+#pragma once
 
 
 
 #include <fullscore/transforms/base.h>
-
 
 
 
@@ -24,5 +21,3 @@ namespace Transform
 
 
 
-
-#endif

--- a/src/actions/paste_measure_from_buffer_action.cpp
+++ b/src/actions/paste_measure_from_buffer_action.cpp
@@ -29,7 +29,9 @@ Action::PasteMeasureFromBuffer::~PasteMeasureFromBuffer()
 
 bool Action::PasteMeasureFromBuffer::execute()
 {
-   if (!yank_measure_buffer || !destination_measure) return false;
+   if (!yank_measure_buffer) throw std::runtime_error("Cannot yank to a nullptr yank_measure_buffer");
+   if (!destination_measure) throw std::runtime_error("Cannot yank from a nullptr destination_measure");
+
    destination_measure->set_notes(yank_measure_buffer->get_notes_copy());
    return true;
 }

--- a/src/actions/set_reference_measure_action.cpp
+++ b/src/actions/set_reference_measure_action.cpp
@@ -29,6 +29,9 @@ bool Action::SetReferenceMeasure::execute()
 {
    if (!measure_grid) throw std::runtime_error("Cannot set Measure::Reference on a nullptr measure_grid");
 
+   if (measure_grid == referenced_measure_grid && measure_x == referenced_measure_x && staff_y == referenced_staff_y)
+      throw std::runtime_error("a Measure::Reference cannot reference itself");
+
    Measure::Reference *new_reference_measure = new Measure::Reference(referenced_measure_grid, referenced_measure_x, referenced_staff_y);
 
    bool measure_set_successfully = measure_grid->set_measure(measure_x, staff_y, new_reference_measure);

--- a/src/actions/set_reference_measure_action.cpp
+++ b/src/actions/set_reference_measure_action.cpp
@@ -1,0 +1,45 @@
+
+
+
+#include <fullscore/actions/set_reference_measure_action.h>
+
+#include <fullscore/models/measures/reference.h>
+#include <fullscore/models/measure_grid.h>
+
+
+
+Action::SetReferenceMeasure::SetReferenceMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y)
+   : Base("set_reference_measure")
+   , measure_grid(measure_grid)
+   , measure_x(measure_x)
+   , staff_y(staff_y)
+{}
+
+
+
+Action::SetReferenceMeasure::~SetReferenceMeasure()
+{}
+
+
+
+bool Action::SetReferenceMeasure::execute()
+{
+   if (!measure_grid) throw std::runtime_error("Cannot set Measure::Reference on a nullptr measure_grid");
+
+   Measure::Reference *new_reference_measure = new Measure::Reference(nullptr, -1, -1);
+
+   bool measure_set_successfully = measure_grid->set_measure(measure_x, staff_y, new_reference_measure);
+
+   if (!measure_set_successfully)
+   {
+      delete new_reference_measure;
+      std::stringstream error_message;
+      error_message << "Could not set a Measure::Reference the measure in the measure grid at (" << measure_x << ", " << staff_y << ")";
+      throw std::runtime_error(error_message.str());
+   }
+
+   return true;
+}
+
+
+

--- a/src/actions/set_reference_measure_action.cpp
+++ b/src/actions/set_reference_measure_action.cpp
@@ -8,11 +8,14 @@
 
 
 
-Action::SetReferenceMeasure::SetReferenceMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y)
+Action::SetReferenceMeasure::SetReferenceMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y, MeasureGrid *referenced_measure_grid, int referenced_measure_x, int referenced_staff_y)
    : Base("set_reference_measure")
    , measure_grid(measure_grid)
    , measure_x(measure_x)
    , staff_y(staff_y)
+   , referenced_measure_grid(referenced_measure_grid)
+   , referenced_measure_x(referenced_measure_x)
+   , referenced_staff_y(referenced_staff_y)
 {}
 
 
@@ -26,7 +29,7 @@ bool Action::SetReferenceMeasure::execute()
 {
    if (!measure_grid) throw std::runtime_error("Cannot set Measure::Reference on a nullptr measure_grid");
 
-   Measure::Reference *new_reference_measure = new Measure::Reference(nullptr, -1, -1);
+   Measure::Reference *new_reference_measure = new Measure::Reference(referenced_measure_grid, referenced_measure_x, referenced_staff_y);
 
    bool measure_set_successfully = measure_grid->set_measure(measure_x, staff_y, new_reference_measure);
 

--- a/src/actions/transforms/retrograde_action.cpp
+++ b/src/actions/transforms/retrograde_action.cpp
@@ -26,7 +26,7 @@ Action::Transform::Retrograde::~Retrograde()
 
 bool Action::Transform::Retrograde::execute()
 {
-   if (!notes) return false;
+   if (!notes) throw std::runtime_error("Cannot retrograde on nullptr notes");
 
    ::Transform::Retrograde retrograde_transform;
    *notes = retrograde_transform.transform(*notes);

--- a/src/actions/transforms/toggle_rest_action.cpp
+++ b/src/actions/transforms/toggle_rest_action.cpp
@@ -26,7 +26,7 @@ Action::ToggleRest::~ToggleRest()
 
 bool Action::ToggleRest::execute()
 {
-   if (!note) return false;
+   if (!note) throw std::runtime_error("Cannot toggle_rest on a nullptr note");
 
    std::vector<Note> single_note_as_array;
    single_note_as_array.push_back(*note);

--- a/src/actions/yank_measure_to_buffer_action.cpp
+++ b/src/actions/yank_measure_to_buffer_action.cpp
@@ -29,7 +29,9 @@ Action::YankMeasureToBuffer::~YankMeasureToBuffer()
 
 bool Action::YankMeasureToBuffer::execute()
 {
-   if (!yank_measure_buffer || !source_measure) return false;
+   if (!yank_measure_buffer) throw std::runtime_error("Cannot yank to a nullptr yank_measure_buffer");
+   if (!source_measure) throw std::runtime_error("Cannot yank from a nullptr source_measure");
+
    yank_measure_buffer->set_notes(source_measure->get_notes_copy());
    return true;
 }

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -41,6 +41,16 @@ void MeasureGridRenderComponent::set_showing_debug_data(bool show)
 
 
 
+float __get_measure_width(Measure::Base *m)  // TODO: should probably use a helper
+{
+   if (!m) return 0;
+   float sum = 0;
+   for (auto &note : m->get_notes_copy())  // TODO: ineffecient use of get_notes_copy()
+      sum += DurationHelper::get_length(note.duration.denominator, note.duration.dots);
+   return sum;
+}
+
+
 
 void MeasureGridRenderComponent::render()
 {
@@ -81,20 +91,30 @@ void MeasureGridRenderComponent::render()
          if (!measure) continue;
 
          float x_pos = MeasureGridHelper::get_length_to_measure(*measure_grid, x) * full_measure_width;
-         music_engraver->draw(measure, x_pos, y_pos + staff_height/2, full_measure_width);
 
-         if (measure && measure->get_num_notes() == 0)
+         ALLEGRO_COLOR measure_block_color = color::color(color::black, 0.075);
+
+         int measure_width = 16;
+
+         if (measure)
          {
-            int measure_width = 16;
-
-            // measure box outline
-            ALLEGRO_COLOR measure_block_color = color::color(color::black, 0.075);
-            if (measure->is_type("reference")) measure_block_color = color::color(color::yellow, 0.2);
-
-            al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,
-               x_pos+measure_width, row_middle_y+staff_height/2,
-               4, 4, measure_block_color);
+            if (measure->get_num_notes() == 0)
+            {
+               measure_width = 16;
+               ALLEGRO_COLOR measure_block_color = color::color(color::black, 0.075);
+            }
+            else if (measure->is_type("reference"))
+            {
+               measure_width = __get_measure_width(measure) * full_measure_width;
+               measure_block_color = color::color(color::yellow, 0.2);
+            }
          }
+
+         al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,
+            x_pos+measure_width, row_middle_y+staff_height/2,
+            4, 4, measure_block_color);
+
+         music_engraver->draw(measure, x_pos, y_pos + staff_height/2, full_measure_width);
 
          // draw debug info on the note
          if (showing_debug_data)

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -88,9 +88,12 @@ void MeasureGridRenderComponent::render()
             int measure_width = 16;
 
             // measure box outline
+            ALLEGRO_COLOR measure_block_color = color::color(color::black, 0.075);
+            if (measure->is_type("reference")) measure_block_color = color::color(color::yellow, 0.2);
+
             al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,
                x_pos+measure_width, row_middle_y+staff_height/2,
-               4, 4, color::color(color::black, 0.075));
+               4, 4, measure_block_color);
          }
 
          // draw debug info on the note

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -333,7 +333,9 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
    else if (action_name == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(current_gui_score_editor);
    else if (action_name == "set_reference_measure")
-      action = new Action::SetReferenceMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
+      action = new Action::SetReferenceMeasure(
+            &current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y,
+            &current_gui_score_editor->measure_grid, 0, 0);
    else if (action_name == "set_basic_measure")
       action = new Action::SetBasicMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
    else if (action_name == "insert_measure")

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -220,6 +220,7 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       }
       else
       {
+         if (!notes) { std::cout << "cannot transpose_up on nullptr notes" << std::endl; return nullptr; }
          Action::Queue *action_queue = new Action::Queue(action_name);
          for (auto &note : *notes)
             for (unsigned i=0; i<(Framework::key_shift ? 7 : 1); i++)
@@ -238,6 +239,7 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       }
       else
       {
+         if (!notes) { std::cout << "cannot transpose_down on nullptr notes" << std::endl; return nullptr; }
          Action::Queue *action_queue = new Action::Queue(action_name);
          for (auto &note : *notes)
             for (unsigned i=0; i<(Framework::key_shift ? 7 : 1); i++)
@@ -250,6 +252,7 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       if (current_gui_score_editor->is_note_target_mode()) action = new Action::HalfDurationTransform(single_note);
       else
       {
+         if (!notes) { std::cout << "cannot half_duration on nullptr notes" << std::endl; return nullptr; }
          Action::Queue *action_queue = new Action::Queue(action_name);
          for (auto &note : *notes) action_queue->add_action(new Action::HalfDurationTransform(&note));
          return action_queue;
@@ -260,6 +263,7 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       if (current_gui_score_editor->is_note_target_mode()) action = new Action::DoubleDurationTransform(single_note);
       else
       {
+         if (!notes) { std::cout << "cannot double_duration on nullptr notes" << std::endl; return nullptr; }
          Action::Queue *action_queue = new Action::Queue(action_name);
          for (auto &note : *notes) action_queue->add_action(new Action::DoubleDurationTransform(&note));
          return action_queue;
@@ -270,6 +274,7 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       if (current_gui_score_editor->is_note_target_mode()) action = new Action::ToggleRest(single_note);
       else
       {
+         if (!notes) { std::cout << "cannot toggle_rest on nullptr notes" << std::endl; return nullptr; }
          Action::Queue *action_queue = new Action::Queue(action_name);
          for (auto &note : *notes) action_queue->add_action(new Action::ToggleRest(&note));
          return action_queue;

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -122,7 +122,7 @@ std::string FullscoreApplicationController::find_action_identifier(GUIScoreEdito
       case ALLEGRO_KEY_D: return "transpose_down"; break;
       case ALLEGRO_KEY_S: return "half_duration"; break;
       case ALLEGRO_KEY_G: return "double_duration"; break;
-      case ALLEGRO_KEY_R: shift ? return "set_reference_measure" : return "toggle_rest"; break;
+      case ALLEGRO_KEY_R: if (shift) { return "set_reference_measure"; } else { return "toggle_rest"; } break;
       case ALLEGRO_KEY_N: return "invert"; break;
       case ALLEGRO_KEY_FULLSTOP: return "add_dot"; break;
       case ALLEGRO_KEY_COMMA: return "remove_dot"; break;

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -38,15 +38,16 @@
 #include <fullscore/actions/save_measure_grid_action.h>
 #include <fullscore/actions/set_basic_measure_action.h>
 #include <fullscore/actions/set_camera_target_action.h>
+#include <fullscore/actions/set_command_mode_action.h>
 #include <fullscore/actions/set_current_gui_score_editor_action.h>
+#include <fullscore/actions/set_mode_action.h>
+#include <fullscore/actions/set_normal_mode_action.h>
+#include <fullscore/actions/set_reference_measure_action.h>
 #include <fullscore/actions/set_score_zoom_action.h>
 #include <fullscore/actions/start_motion_action.h>
 #include <fullscore/actions/toggle_edit_mode_target_action.h>
 #include <fullscore/actions/toggle_playback_action.h>
 #include <fullscore/actions/toggle_show_debug_data_action.h>
-#include <fullscore/actions/set_command_mode_action.h>
-#include <fullscore/actions/set_normal_mode_action.h>
-#include <fullscore/actions/set_mode_action.h>
 #include <fullscore/actions/yank_measure_to_buffer_action.h>
 
 #include <fullscore/factories/measure_grid_factory.h>

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -122,7 +122,7 @@ std::string FullscoreApplicationController::find_action_identifier(GUIScoreEdito
       case ALLEGRO_KEY_D: return "transpose_down"; break;
       case ALLEGRO_KEY_S: return "half_duration"; break;
       case ALLEGRO_KEY_G: return "double_duration"; break;
-      case ALLEGRO_KEY_R: return "toggle_rest"; break;
+      case ALLEGRO_KEY_R: shift ? return "set_reference_measure" : return "toggle_rest"; break;
       case ALLEGRO_KEY_N: return "invert"; break;
       case ALLEGRO_KEY_FULLSTOP: return "add_dot"; break;
       case ALLEGRO_KEY_COMMA: return "remove_dot"; break;
@@ -141,7 +141,7 @@ std::string FullscoreApplicationController::find_action_identifier(GUIScoreEdito
       case ALLEGRO_KEY_J: return "move_cursor_down"; break;
       case ALLEGRO_KEY_K: return "move_cursor_up"; break;
       case ALLEGRO_KEY_L: return "move_cursor_right"; break;
-      case ALLEGRO_KEY_M: return "set_basic_measure"; break;
+      case ALLEGRO_KEY_M: if(shift) return "set_basic_measure"; break;
       case ALLEGRO_KEY_Y: return "yank_measure_to_buffer"; break;
       case ALLEGRO_KEY_P: return "paste_measure_from_buffer"; break;
       case ALLEGRO_KEY_O: return "octatonic_1_transform"; break;
@@ -332,6 +332,8 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
    else if (action_name == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(current_gui_score_editor);
+   else if (action_name == "set_reference_measure")
+      action = new Action::SetReferenceMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
    else if (action_name == "set_basic_measure")
       action = new Action::SetBasicMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
    else if (action_name == "insert_measure")

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -51,6 +51,7 @@
 
 #include <fullscore/factories/measure_grid_factory.h>
 
+#include <fullscore/models/measures/static.h>
 
 
 
@@ -83,6 +84,8 @@ FullscoreApplicationController::FullscoreApplicationController(Display *display)
    dm->genesis->add_transform(&reference_transform);
    dm->genesis->add_transform(&double_duration_transform);
    dm->refresh();
+
+   current_gui_score_editor->measure_grid.set_measure(0, 3, new Measure::Static());
 
    follow_camera.target.position.y = 200;
    follow_camera.target.position.x = 200;

--- a/src/models/measures/reference.cpp
+++ b/src/models/measures/reference.cpp
@@ -1,0 +1,57 @@
+
+
+
+#include <fullscore/models/measures/reference.h>
+#include <fullscore/models/measure_grid.h>
+
+
+
+Measure::Reference::Reference(MeasureGrid *measure_grid, int measure_x, int staff_y)
+   : Base("reference")
+   , measure_grid(measure_grid)
+   , measure_x(measure_x)
+   , staff_y(staff_y)
+{}
+
+
+
+std::vector<Note> Measure::Reference::get_notes_copy()
+{
+   // TODO: this could be a dead pointer if it is deleted externally
+   Measure::Base *referenced_measure = measure_grid->get_measure(measure_x, staff_y);
+   if (referenced_measure) referenced_measure->get_notes_copy();
+   return {};
+}
+
+
+
+Measure::Base *Measure::Reference::get_referenced_measure()
+{
+   return measure_grid->get_measure(measure_x, staff_y);
+}
+
+
+
+int Measure::Reference::get_num_notes()
+{
+   Measure::Base *measure = get_referenced_measure();
+   if (!measure) return 0;
+   return measure->get_num_notes();
+}
+
+
+
+bool Measure::Reference::set_notes(std::vector<Note> notes)
+{
+   return false;
+}
+
+
+
+std::vector<Note> *Measure::Reference::get_notes_pointer()
+{
+   return nullptr;
+}
+
+
+

--- a/src/models/measures/reference.cpp
+++ b/src/models/measures/reference.cpp
@@ -19,7 +19,7 @@ std::vector<Note> Measure::Reference::get_notes_copy()
 {
    // TODO: this could be a dead pointer if it is deleted externally
    Measure::Base *referenced_measure = measure_grid->get_measure(measure_x, staff_y);
-   if (referenced_measure) referenced_measure->get_notes_copy();
+   if (referenced_measure) return referenced_measure->get_notes_copy();
    return {};
 }
 


### PR DESCRIPTION
## Problem

Cannot create reference measures in the score

## Solution

- Add an action `Action::SetReferenceMeasure`.
- Color reference measures in yellow
- Reference measure update in realtime 🎉 

![fullscore 2017-07-16 04-17-28](https://user-images.githubusercontent.com/772949/28245860-d08bcd0a-69dd-11e7-8287-20681d2d35de.png)

## Still To Do

⚠️ A reference measure's referenced measure coordinates cannot be set, it's currently hard coded to reference the measure at `(0, 0)`.