### PR TITLE
Fix crash on reference measure

### DIFF
--- a/src/actions/set_reference_measure_action.cpp
+++ b/src/actions/set_reference_measure_action.cpp
@@ -28,6 +28,8 @@ Action::SetReferenceMeasure::~SetReferenceMeasure()
 bool Action::SetReferenceMeasure::execute()
 {
    if (!measure_grid) throw std::runtime_error("Cannot set Measure::Reference on a nullptr measure_grid");
+   // this next line has been commented out because it is probably not needed
+   //if (!referenced_measure_grid) throw std::runtime_error("Cannot set Measure::Reference on a nullptr reference_measure_grid");
 
    if (measure_grid == referenced_measure_grid && measure_x == referenced_measure_x && staff_y == referenced_staff_y)
       throw std::runtime_error("a Measure::Reference cannot reference itself");

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -77,6 +77,8 @@ AppController::AppController(Display *display)
    create_new_score_editor("");
    set_current_measure_grid_editor(create_new_score_editor("full_score"));
 
+   reference_cursor.set_position(&current_measure_grid_editor->measure_grid, 0, 0);
+
    current_measure_grid_editor->measure_grid.set_measure(0, 0, new Measure::Basic({Note(2), Note(0), Note(1)}));
    Measure::Base *m = current_measure_grid_editor->measure_grid.get_measure(0, 0);
    if (!m) throw std::runtime_error("hmm, ApplicationController not able to set/get a measure from the MeasureGrid (0, 0)");

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -105,10 +105,11 @@ AppController::AppController(Display *display)
 
 void AppController::primary_timer_func()
 {
-   UIScreen::primary_timer_func();
    if (ui_measure_inspector) ui_measure_inspector->set_measure(current_measure_grid_editor->get_measure_at_cursor());
    ui_measure_inspector->place.position = vec2d(display->width(), 0);
    ui_measure_inspector->place.size = vec2d(300, display->height());
+
+   UIScreen::primary_timer_func();
 }
 
 

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -344,7 +344,13 @@ Action::Base *AppController::create_action(std::string action_name)
    else if (action_name == "move_cursor_right")
       action = new Action::MoveCursorRight(current_measure_grid_editor);
    else if (action_name == "yank_measure_to_buffer")
-      action = new Action::YankMeasureToBuffer(&yank_measure_buffer, focused_measure);
+   {
+      action = new Action::Queue("yank_measure_to_buffer and set_reference_measure");
+      static_cast<Action::Queue *>(action)->add_action(new Action::YankMeasureToBuffer(&yank_measure_buffer, focused_measure));
+      static_cast<Action::Queue *>(action)->add_action(new Action::SetReferenceCursor(&reference_cursor,
+            &current_measure_grid_editor->measure_grid, current_measure_grid_editor->measure_cursor_x, current_measure_grid_editor->measure_cursor_y)
+         );
+   }
    else if (action_name == "paste_measure_from_buffer")
       action = new Action::PasteMeasureFromBuffer(focused_measure, &yank_measure_buffer);
    else if (action_name == "toggle_edit_mode_target")

--- a/src/models/measures/reference.cpp
+++ b/src/models/measures/reference.cpp
@@ -17,6 +17,8 @@ Measure::Reference::Reference(MeasureGrid *measure_grid, int measure_x, int staf
 
 std::vector<Note> Measure::Reference::get_notes_copy()
 {
+   if (!measure_grid) return {};
+
    // TODO: this could be a dead pointer if it is deleted externally
    Measure::Base *referenced_measure = measure_grid->get_measure(measure_x, staff_y);
    if (referenced_measure) return referenced_measure->get_notes_copy();
@@ -27,6 +29,8 @@ std::vector<Note> Measure::Reference::get_notes_copy()
 
 Measure::Base *Measure::Reference::get_referenced_measure()
 {
+   if (!measure_grid) return nullptr;
+
    return measure_grid->get_measure(measure_x, staff_y);
 }
 
@@ -50,7 +54,7 @@ bool Measure::Reference::set_notes(std::vector<Note> notes)
 
 std::vector<Note> *Measure::Reference::get_notes_pointer()
 {
-   return nullptr;
+   return nullptr; //TODO ensure all calls to get_notes_pointer() check for validity
 }
 
 


### PR DESCRIPTION
## Problem

When setting a reference measure, sometimes the program will crash.

## Solution

In the `AppController`, the reference measure was being set _after_ the widget was rendered.  In some cases, this led to the `AppController` having a pointer to a dead measure. 
 That was fixed here: https://github.com/MarkOates/fullscore/commit/01972ecdfa539c0a7e2eb068a5018b040f1b5a76

- Also, a reference measure will now return `{}` of notes if it has an invalid `measure_grid`.
- Also, `AppController` will now set the reference cursor to `0, 0` upon initialization.
- The "yanking" action will also now set the reference cursor.