### PR TITLE
Modify TimeSignature Numerator

### DIFF
--- a/include/fullscore/actions/set_time_signature_numerator_action.h
+++ b/include/fullscore/actions/set_time_signature_numerator_action.h
@@ -1,0 +1,30 @@
+#pragma once
+
+
+
+#include <fullscore/actions/action_base.h>
+
+
+
+class TimeSignature;
+
+
+
+namespace Action
+{
+   class SetTimeSignatureNumerator : public Base
+   {
+   private:
+      TimeSignature *time_signature;
+      int numerator;
+
+   public:
+      SetTimeSignatureNumerator(TimeSignature *time_signature, int numerator);
+
+      bool execute() override;
+   };
+}
+
+
+
+

--- a/include/fullscore/actions/set_time_signature_numerator_action.h
+++ b/include/fullscore/actions/set_time_signature_numerator_action.h
@@ -27,4 +27,3 @@ namespace Action
 
 
 
-

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -50,6 +50,7 @@ public:
 
    bool set_time_signature(int index, TimeSignature time_signature);
    TimeSignature get_time_signature(int index);
+   TimeSignature *get_time_signature_ptr(int index);
 };
 
 

--- a/include/fullscore/models/time_signature.h
+++ b/include/fullscore/models/time_signature.h
@@ -14,6 +14,8 @@ private:
    Duration denominator;
 
 public:
+   static const int NUMERATOR_MAX = 12;
+
    TimeSignature(int numerator, Duration denominator);
    ~TimeSignature();
 

--- a/src/actions/set_time_signature_numerator_action.cpp
+++ b/src/actions/set_time_signature_numerator_action.cpp
@@ -1,0 +1,33 @@
+
+
+
+#include <fullscore/actions/set_time_signature_numerator_action.h>
+
+#include <fullscore/models/time_signature.h>
+
+
+
+Action::SetTimeSignatureNumerator::SetTimeSignatureNumerator(TimeSignature *time_signature, int numerator)
+   : Base("set_time_signature_numerator")
+   , time_signature(time_signature)
+   , numerator(numerator)
+{}
+
+
+
+bool Action::SetTimeSignatureNumerator::execute()
+{
+   if (!time_signature) throw std::invalid_argument("Cannot set time signature's numerator on a nullprt time_signature");
+   if (numerator <= 0) throw std::invalid_argument("Cannot set a time signature's numerator to <= 0");
+   if (numerator > TimeSignature::NUMERATOR_MAX)
+   {
+      std::stringstream error_message;
+      error_message << "Cannot set a time signature's numerator to greater than" << TimeSignature::NUMERATOR_MAX;
+      throw std::invalid_argument(error_message.str());
+   }
+
+   return time_signature->set_numerator(numerator);
+}
+
+
+

--- a/src/actions/set_time_signature_numerator_action.cpp
+++ b/src/actions/set_time_signature_numerator_action.cpp
@@ -17,12 +17,12 @@ Action::SetTimeSignatureNumerator::SetTimeSignatureNumerator(TimeSignature *time
 
 bool Action::SetTimeSignatureNumerator::execute()
 {
-   if (!time_signature) throw std::invalid_argument("Cannot set time signature's numerator on a nullprt time_signature");
+   if (!time_signature) throw std::invalid_argument("Cannot set time signature's numerator on a nullptr time_signature");
    if (numerator <= 0) throw std::invalid_argument("Cannot set a time signature's numerator to <= 0");
    if (numerator > TimeSignature::NUMERATOR_MAX)
    {
       std::stringstream error_message;
-      error_message << "Cannot set a time signature's numerator to greater than" << TimeSignature::NUMERATOR_MAX;
+      error_message << "Cannot set a time signature's numerator to greater than " << TimeSignature::NUMERATOR_MAX;
       throw std::invalid_argument(error_message.str());
    }
 

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -372,7 +372,7 @@ Action::Base *AppController::create_action(std::string action_name)
    else if (action_name == "append_staff")
       action = new Action::AppendStaff(&current_measure_grid_editor->measure_grid);
    else if (action_name == "set_time_signature_numerator_2")
-      action = new Action::SetTimeSignatureNumerator(current_measure_grid_editor->measure_grid.get_time_signature_ptr(current_measure_grid_editor->measure_cursor_x), 3);
+      action = new Action::SetTimeSignatureNumerator(current_measure_grid_editor->measure_grid.get_time_signature_ptr(current_measure_grid_editor->measure_cursor_x), 2);
    else if (action_name == "set_time_signature_numerator_3")
       action = new Action::SetTimeSignatureNumerator(current_measure_grid_editor->measure_grid.get_time_signature_ptr(current_measure_grid_editor->measure_cursor_x), 3);
    else if (action_name == "set_time_signature_numerator_4")

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -47,6 +47,7 @@
 #include <fullscore/actions/set_reference_measure_action.h>
 #include <fullscore/actions/set_score_zoom_action.h>
 #include <fullscore/actions/set_stack_measure_action.h>
+#include <fullscore/actions/set_time_signature_numerator_action.h>
 #include <fullscore/actions/start_motion_action.h>
 #include <fullscore/actions/toggle_edit_mode_target_action.h>
 #include <fullscore/actions/toggle_playback_action.h>
@@ -158,6 +159,10 @@ std::string AppController::find_action_identifier(UIMeasureGridEditor::mode_t mo
       case ALLEGRO_KEY_P: return "paste_measure_from_buffer"; break;
       case ALLEGRO_KEY_O: return "octatonic_1_transform"; break;
       case ALLEGRO_KEY_TAB: return "toggle_edit_mode_target"; break;
+      case ALLEGRO_KEY_2: return "set_time_signature_numerator_2"; break;
+      case ALLEGRO_KEY_3: return "set_time_signature_numerator_3"; break;
+      case ALLEGRO_KEY_4: return "set_time_signature_numerator_4"; break;
+      case ALLEGRO_KEY_5: return "set_time_signature_numerator_5"; break;
       }
 
    if (mode == UIMeasureGridEditor::COMMAND_MODE)
@@ -366,6 +371,14 @@ Action::Base *AppController::create_action(std::string action_name)
       action = new Action::AppendMeasure(&current_measure_grid_editor->measure_grid);
    else if (action_name == "append_staff")
       action = new Action::AppendStaff(&current_measure_grid_editor->measure_grid);
+   else if (action_name == "set_time_signature_numerator_2")
+      action = new Action::SetTimeSignatureNumerator(current_measure_grid_editor->measure_grid.get_time_signature_ptr(current_measure_grid_editor->measure_cursor_x), 3);
+   else if (action_name == "set_time_signature_numerator_3")
+      action = new Action::SetTimeSignatureNumerator(current_measure_grid_editor->measure_grid.get_time_signature_ptr(current_measure_grid_editor->measure_cursor_x), 3);
+   else if (action_name == "set_time_signature_numerator_4")
+      action = new Action::SetTimeSignatureNumerator(current_measure_grid_editor->measure_grid.get_time_signature_ptr(current_measure_grid_editor->measure_cursor_x), 4);
+   else if (action_name == "set_time_signature_numerator_5")
+      action = new Action::SetTimeSignatureNumerator(current_measure_grid_editor->measure_grid.get_time_signature_ptr(current_measure_grid_editor->measure_cursor_x), 5);
 
    return action;
 }

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -212,3 +212,12 @@ TimeSignature MeasureGrid::get_time_signature(int index)
 
 
 
+TimeSignature *MeasureGrid::get_time_signature_ptr(int index)
+{
+   if (index < 0 || index >= get_num_measures()) return nullptr;
+
+   return &time_signatures[index];
+}
+
+
+

--- a/src/models/time_signature.cpp
+++ b/src/models/time_signature.cpp
@@ -39,7 +39,7 @@ Duration TimeSignature::get_denominator() const
 bool TimeSignature::set_numerator(int numerator)
 {
    if (numerator <= 0) return false;
-   if (numerator > 12) return false;
+   if (numerator > NUMERATOR_MAX) return false;
 
    this->numerator = numerator;
    return true;

--- a/tests/actions/set_time_signature_numerator_action_test.cpp
+++ b/tests/actions/set_time_signature_numerator_action_test.cpp
@@ -1,0 +1,32 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/actions/set_time_signature_numerator_action.h>
+#include <fullscore/models/time_signature.h>
+
+
+
+TEST(SetTimeSignatureNumeratorActionTest, sets_the_time_signatures_numerator)
+{
+   TimeSignature time_signature(4, Duration());
+
+   EXPECT_EQ(4, time_signature.get_numerator());
+
+   Action::SetTimeSignatureNumerator set_time_signature_numerator_action(&time_signature, 3);
+   set_time_signature_numerator_action.execute();
+
+   EXPECT_EQ(3, time_signature.get_numerator());
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/actions/set_time_signature_numerator_action_test.cpp
+++ b/tests/actions/set_time_signature_numerator_action_test.cpp
@@ -22,6 +22,25 @@ TEST(SetTimeSignatureNumeratorActionTest, sets_the_time_signatures_numerator)
 
 
 
+TEST(SetTimeSignatureNumeratorActionTest, with_an_invalid_time_signature_raises_an_exception)
+{
+   try
+   {
+      Action::SetTimeSignatureNumerator set_time_signature_numerator_action(nullptr, 3);
+      set_time_signature_numerator_action.execute();
+   }
+   catch (std::invalid_argument const &e)
+   {
+      EXPECT_EQ(e.what(), std::string("Cannot set time signature's numerator on a nullprt time_signature"));
+   }
+   catch (...)
+   {
+      FAIL() << "Expected std::invalid_argument";
+   }
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/actions/set_time_signature_numerator_action_test.cpp
+++ b/tests/actions/set_time_signature_numerator_action_test.cpp
@@ -31,7 +31,27 @@ TEST(SetTimeSignatureNumeratorActionTest, with_an_invalid_time_signature_raises_
    }
    catch (std::invalid_argument const &e)
    {
-      EXPECT_EQ(e.what(), std::string("Cannot set time signature's numerator on a nullprt time_signature"));
+      EXPECT_EQ(e.what(), std::string("Cannot set time signature's numerator on a nullptr time_signature"));
+   }
+   catch (...)
+   {
+      FAIL() << "Expected std::invalid_argument";
+   }
+}
+
+
+
+TEST(SetTimeSignatureNumeratorActionTest, with_an_numerator_that_is_greater_than_allowed_raises_an_exception)
+{
+   try
+   {
+      TimeSignature time_signature(4, Duration());
+      Action::SetTimeSignatureNumerator set_time_signature_numerator_action(&time_signature, TimeSignature::NUMERATOR_MAX+1);
+      set_time_signature_numerator_action.execute();
+   }
+   catch (std::invalid_argument const &e)
+   {
+      EXPECT_EQ(e.what(), std::string("Cannot set a time signature's numerator to greater than 12"));
    }
    catch (...)
    {

--- a/tests/actions/set_time_signature_numerator_action_test.cpp
+++ b/tests/actions/set_time_signature_numerator_action_test.cpp
@@ -61,6 +61,26 @@ TEST(SetTimeSignatureNumeratorActionTest, with_an_numerator_that_is_greater_than
 
 
 
+TEST(SetTimeSignatureNumeratorActionTest, with_an_numerator_that_is_less_than_allowed_raises_an_exception)
+{
+   try
+   {
+      TimeSignature time_signature(4, Duration());
+      Action::SetTimeSignatureNumerator set_time_signature_numerator_action(&time_signature, 0);
+      set_time_signature_numerator_action.execute();
+   }
+   catch (std::invalid_argument const &e)
+   {
+      EXPECT_EQ(e.what(), std::string("Cannot set a time signature's numerator to <= 0"));
+   }
+   catch (...)
+   {
+      FAIL() << "Expected std::invalid_argument";
+   }
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Problem

We can't modify any `TimeSignatures` in the `MeasureGridEditor` - they're stuck in 4/4!!

## Solution

Add a simple feature to change the numerator.  Press a number key to set the numerator of the current time signature.  Only <kbd>2</kbd>, <kbd>3</kbd>, <kbd>4</kbd> and <kbd>5</kbd> are currently supported.

![broken harray potter - but now in 3 4 - fullscore 2017-07-25 23-25-18](https://user-images.githubusercontent.com/772949/28603197-c9820a82-7190-11e7-98e7-645af1b0511f.png)
