### PR TITLE
Color static measure and reference cursor

### DIFF
--- a/include/fullscore/actions/set_reference_cursor_action.h
+++ b/include/fullscore/actions/set_reference_cursor_action.h
@@ -1,0 +1,33 @@
+#pragma once
+
+
+
+#include <fullscore/actions/action_base.h>
+
+
+
+class MeasureGrid;
+class ReferenceCursor;
+
+
+
+namespace Action
+{
+   class SetReferenceCursor : public Base
+   {
+   private:
+      ReferenceCursor *reference_cursor;
+      MeasureGrid *measure_grid;
+      int measure_x;
+      int staff_y;
+
+   public:
+      SetReferenceCursor(ReferenceCursor *reference_cursor, MeasureGrid *measure_grid, int measure_x, int staff_y);
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/fullscore_application_controller.h
+++ b/include/fullscore/fullscore_application_controller.h
@@ -13,6 +13,7 @@
 #include <fullscore/follow_camera.h>
 #include <fullscore/gui_score_editor.h>
 #include <fullscore/playback_device_generic.h>
+#include <fullscore/reference_cursor.h>
 
 
 
@@ -30,6 +31,7 @@ public:
    UIMeasureInspector *ui_measure_inspector;
    Measure::Basic yank_measure_buffer;
    bool showing_help_menu;
+   ReferenceCursor reference_cursor;
 
    FullscoreApplicationController(Display *display);
    void primary_timer_func() override;

--- a/include/fullscore/models/index_set.h
+++ b/include/fullscore/models/index_set.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-#include <Fullscore/models/pitch.h>
+#include <fullscore/models/pitch.h>
 
 
 

--- a/include/fullscore/models/projection_set.h
+++ b/include/fullscore/models/projection_set.h
@@ -4,7 +4,7 @@
 
 #include <vector>
 
-#include <Fullscore/models/pitch.h>
+#include <fullscore/models/pitch.h>
 
 
 

--- a/include/fullscore/reference_cursor.h
+++ b/include/fullscore/reference_cursor.h
@@ -21,7 +21,7 @@ public:
    int get_x();
    int get_y();
    MeasureGrid *get_measure_grid();
-   void set(int x, int y);
+   void set_coordinates(int x, int y);
    bool is_on_measure_grid(const MeasureGrid *measure_grid);
    void move(int delta_x, int delta_y);
 };

--- a/include/fullscore/reference_cursor.h
+++ b/include/fullscore/reference_cursor.h
@@ -24,6 +24,7 @@ public:
    void set_coordinates(int x, int y);
    bool is_on_measure_grid(const MeasureGrid *measure_grid);
    void move(int delta_x, int delta_y);
+   bool is_valid();
 };
 
 

--- a/include/fullscore/reference_cursor.h
+++ b/include/fullscore/reference_cursor.h
@@ -1,0 +1,30 @@
+#pragma once
+
+
+
+class MeasureGrid;
+
+
+
+class ReferenceCursor
+{
+private:
+   MeasureGrid *measure_grid;
+   int x;
+   int y;
+
+public:
+   ReferenceCursor();
+   ReferenceCursor(MeasureGrid *measure_grid, int x, int y);
+
+   void set_position(MeasureGrid *measure_grid, int x, int y);
+   int get_x();
+   int get_y();
+   MeasureGrid *get_measure_grid();
+   void set(int x, int y);
+   bool is_on_measure_grid(const MeasureGrid *measure_grid);
+   void move(int delta_x, int delta_y);
+};
+
+
+

--- a/src/actions/set_reference_cursor_action.cpp
+++ b/src/actions/set_reference_cursor_action.cpp
@@ -20,6 +20,10 @@ Action::SetReferenceCursor::SetReferenceCursor(ReferenceCursor *reference_cursor
 
 bool Action::SetReferenceCursor::execute()
 {
+   if (!reference_cursor) throw std::invalid_argument("Cannot set reference cursor on a nullptr reference_cursor");
+
+   reference_cursor->set_position(measure_grid, measure_x, staff_y);
+
    return true;
 }
 

--- a/src/actions/set_reference_cursor_action.cpp
+++ b/src/actions/set_reference_cursor_action.cpp
@@ -24,6 +24,8 @@ bool Action::SetReferenceCursor::execute()
 
    reference_cursor->set_position(measure_grid, measure_x, staff_y);
 
+   if (!reference_cursor->is_valid()) throw std::runtime_error("Recently set reference cursor is now invalid");
+
    return true;
 }
 

--- a/src/actions/set_reference_cursor_action.cpp
+++ b/src/actions/set_reference_cursor_action.cpp
@@ -1,0 +1,27 @@
+
+
+
+#include <fullscore/actions/set_reference_cursor_action.h>
+
+#include <fullscore/models/measure_grid.h>
+#include <fullscore/reference_cursor.h>
+
+
+
+Action::SetReferenceCursor::SetReferenceCursor(ReferenceCursor *reference_cursor, MeasureGrid *measure_grid, int measure_x, int staff_y)
+   : Base("set_reference_cursor")
+   , reference_cursor(reference_cursor)
+   , measure_grid(measure_grid)
+   , measure_x(measure_x)
+   , staff_y(staff_y)
+{}
+
+
+
+bool Action::SetReferenceCursor::execute()
+{
+   return true;
+}
+
+
+

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -113,6 +113,11 @@ void MeasureGridRenderComponent::render()
                measure_width = __get_measure_width(measure) * full_measure_width;
                measure_block_color = color::color(color::red, 0.2);
             }
+            else if (measure->is_type("static"))
+            {
+               measure_width = __get_measure_width(measure) * full_measure_width;
+               measure_block_color = color::color(color::dodgerblue, 0.1);
+            }
          }
 
          al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -67,6 +67,7 @@ FullscoreApplicationController::FullscoreApplicationController(Display *display)
    , command_bar(new UICommandBar(this))
    , ui_measure_inspector(new UIMeasureInspector(this))
    , yank_measure_buffer()
+   , reference_cursor(nullptr, 0, 0)
 {
    UIScreen::draw_focused_outline = false;
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -343,7 +343,7 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
    else if (action_name == "set_reference_measure")
       action = new Action::SetReferenceMeasure(
             &current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y,
-            &current_gui_score_editor->measure_grid, 0, 0);
+            reference_cursor.get_measure_grid(), reference_cursor.get_x(), reference_cursor.get_y());
    else if (action_name == "set_reference_cursor")
       action = new Action::SetReferenceCursor(&reference_cursor,
             &current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -42,6 +42,7 @@
 #include <fullscore/actions/set_current_gui_score_editor_action.h>
 #include <fullscore/actions/set_mode_action.h>
 #include <fullscore/actions/set_normal_mode_action.h>
+#include <fullscore/actions/set_reference_cursor_action.h>
 #include <fullscore/actions/set_reference_measure_action.h>
 #include <fullscore/actions/set_score_zoom_action.h>
 #include <fullscore/actions/set_stack_measure_action.h>
@@ -129,6 +130,7 @@ std::string FullscoreApplicationController::find_action_identifier(GUIScoreEdito
       case ALLEGRO_KEY_S: if (shift) { return "set_stack_measure"; } else { return "half_duration"; } break;
       case ALLEGRO_KEY_G: return "double_duration"; break;
       case ALLEGRO_KEY_R: if (shift) { return "set_reference_measure"; } else { return "toggle_rest"; } break;
+      case ALLEGRO_KEY_C: if (shift) return "set_reference_cursor"; break;
       case ALLEGRO_KEY_N: return "invert"; break;
       case ALLEGRO_KEY_FULLSTOP: return "add_dot"; break;
       case ALLEGRO_KEY_COMMA: return "remove_dot"; break;
@@ -342,6 +344,9 @@ Action::Base *FullscoreApplicationController::create_action(std::string action_n
       action = new Action::SetReferenceMeasure(
             &current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y,
             &current_gui_score_editor->measure_grid, 0, 0);
+   else if (action_name == "set_reference_cursor")
+      action = new Action::SetReferenceCursor(&reference_cursor,
+            &current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
    else if (action_name == "set_basic_measure")
       action = new Action::SetBasicMeasure(&current_gui_score_editor->measure_grid, current_gui_score_editor->measure_cursor_x, current_gui_score_editor->measure_cursor_y);
    else if (action_name == "set_stack_measure")

--- a/src/reference_cursor.cpp
+++ b/src/reference_cursor.cpp
@@ -76,3 +76,16 @@ void ReferenceCursor::move(int delta_x, int delta_y)
 
 
 
+bool ReferenceCursor::is_valid()
+{
+   if (!measure_grid) return false;
+   if (x >= measure_grid->get_num_measures()) return false;
+   if (x < 0) return false;
+   if (y >= measure_grid->get_num_staves()) return false;
+   if (y < 0) return false;
+
+   return true;
+}
+
+
+

--- a/src/reference_cursor.cpp
+++ b/src/reference_cursor.cpp
@@ -32,7 +32,7 @@ void ReferenceCursor::set_position(MeasureGrid *measure_grid, int x, int y)
 
 
 
-void ReferenceCursor::set(int x, int y)
+void ReferenceCursor::set_coordinates(int x, int y)
 {
    this->x = x;
    this->y = y;

--- a/src/reference_cursor.cpp
+++ b/src/reference_cursor.cpp
@@ -1,0 +1,78 @@
+
+
+
+#include <fullscore/reference_cursor.h>
+
+#include <fullscore/models/measure_grid.h>
+
+
+
+ReferenceCursor::ReferenceCursor()
+   : measure_grid(nullptr)
+   , x(0)
+   , y(0)
+{}
+
+
+
+ReferenceCursor::ReferenceCursor(MeasureGrid *measure_grid, int x, int y)
+   : measure_grid(measure_grid)
+   , x(x)
+   , y(y)
+{}
+
+
+
+void ReferenceCursor::set_position(MeasureGrid *measure_grid, int x, int y)
+{
+   this->measure_grid = measure_grid;
+   this->x = x;
+   this->y = y;
+}
+
+
+
+void ReferenceCursor::set(int x, int y)
+{
+   this->x = x;
+   this->y = y;
+}
+
+
+
+MeasureGrid *ReferenceCursor::get_measure_grid()
+{
+   return measure_grid;
+}
+
+
+
+int ReferenceCursor::get_x()
+{
+   return x;
+}
+
+
+
+int ReferenceCursor::get_y()
+{
+   return y;
+}
+
+
+
+bool ReferenceCursor::is_on_measure_grid(const MeasureGrid *measure_grid)
+{
+   return this->measure_grid == measure_grid;
+}
+
+
+
+void ReferenceCursor::move(int delta_x, int delta_y)
+{
+   x += delta_x;
+   y += delta_y;
+}
+
+
+

--- a/tests/reference_cursor_test.cpp
+++ b/tests/reference_cursor_test.cpp
@@ -89,6 +89,45 @@ TEST(ReferenceCursorTest, can_move_its_x_y_coordinates)
 
 
 
+TEST(ReferenceCursorTest, with_no_measure_grid__is_invalid)
+{
+   ReferenceCursor reference_cursor;
+
+   EXPECT_FALSE(reference_cursor.is_valid());
+}
+
+
+
+TEST(ReferenceCursorTest, with_a_reference_grid_and_coordinates_within_the_grid__is_valid)
+{
+   MeasureGrid measure_grid(3, 4);
+   ReferenceCursor reference_cursor(&measure_grid, 2, 1);
+
+   EXPECT_TRUE(reference_cursor.is_valid());
+}
+
+
+
+TEST(ReferenceCursorTest, with_a_reference_grid_and_coordinates_outside_the_grid__is_invalid)
+{
+   MeasureGrid measure_grid(3, 4);
+   ReferenceCursor reference_cursor(&measure_grid, 2, 1);
+
+   reference_cursor.set_coordinates(999, 999);
+
+   EXPECT_FALSE(reference_cursor.is_valid());
+
+   reference_cursor.set_coordinates(-1, 1);
+
+   EXPECT_FALSE(reference_cursor.is_valid());
+
+   reference_cursor.set_coordinates(1, -1);
+
+   EXPECT_FALSE(reference_cursor.is_valid());
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/reference_cursor_test.cpp
+++ b/tests/reference_cursor_test.cpp
@@ -59,12 +59,12 @@ TEST(ReferenceCursorTest, can_set_its_x_y_coordinates)
 {
    ReferenceCursor reference_cursor;
 
-   reference_cursor.set(20, 30);
+   reference_cursor.set_coordinates(20, 30);
 
    EXPECT_EQ(20, reference_cursor.get_x());
    EXPECT_EQ(30, reference_cursor.get_y());
 
-   reference_cursor.set(17, 26);
+   reference_cursor.set_coordinates(17, 26);
 
    EXPECT_EQ(17, reference_cursor.get_x());
    EXPECT_EQ(26, reference_cursor.get_y());

--- a/tests/reference_cursor_test.cpp
+++ b/tests/reference_cursor_test.cpp
@@ -1,0 +1,100 @@
+
+
+
+#include <gtest/gtest.h>
+
+
+
+#include <fullscore/reference_cursor.h>
+
+#include <fullscore/models/measure_grid.h>
+
+
+
+TEST(ReferenceCursorTest, can_be_constructed_with_an_empty_constructor)
+{
+   ReferenceCursor reference_cursor;
+
+   EXPECT_EQ(nullptr, reference_cursor.get_measure_grid());
+   EXPECT_EQ(0, reference_cursor.get_x());
+   EXPECT_EQ(0, reference_cursor.get_y());
+}
+
+
+
+TEST(ReferenceCursorTest, can_be_constructed_with_arguments)
+{
+   MeasureGrid measure_grid(1, 1);
+   ReferenceCursor reference_cursor(&measure_grid, 9, 16);
+
+   EXPECT_EQ(&measure_grid, reference_cursor.get_measure_grid());
+   EXPECT_EQ(9, reference_cursor.get_x());
+   EXPECT_EQ(16, reference_cursor.get_y());
+}
+
+
+
+TEST(ReferenceCursorTest, can_set_its_position)
+{
+   MeasureGrid measure_grid_1(1, 1);
+   MeasureGrid measure_grid_2(1, 1);
+   ReferenceCursor reference_cursor;
+
+   reference_cursor.set_position(&measure_grid_1, 9, 16);
+
+   EXPECT_EQ(&measure_grid_1, reference_cursor.get_measure_grid());
+   EXPECT_EQ(9, reference_cursor.get_x());
+   EXPECT_EQ(16, reference_cursor.get_y());
+
+   reference_cursor.set_position(&measure_grid_2, 19, 7);
+
+   EXPECT_EQ(&measure_grid_2, reference_cursor.get_measure_grid());
+   EXPECT_EQ(19, reference_cursor.get_x());
+   EXPECT_EQ(7, reference_cursor.get_y());
+}
+
+
+
+TEST(ReferenceCursorTest, can_set_its_x_y_coordinates)
+{
+   ReferenceCursor reference_cursor;
+
+   reference_cursor.set(20, 30);
+
+   EXPECT_EQ(20, reference_cursor.get_x());
+   EXPECT_EQ(30, reference_cursor.get_y());
+
+   reference_cursor.set(17, 26);
+
+   EXPECT_EQ(17, reference_cursor.get_x());
+   EXPECT_EQ(26, reference_cursor.get_y());
+}
+
+
+
+TEST(ReferenceCursorTest, can_move_its_x_y_coordinates)
+{
+   ReferenceCursor reference_cursor;
+
+   reference_cursor.move(20, 30);
+
+   EXPECT_EQ(20, reference_cursor.get_x());
+   EXPECT_EQ(30, reference_cursor.get_y());
+
+   reference_cursor.move(17, 26);
+
+   EXPECT_EQ(37, reference_cursor.get_x());
+   EXPECT_EQ(56, reference_cursor.get_y());
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+
+


### PR DESCRIPTION
## 2 Problems

- It's not easy to know if a measure is a static measure
- It's not possible to set the reference target of a reference measure in the GUI

## Solution

- Render a static measure in blue

![fullscore 2017-07-23 03-14-17](https://user-images.githubusercontent.com/772949/28497435-0ccb994a-6f55-11e7-9547-c65ec91f3d39.png)

- Add a `ReferenceCursor reference_cursor` that is used in the `ApplicationController`.  The `reference_cursor`'s position can be set by moving your cursor to the measure you want to reference and pressing <kbd>Shift</kbd>+<kbd>C</kbd>.  Any `Measure::Reference` that is created will reference the measure where the `reference_cursor` is placed.

## To Do

There is no way of knowing where the `reference_cursor` is currently at.  Need to add some visual clue or rendering to where the cursor is on the screen.