### PR TITLE
Automatically Add Measure When Pasting

### DIFF
--- a/include/fullscore/actions/paste_measure_from_buffer_to_measure_grid_coordinates_action.h
+++ b/include/fullscore/actions/paste_measure_from_buffer_to_measure_grid_coordinates_action.h
@@ -1,0 +1,33 @@
+#pragma once
+
+
+
+#include <fullscore/actions/action_base.h>
+
+
+
+namespace Measure { class Basic; class Base; }
+class MeasureGrid;
+
+
+
+namespace Action
+{
+   class PasteMeasureFromBufferToMeasureGridCoordinates : public Base
+   {
+   private:
+      Measure::Basic *yank_measure_buffer;
+      MeasureGrid *measure_grid;
+      int measure_x;
+      int staff_y;
+
+   public:
+      PasteMeasureFromBufferToMeasureGridCoordinates(Measure::Basic *yank_measure_buffer, MeasureGrid *measure_grid, int measure_x, int staff_y);
+      ~PasteMeasureFromBufferToMeasureGridCoordinates();
+
+      bool execute();
+   };
+}
+
+
+

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -2,6 +2,7 @@
 
 
 
+#include <string>
 #include <vector>
 #include <fullscore/models/note.h>
 
@@ -9,11 +10,11 @@
 
 namespace Measure
 {
-   MEASURE_TYPE_IDENTIFIER_BASE = "base";
-   MEASURE_TYPE_IDENTIFIER_BASIC = "basic";
-   MEASURE_TYPE_IDENTIFIER_REFERENCE = "reference";
-   MEASURE_TYPE_IDENTIFIER_STACK = "stack";
-   MEASURE_TYPE_IDENTIFIER_STATIC = "static";
+   std::string const TYPE_IDENTIFIER_BASE      = "base";
+   std::string const TYPE_IDENTIFIER_BASIC     = "basic";
+   std::string const TYPE_IDENTIFIER_REFERENCE = "reference";
+   std::string const TYPE_IDENTIFIER_STACK     = "stack";
+   std::string const TYPE_IDENTIFIER_STATIC    = "static";
 
    class Base;
 

--- a/include/fullscore/models/measure.h
+++ b/include/fullscore/models/measure.h
@@ -9,6 +9,12 @@
 
 namespace Measure
 {
+   MEASURE_TYPE_IDENTIFIER_BASE = "base";
+   MEASURE_TYPE_IDENTIFIER_BASIC = "basic";
+   MEASURE_TYPE_IDENTIFIER_REFERENCE = "reference";
+   MEASURE_TYPE_IDENTIFIER_STACK = "stack";
+   MEASURE_TYPE_IDENTIFIER_STATIC = "static";
+
    class Base;
 
    extern std::vector<Base *> pool;

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -34,6 +34,8 @@ public:
    bool set_measure(int x_measure, int y_staff, Measure::Base *measure);
    bool delete_measure(int x_measure, int y_staff);
 
+   bool in_grid_range(int x_measure, int y_staff);
+
    int get_num_staves() const;
    int get_num_measures() const;
 

--- a/src/actions/paste_measure_from_buffer_action.cpp
+++ b/src/actions/paste_measure_from_buffer_action.cpp
@@ -11,7 +11,7 @@
 
 
 Action::PasteMeasureFromBuffer::PasteMeasureFromBuffer(Measure::Base *destination_measure, Measure::Basic *yank_measure_buffer)
-   : Base("yank_measure_to_buffer")
+   : Base("paste_measure_from_buffer")
    , yank_measure_buffer(yank_measure_buffer)
    , destination_measure(destination_measure)
 {
@@ -29,8 +29,8 @@ Action::PasteMeasureFromBuffer::~PasteMeasureFromBuffer()
 
 bool Action::PasteMeasureFromBuffer::execute()
 {
-   if (!yank_measure_buffer) throw std::runtime_error("Cannot yank to a nullptr yank_measure_buffer");
-   if (!destination_measure) throw std::runtime_error("Cannot yank from a nullptr destination_measure");
+   if (!yank_measure_buffer) throw std::runtime_error("Cannot paste from a nullptr yank_measure_buffer");
+   if (!destination_measure) throw std::runtime_error("Cannot paste to a nullptr destination_measure");
 
    destination_measure->set_notes(yank_measure_buffer->get_notes_copy());
    return true;

--- a/src/actions/paste_measure_from_buffer_to_measure_grid_coordinates_action.cpp
+++ b/src/actions/paste_measure_from_buffer_to_measure_grid_coordinates_action.cpp
@@ -1,0 +1,53 @@
+
+
+
+#include <fullscore/actions/paste_measure_from_buffer_to_measure_grid_coordinates_action.h>
+
+#include <fullscore/models/measure_grid.h>
+
+
+
+Action::PasteMeasureFromBufferToMeasureGridCoordinates::PasteMeasureFromBufferToMeasureGridCoordinates(Measure::Basic *yank_measure_buffer, MeasureGrid *measure_grid, int measure_x, int staff_y)
+   : Base("paste_measure_from_buffer_to_measure_grid_coordinates_action")
+   , yank_measure_buffer(yank_measure_buffer)
+   , measure_grid(measure_grid)
+   , measure_x(measure_x)
+   , staff_y(staff_y)
+{
+}
+
+
+
+Action::PasteMeasureFromBufferToMeasureGridCoordinates::~PasteMeasureFromBufferToMeasureGridCoordinates()
+{
+}
+
+
+
+bool Action::PasteMeasureFromBufferToMeasureGridCoordinates::execute()
+{
+   if (!yank_measure_buffer) throw std::runtime_error("Cannot paste to a nullptr measure_grid");
+   if (!measure_grid) throw std::runtime_error("Cannot paste to a nullptr measure_grid");
+   if (!measure_grid->in_grid_range(measure_x, staff_y)) throw std::runtime_error("Cannot paste a measure to coordinates outside the measure_grid");
+
+   Measure::Base *destination_measure = measure_grid->get_measure(measure_x, staff_y);
+
+   if (!destination_measure)
+   {
+      std::stringstream error_message;
+      error_message << "Cannot paste notes into a nullptr measure located at (" << measure_x << ", " << staff_y << ")" << std::endl;
+      throw std::runtime_error(error_message.str());
+   }
+
+   bool successfully_set = destination_measure->set_notes(yank_measure_buffer->get_notes_copy());
+   if (!successfully_set)
+   {
+      std::stringstream error_message;
+      error_message << "Could not set notes measure (type " << destination_measure->get_type() << ") located at (" << measure_x << ", " << staff_y << ")" << std::endl;
+      throw std::runtime_error(error_message.str());
+   }
+   return true;
+}
+
+
+

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -57,6 +57,7 @@
 #include <fullscore/factories/measure_grid_factory.h>
 
 #include <fullscore/models/measures/static.h>
+#include <fullscore/models/measure.h>
 
 
 

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -45,13 +45,13 @@ void MeasureRenderComponent::render()
    if (measure->get_num_notes() > 0)
       measure_width = __get_measure_width(measure) * full_measure_width;
 
-   if (measure->is_type("reference"))
+   if (measure->is_type(MEASURE_TYPE_IDENTIFIER_REFERENCE))
       measure_block_color = color::color(color::yellow, 0.2);
-   else if (measure->is_type("stack"))
+   else if (measure->is_type(MEASURE_TYPE_IDENTIFIER_STACK))
       measure_block_color = color::color(color::red, 0.2);
-   else if (measure->is_type("static"))
+   else if (measure->is_type(MEASURE_TYPE_IDENTIFIER_STATIC))
       measure_block_color = color::color(color::dodgerblue, 0.1);
-   else if (measure->is_type("basic"))
+   else if (measure->is_type(MEASURE_TYPE_IDENTIFIER_BASIC))
       measure_block_color = color::color(color::black, 0.075);
 
    al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -45,13 +45,13 @@ void MeasureRenderComponent::render()
    if (measure->get_num_notes() > 0)
       measure_width = __get_measure_width(measure) * full_measure_width;
 
-   if (measure->is_type(MEASURE_TYPE_IDENTIFIER_REFERENCE))
+   if (measure->is_type(Measure::TYPE_IDENTIFIER_REFERENCE))
       measure_block_color = color::color(color::yellow, 0.2);
-   else if (measure->is_type(MEASURE_TYPE_IDENTIFIER_STACK))
+   else if (measure->is_type(Measure::TYPE_IDENTIFIER_STACK))
       measure_block_color = color::color(color::red, 0.2);
-   else if (measure->is_type(MEASURE_TYPE_IDENTIFIER_STATIC))
+   else if (measure->is_type(Measure::TYPE_IDENTIFIER_STATIC))
       measure_block_color = color::color(color::dodgerblue, 0.1);
-   else if (measure->is_type(MEASURE_TYPE_IDENTIFIER_BASIC))
+   else if (measure->is_type(Measure::TYPE_IDENTIFIER_BASIC))
       measure_block_color = color::color(color::black, 0.075);
 
    al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -65,6 +65,16 @@ bool MeasureGrid::delete_measure(int x_measure, int y_staff)
 
 
 
+bool MeasureGrid::in_grid_range(int x_measure, int y_staff)
+{
+   if (x_measure < 0 || x_measure >= this->get_num_measures() || this->get_num_measures() == 0) return false;
+   if (y_staff < 0 || y_staff >= this->get_num_staves() || this->get_num_staves() == 0) return false;
+
+   return true;
+}
+
+
+
 int MeasureGrid::get_num_measures() const
 {
    if (voices.empty()) return 0;

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -36,8 +36,7 @@ MeasureGrid::MeasureGrid(int num_x_measures, int num_y_staves)
 Measure::Base *MeasureGrid::get_measure(int x_measure, int y_staff)
 {
    // bounds check
-   if (x_measure < 0 || x_measure >= this->get_num_measures() || this->get_num_measures() == 0) return NULL;
-   if (y_staff < 0 || y_staff >= this->get_num_staves() || this->get_num_staves() == 0) return NULL;
+   if (!in_grid_range(x_measure, y_staff)) return nullptr;
 
    return voices[y_staff][x_measure];
 }
@@ -47,8 +46,7 @@ Measure::Base *MeasureGrid::get_measure(int x_measure, int y_staff)
 bool MeasureGrid::set_measure(int x_measure, int y_staff, Measure::Base *measure)
 {
    // bounds check
-   if (x_measure < 0 || x_measure >= this->get_num_measures() || this->get_num_measures() == 0) return false;
-   if (y_staff < 0 || y_staff >= this->get_num_staves() || this->get_num_staves() == 0) return false;
+   if (!in_grid_range(x_measure, y_staff)) return false;
 
    Measure::Base *existing_measure = get_measure(x_measure, y_staff);
    if (existing_measure) delete existing_measure;

--- a/src/models/measures/basic.cpp
+++ b/src/models/measures/basic.cpp
@@ -9,7 +9,7 @@
 
 
 Measure::Basic::Basic()
-   : Base("basic")
+   : Base(MEASURE_TYPE_IDENTIFIER_BASIC)
    , genesis(nullptr)
    , extension(12)
 {}
@@ -17,7 +17,7 @@ Measure::Basic::Basic()
 
 
 Measure::Basic::Basic(std::vector<Note> notes)
-   : Base("basic")
+   : Base(MEASURE_TYPE_IDENTIFIER_BASIC)
    , notes()
    , genesis(nullptr)
    , extension(12)

--- a/src/models/measures/basic.cpp
+++ b/src/models/measures/basic.cpp
@@ -3,13 +3,14 @@
 
 #include <fullscore/models/measures/basic.h>
 
+#include <fullscore/models/measure.h>
 #include <fullscore/models/note.h>
 #include <allegro_flare/useful.h>
 
 
 
 Measure::Basic::Basic()
-   : Base(MEASURE_TYPE_IDENTIFIER_BASIC)
+   : Base(Measure::TYPE_IDENTIFIER_BASIC)
    , genesis(nullptr)
    , extension(12)
 {}
@@ -17,7 +18,7 @@ Measure::Basic::Basic()
 
 
 Measure::Basic::Basic(std::vector<Note> notes)
-   : Base(MEASURE_TYPE_IDENTIFIER_BASIC)
+   : Base(Measure::TYPE_IDENTIFIER_BASIC)
    , notes()
    , genesis(nullptr)
    , extension(12)

--- a/src/models/measures/reference.cpp
+++ b/src/models/measures/reference.cpp
@@ -2,12 +2,14 @@
 
 
 #include <fullscore/models/measures/reference.h>
+
+#include <fullscore/models/measure.h>
 #include <fullscore/models/measure_grid.h>
 
 
 
 Measure::Reference::Reference(MeasureGrid *measure_grid, int measure_x, int staff_y)
-   : Base(MEASURE_TYPE_IDENTIFIER_REFERENCE)
+   : Base(Measure::TYPE_IDENTIFIER_REFERENCE)
    , measure_grid(measure_grid)
    , measure_x(measure_x)
    , staff_y(staff_y)

--- a/src/models/measures/reference.cpp
+++ b/src/models/measures/reference.cpp
@@ -7,7 +7,7 @@
 
 
 Measure::Reference::Reference(MeasureGrid *measure_grid, int measure_x, int staff_y)
-   : Base("reference")
+   : Base(MEASURE_TYPE_IDENTIFIER_REFERENCE)
    , measure_grid(measure_grid)
    , measure_x(measure_x)
    , staff_y(staff_y)

--- a/src/models/measures/stack.cpp
+++ b/src/models/measures/stack.cpp
@@ -9,7 +9,7 @@
 
 
 Measure::Stack::Stack()
-   : Base("stack")
+   : Base(MEASURE_TYPE_IDENTIFIER_STACK)
    , transformations()
 {}
 

--- a/src/models/measures/stack.cpp
+++ b/src/models/measures/stack.cpp
@@ -3,13 +3,14 @@
 
 #include <fullscore/models/measures/stack.h>
 
+#include <fullscore/models/measure.h>
 #include <fullscore/models/note.h>
 #include <allegro_flare/useful.h>
 
 
 
 Measure::Stack::Stack()
-   : Base(MEASURE_TYPE_IDENTIFIER_STACK)
+   : Base(Measure::TYPE_IDENTIFIER_STACK)
    , transformations()
 {}
 

--- a/src/models/measures/static.cpp
+++ b/src/models/measures/static.cpp
@@ -3,10 +3,12 @@
 
 #include <fullscore/models/measures/static.h>
 
+#include <fullscore/models/measure.h>
+
 
 
 Measure::Static::Static()
-   : Base(MEASURE_TYPE_IDENTIFIER_STATIC)
+   : Base(Measure::TYPE_IDENTIFIER_STATIC)
 {}
 
 

--- a/src/models/measures/static.cpp
+++ b/src/models/measures/static.cpp
@@ -6,7 +6,7 @@
 
 
 Measure::Static::Static()
-   : Base("static")
+   : Base(MEASURE_TYPE_IDENTIFIER_STATIC)
 {}
 
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -86,6 +86,30 @@ TEST(MeasureGridTest, can_delete_a_measure)
 
 
 
+TEST(MeasureGridTest, returns_true_if_coordinates_are_within_the_measure_grid)
+{
+   MeasureGrid measure_grid(17, 13);
+
+   ASSERT_EQ(true, measure_grid.in_grid_range(0, 0));
+   ASSERT_EQ(true, measure_grid.in_grid_range(0, 0));
+   ASSERT_EQ(true, measure_grid.in_grid_range(measure_grid.get_num_measures()-1, 0));
+   ASSERT_EQ(true, measure_grid.in_grid_range(0, measure_grid.get_num_staves()-1));
+}
+
+
+
+TEST(MeasureGridTest, returns_false_if_coordinates_are_outside_the_measure_grid)
+{
+   MeasureGrid measure_grid(17, 13);
+
+   ASSERT_EQ(false, measure_grid.in_grid_range(-1, 0));
+   ASSERT_EQ(false, measure_grid.in_grid_range(0, -1));
+   ASSERT_EQ(false, measure_grid.in_grid_range(measure_grid.get_num_measures(), 0));
+   ASSERT_EQ(false, measure_grid.in_grid_range(0, measure_grid.get_num_staves()));
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -57,7 +57,7 @@ TEST(MeasureGridTest, sets_and_gets_a_measure_to_a_coordinate)
 
    Measure::Base *retrieved_measure = measure_grid.get_measure(3, 7);
    ASSERT_NE(nullptr, retrieved_measure);
-   ASSERT_TRUE(retrieved_measure->is_type("basic"));
+   ASSERT_TRUE(retrieved_measure->is_type(MEASURE_TYPE_IDENTIFIER_BASIC));
 
    int expected_id = basic_measure->get_id();
    int returned_id = retrieved_measure->get_id();

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <fullscore/models/measure.h>
 #include <fullscore/models/measure_grid.h>
 #include <fullscore/models/note.h>
 
@@ -57,7 +58,7 @@ TEST(MeasureGridTest, sets_and_gets_a_measure_to_a_coordinate)
 
    Measure::Base *retrieved_measure = measure_grid.get_measure(3, 7);
    ASSERT_NE(nullptr, retrieved_measure);
-   ASSERT_TRUE(retrieved_measure->is_type(MEASURE_TYPE_IDENTIFIER_BASIC));
+   ASSERT_TRUE(retrieved_measure->is_type(Measure::TYPE_IDENTIFIER_BASIC));
 
    int expected_id = basic_measure->get_id();
    int returned_id = retrieved_measure->get_id();


### PR DESCRIPTION
## Problem

It's not possible to paste into a measure unless a `Measure::Base` is present at those coordinates in the `MeasureGrid`.  A lot of the times, you don't really care what's in the `MeasureGrid` coordinates at that point, you just want to paste, and, it's a bit annoying to have to manually create a new `Measure::Basic` before pasting notes.

## Solution

If there is already a `Measure::Basic` at that location, paste the notes into it.  If not, then a `Action::Queue` is created that will:

1. Delete the current measure
2. Create a new `Measure::Basic`
3. Paste the notes from the buffer into that new measure.

In order to facilitate Step 3, a new action, `PasteMeasureFromBufferToMeasureGridCoordinates`, had to be created.  The previous action used for pasting (`PasteMeasureFromBuffer`) required a pointer to a `Measure::Base` as an argument, but since no measure existed at the time that `Action::Queue` is created, no pointer could be set to that action.  Thus, a _new_ action needed to be created that could paste when only given a `MeasureGrid` and coordinates.

## Problem To Fix

When setting measures, the existing measure should be deleted first.  I don't think this is the case with most measure-setting actions.