### PR TITLE
Add Stack Measures

### DIFF
--- a/include/fullscore/actions/set_stack_measure_action.h
+++ b/include/fullscore/actions/set_stack_measure_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+#include <fullscore/actions/action_base.h>
+
+
+
+class MeasureGrid;
+
+
+
+namespace Action
+{
+   class SetStackMeasure : public Base
+   {
+   private:
+      MeasureGrid *measure_grid;
+      int measure_x;
+      int staff_y;
+
+   public:
+      SetStackMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y);
+      ~SetStackMeasure();
+
+      bool execute() override;
+   };
+};
+
+
+

--- a/include/fullscore/models/measures/stack.h
+++ b/include/fullscore/models/measures/stack.h
@@ -1,0 +1,34 @@
+#pragma once
+
+
+
+#include <vector>
+
+#include <fullscore/transforms/stack.h>
+#include <fullscore/models/measures/base.h>
+
+
+
+class Note;
+
+
+
+namespace Measure
+{
+   class Stack : public Measure::Base
+   {
+   public:
+      Transform::Stack transformations;
+      bool refresh();
+
+      Stack();
+
+      virtual int get_num_notes() override;
+      virtual bool set_notes(std::vector<Note> notes) override;
+      virtual std::vector<Note> get_notes_copy() override;
+      virtual std::vector<Note> *get_notes_pointer() override;
+   };
+};
+
+
+

--- a/src/actions/set_stack_measure_action.cpp
+++ b/src/actions/set_stack_measure_action.cpp
@@ -6,6 +6,12 @@
 #include <fullscore/models/measures/stack.h>
 #include <fullscore/models/measure_grid.h>
 
+// this next few lines are for testing
+#include <fullscore/transforms/copy.h>
+#include <fullscore/transforms/double_duration.h>
+#include <fullscore/transforms/retrograde.h>
+#include <fullscore/transforms/transpose.h>
+
 
 
 Action::SetStackMeasure::SetStackMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y)
@@ -29,6 +35,13 @@ bool Action::SetStackMeasure::execute()
    Measure::Stack *new_stack_measure = new Measure::Stack();
 
    bool measure_set_successfully = measure_grid->set_measure(measure_x, staff_y, new_stack_measure);
+
+   // these next transform lines are simply for testing
+   Measure::Stack *measure =  static_cast<Measure::Stack *>(measure_grid->get_measure(measure_x, staff_y));
+   measure->transformations.add_transform(new Transform::Copy(measure_grid, 0, 0));
+   measure->transformations.add_transform(new Transform::DoubleDuration());
+   measure->transformations.add_transform(new Transform::Retrograde());
+   measure->transformations.add_transform(new Transform::Transpose(-5));
 
    if (!measure_set_successfully)
    {

--- a/src/actions/set_stack_measure_action.cpp
+++ b/src/actions/set_stack_measure_action.cpp
@@ -1,0 +1,45 @@
+
+
+
+#include <fullscore/actions/set_stack_measure_action.h>
+
+#include <fullscore/models/measures/stack.h>
+#include <fullscore/models/measure_grid.h>
+
+
+
+Action::SetStackMeasure::SetStackMeasure(MeasureGrid *measure_grid, int measure_x, int staff_y)
+   : Base("set_stack_measure")
+   , measure_grid(measure_grid)
+   , measure_x(measure_x)
+   , staff_y(staff_y)
+{}
+
+
+
+Action::SetStackMeasure::~SetStackMeasure()
+{}
+
+
+
+bool Action::SetStackMeasure::execute()
+{
+   if (!measure_grid) throw std::runtime_error("Cannot set Measure::Stack on a nullptr measure_grid");
+
+   Measure::Stack *new_stack_measure = new Measure::Stack();
+
+   bool measure_set_successfully = measure_grid->set_measure(measure_x, staff_y, new_stack_measure);
+
+   if (!measure_set_successfully)
+   {
+      delete new_stack_measure;
+      std::stringstream error_message;
+      error_message << "Could not set a Measure::Stack the measure in the measure grid at (" << measure_x << ", " << staff_y << ")";
+      throw std::runtime_error(error_message.str());
+   }
+
+   return true;
+}
+
+
+

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -108,6 +108,11 @@ void MeasureGridRenderComponent::render()
                measure_width = __get_measure_width(measure) * full_measure_width;
                measure_block_color = color::color(color::yellow, 0.2);
             }
+            else if (measure->is_type("stack"))
+            {
+               measure_width = __get_measure_width(measure) * full_measure_width;
+               measure_block_color = color::color(color::red, 0.2);
+            }
          }
 
          al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -44,6 +44,7 @@
 #include <fullscore/actions/set_normal_mode_action.h>
 #include <fullscore/actions/set_reference_measure_action.h>
 #include <fullscore/actions/set_score_zoom_action.h>
+#include <fullscore/actions/set_stack_measure_action.h>
 #include <fullscore/actions/start_motion_action.h>
 #include <fullscore/actions/toggle_edit_mode_target_action.h>
 #include <fullscore/actions/toggle_playback_action.h>
@@ -120,7 +121,7 @@ std::string FullscoreApplicationController::find_action_identifier(GUIScoreEdito
       {
       case ALLEGRO_KEY_F: return "transpose_up"; break;
       case ALLEGRO_KEY_D: return "transpose_down"; break;
-      case ALLEGRO_KEY_S: return "half_duration"; break;
+      case ALLEGRO_KEY_S: if (shift) { return "set_stack_measure"; } else { return "half_duration"; } break;
       case ALLEGRO_KEY_G: return "double_duration"; break;
       case ALLEGRO_KEY_R: if (shift) { return "set_reference_measure"; } else { return "toggle_rest"; } break;
       case ALLEGRO_KEY_N: return "invert"; break;
@@ -338,6 +339,8 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
             &current_gui_score_editor->measure_grid, 0, 0);
    else if (action_name == "set_basic_measure")
       action = new Action::SetBasicMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
+   else if (action_name == "set_stack_measure")
+      action = new Action::SetStackMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
    else if (action_name == "insert_measure")
       action = new Action::InsertMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x);
    else if (action_name == "delete_measure")

--- a/src/models/measures/stack.cpp
+++ b/src/models/measures/stack.cpp
@@ -1,0 +1,53 @@
+
+
+
+#include <fullscore/models/measures/stack.h>
+
+#include <fullscore/models/note.h>
+#include <allegro_flare/useful.h>
+
+
+
+Measure::Stack::Stack()
+   : Base("stack")
+   , transformations()
+{}
+
+
+
+bool Measure::Stack::set_notes(std::vector<Note> notes)
+{
+   return false;
+}
+
+
+
+int Measure::Stack::get_num_notes()
+{
+   return get_notes_copy().size();
+}
+
+
+
+std::vector<Note> Measure::Stack::get_notes_copy()
+{
+   try
+   {
+      return transformations.transform({});
+   }
+   catch (...)
+   {
+      std::cout << "Measure::Stack transformations failed" << std::endl;
+      return {};
+   }
+}
+
+
+
+std::vector<Note> *Measure::Stack::get_notes_pointer()
+{
+   return nullptr;
+}
+
+
+

--- a/tests/models/measure/stack_test.cpp
+++ b/tests/models/measure/stack_test.cpp
@@ -1,0 +1,83 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/measures/stack.h>
+
+#include <fullscore/transforms/double_duration.h>
+#include <fullscore/transforms/erase_note.h>
+#include <fullscore/transforms/retrograde.h>
+#include <fullscore/transforms/octatonic_1.h>
+
+
+
+TEST(MeasureStackTest, can_be_created)
+{
+   Measure::Stack measure;
+}
+
+
+
+TEST(MeasureStackTest, returns_a_nullptr_when_asked_for_a_ponter_to_its_notes)
+{
+   Measure::Stack measure;
+
+   measure.transformations.add_transform(new Transform::Octatonic1());
+   measure.transformations.add_transform(new Transform::EraseNote(0));
+   measure.transformations.add_transform(new Transform::EraseNote(2));
+
+   ASSERT_EQ(nullptr, measure.get_notes_pointer());
+}
+
+
+
+TEST(MeasureStackTest, with_transformations_returns_the_number_of_notes)
+{
+   Measure::Stack measure;
+
+   measure.transformations.add_transform(new Transform::Octatonic1());
+   measure.transformations.add_transform(new Transform::EraseNote(0));
+   measure.transformations.add_transform(new Transform::EraseNote(2));
+
+   int num_returned_notes = measure.get_num_notes();
+
+   ASSERT_EQ(6, num_returned_notes);
+}
+
+
+
+TEST(MeasureStackTest, with_a_transformation_populates_its_notes)
+{
+   Measure::Stack measure;
+
+   measure.transformations.add_transform(new Transform::Octatonic1());
+   measure.transformations.add_transform(new Transform::EraseNote(0));
+   measure.transformations.add_transform(new Transform::EraseNote(2));
+   measure.transformations.add_transform(new Transform::DoubleDuration());
+   measure.transformations.add_transform(new Transform::Retrograde());
+
+   std::vector<Note> expected_notes = {
+      Note(11, Duration::HALF),
+      Note(9, Duration::HALF),
+      Note(8, Duration::HALF),
+      Note(6, Duration::HALF),
+      Note(3, Duration::HALF),
+      Note(2, Duration::HALF),
+   };
+   std::vector<Note> measure_notes = measure.get_notes_copy();
+
+   ASSERT_EQ(expected_notes, measure_notes);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+
+


### PR DESCRIPTION
## Problem

`Reference` measures exist and are updated real-time.  However, there are no measures with transforms that update real-time.

## Solution

Add a `Measure::Stack`, tests, an `*Action` to create it (with<kbd>shift</kbd>+<kbd>S</kbd>).  Also, `Stack` measures are color tinted as red when drawn on the score:

![stack measure - fullscore 2017-07-16 23-14-24](https://user-images.githubusercontent.com/772949/28268869-f6e84b0e-6acd-11e7-9789-88ebdca2920b.png)

## Still Left To Do

- for `Reference` measures, allow setting the target measure, which is hard-coded to `(0, 0)`.
- for `Stack` measures, allow adding/removing items from the stack.
- for `Basic` measures, remove the `genesis`, which is no longer needed and in those instances, should be replaced with a `Stack` measure.

