### PR TITLE
Render ReferenceCursor

### DIFF
--- a/include/fullscore/components/measure_grid_render_component.h
+++ b/include/fullscore/components/measure_grid_render_component.h
@@ -5,18 +5,20 @@
 
 class MeasureGrid;
 class MusicEngraver;
+class ReferenceCursor;
 
 class MeasureGridRenderComponent
 {
 private:
    MeasureGrid *measure_grid;
    MusicEngraver *music_engraver;
+   ReferenceCursor *reference_cursor;
    float full_measure_width;
    float staff_height;
    bool showing_debug_data;
 
 public:
-   MeasureGridRenderComponent(MeasureGrid *measure_grid, MusicEngraver *engraver, float full_measure_width, float staff_height);
+   MeasureGridRenderComponent(MeasureGrid *measure_grid, MusicEngraver *engraver, ReferenceCursor *reference_cursor, float full_measure_width, float staff_height);
    ~MeasureGridRenderComponent();
 
    void set_showing_debug_data(bool show);

--- a/include/fullscore/gui_score_editor.h
+++ b/include/fullscore/gui_score_editor.h
@@ -20,6 +20,15 @@ class ReferenceCursor;
 class GUIScoreEditor : public UIWidget
 {
 public:
+   class RenderingDependencies
+   {
+   public:
+      RenderingDependencies();
+
+      ReferenceCursor *reference_cursor;
+      void set_reference_cursor(ReferenceCursor *reference_cursor);
+   };
+
    enum edit_mode_target_t
    {
       NOTE_TARGET=0,
@@ -43,7 +52,8 @@ public:
 
    MeasureGrid measure_grid;
    PlaybackControl playback_control;
-   ReferenceCursor *reference_cursor;
+
+   RenderingDependencies rendering_dependencies;
 
    int measure_cursor_x; // should be renamed to grid_cursor_x, grid_cursor_y
    int measure_cursor_y;

--- a/include/fullscore/gui_score_editor.h
+++ b/include/fullscore/gui_score_editor.h
@@ -13,6 +13,9 @@
 
 
 
+class ReferenceCursor;
+
+
 
 class GUIScoreEditor : public UIWidget
 {
@@ -40,6 +43,7 @@ public:
 
    MeasureGrid measure_grid;
    PlaybackControl playback_control;
+   ReferenceCursor *reference_cursor;
 
    int measure_cursor_x; // should be renamed to grid_cursor_x, grid_cursor_y
    int measure_cursor_y;
@@ -64,6 +68,7 @@ public:
    int move_measure_cursor_x(int delta);
    int move_measure_cursor_y(int delta);
    int move_note_cursor_x(int delta);
+   void set_reference_cursor(ReferenceCursor *reference_cursor);
 
    float get_measure_cursor_real_x();
    float get_measure_cursor_real_y();

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -13,13 +13,15 @@
 #include <fullscore/models/note.h>
 #include <fullscore/models/measure_grid.h>
 #include <fullscore/music_engraver.h>
+#include <fullscore/reference_cursor.h>
 
 
 
 
-MeasureGridRenderComponent::MeasureGridRenderComponent(MeasureGrid *measure_grid, MusicEngraver *music_engraver, float full_measure_width, float staff_height)
+MeasureGridRenderComponent::MeasureGridRenderComponent(MeasureGrid *measure_grid, MusicEngraver *music_engraver, ReferenceCursor *reference_cursor, float full_measure_width, float staff_height)
    : measure_grid(measure_grid)
    , music_engraver(music_engraver)
+   , reference_cursor(reference_cursor)
    , full_measure_width(full_measure_width)
    , staff_height(staff_height)
    , showing_debug_data(false)

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -58,6 +58,15 @@ void MeasureGridRenderComponent::render()
 {
    if (!measure_grid || !music_engraver) return;
 
+   int reference_cursor_x = -1;
+   int reference_cursor_y = -1;
+
+   if (reference_cursor && reference_cursor->is_on_measure_grid(measure_grid))
+   {
+      reference_cursor_x = reference_cursor->get_x();
+      reference_cursor_y = reference_cursor->get_y();
+   }
+
    // draw barlines
    TimeSignature previous_time_signature = TimeSignature(0, Duration());
    for (int x=0; x<measure_grid->get_num_measures(); x++)
@@ -89,10 +98,26 @@ void MeasureGridRenderComponent::render()
       // draw the measures
       for (int x=0; x<measure_grid->get_num_measures(); x++)
       {
+         // draw the reference_cursor
+         float x_pos = MeasureGridHelper::get_length_to_measure(*measure_grid, x) * full_measure_width;
+
+         bool draw_reference_cursor = (y == reference_cursor_y && x == reference_cursor_x);
+         if (draw_reference_cursor)
+         {
+            float reference_cursor_height = 20;
+            float reference_cursor_width = 18;
+            float reference_cursor_hwidth = reference_cursor_width * 0.5;
+
+            al_draw_filled_triangle(
+                  x_pos, y_pos,
+                  x_pos-reference_cursor_hwidth, y_pos-reference_cursor_height,
+                  x_pos+reference_cursor_hwidth, y_pos-reference_cursor_height,
+                  color::darkorange);
+         }
+
+         //draw the measure
          Measure::Base *measure = measure_grid->get_measure(x,y);
          if (!measure) continue;
-
-         float x_pos = MeasureGridHelper::get_length_to_measure(*measure_grid, x) * full_measure_width;
 
          ALLEGRO_COLOR measure_block_color = color::color(color::black, 0.075);
 

--- a/src/fullscore_application_controller.cpp
+++ b/src/fullscore_application_controller.cpp
@@ -467,6 +467,8 @@ GUIScoreEditor *FullscoreApplicationController::create_new_score_editor(std::str
    new_gui_score_editor->place.position = vec2d(new_x, new_y);
    new_gui_score_editor->place.align = vec2d(0.0, 0.0);
 
+   new_gui_score_editor->rendering_dependencies.set_reference_cursor(&this->reference_cursor);
+
    gui_score_editors.push_back(new_gui_score_editor);
 
    new_y += 300;

--- a/src/gui_score_editor.cpp
+++ b/src/gui_score_editor.cpp
@@ -73,7 +73,7 @@ void GUIScoreEditor::on_draw()
    }
 
    // render the measure grid
-   MeasureGridRenderComponent measure_grid_render_component(&measure_grid, &music_engraver, FULL_MEASURE_WIDTH, STAFF_HEIGHT);
+   MeasureGridRenderComponent measure_grid_render_component(&measure_grid, &music_engraver, rendering_dependencies.reference_cursor, FULL_MEASURE_WIDTH, STAFF_HEIGHT);
    measure_grid_render_component.set_showing_debug_data(showing_debug_data);
    measure_grid_render_component.render();
 

--- a/src/gui_score_editor.cpp
+++ b/src/gui_score_editor.cpp
@@ -14,12 +14,27 @@
 
 
 
+GUIScoreEditor::RenderingDependencies::RenderingDependencies()
+   : reference_cursor(nullptr)
+{}
+
+
+
+
+void GUIScoreEditor::RenderingDependencies::set_reference_cursor(ReferenceCursor *reference_cursor)
+{
+   this->reference_cursor = reference_cursor;
+}
+
+
+
+
 GUIScoreEditor::GUIScoreEditor(UIWidget *parent)
    // the widget is placed in the center of the screen with a padding of 10 pixels to the x and y edges
    : UIWidget(parent, "GUIScoreEditor", new UISurfaceAreaBoxPadded(0, 0, 300, 200, 30, 30, 30, 30))
    , measure_grid(0, 0)
    , playback_control()
-   , reference_cursor(nullptr)
+   , rendering_dependencies()
    , measure_cursor_x(0)
    , measure_cursor_y(0)
    , note_cursor_x(0)
@@ -256,13 +271,6 @@ int GUIScoreEditor::move_note_cursor_x(int delta)
       note_cursor_x = limit<int>(0, num_notes-1, note_cursor_x + delta);
    }
    return note_cursor_x;
-}
-
-
-
-void GUIScoreEditor::set_reference_cursor(ReferenceCursor *reference_cursor)
-{
-   this->reference_cursor = reference_cursor;
 }
 
 

--- a/src/gui_score_editor.cpp
+++ b/src/gui_score_editor.cpp
@@ -19,6 +19,7 @@ GUIScoreEditor::GUIScoreEditor(UIWidget *parent)
    : UIWidget(parent, "GUIScoreEditor", new UISurfaceAreaBoxPadded(0, 0, 300, 200, 30, 30, 30, 30))
    , measure_grid(0, 0)
    , playback_control()
+   , reference_cursor(nullptr)
    , measure_cursor_x(0)
    , measure_cursor_y(0)
    , note_cursor_x(0)
@@ -257,6 +258,12 @@ int GUIScoreEditor::move_note_cursor_x(int delta)
    return note_cursor_x;
 }
 
+
+
+void GUIScoreEditor::set_reference_cursor(ReferenceCursor *reference_cursor)
+{
+   this->reference_cursor = reference_cursor;
+}
 
 
 


### PR DESCRIPTION
## Problem

It's not possible to see where the `reference_cursor` is located on the score.

## Solution

Render the `reference_cursor` as an orange triangle at its `x`, `y` coordinates on the `MeasureGrid`.

![fullscore 2017-07-23 12-29-11](https://user-images.githubusercontent.com/772949/28501096-8fa7b2de-6fa2-11e7-9497-2b3acb1282eb.png)
