### PR TITLE
Setup MeasureGrid for Staff Types

### DIFF
--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -26,7 +26,7 @@ private:
       Measure::Base *get_measure(int x_measure);
    };
 
-   std::vector<Row> voices;
+   std::vector<Row *> voices;
    std::vector<TimeSignature> time_signatures;
 
 public:

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -20,14 +20,15 @@ private:
    {
    private:
       std::string name;
-
-   public:
       std::vector<Measure::Base *> measures;
 
+   public:
       Row(int num_measures);
 
       void set_name(std::string name);
       std::string get_name();
+
+      int get_num_measures();
 
       Measure::Base *get_measure(int x_measure);
    };

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -21,8 +21,9 @@ private:
    public:
       std::string name;
       std::vector<Measure::Base *> measures;
+
       Row(int num_measures);
-      Measure::Base *operator[](unsigned int index);
+      Measure::Base *get_measure(int x_measure);
    };
 
    std::vector<Row> voices;

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -31,6 +31,7 @@ private:
       int get_num_measures();
       bool set_measure(int measure_x, Measure::Base *measure);
       bool insert_measure(int at_index, Measure::Base *measure);
+      bool erase_measure(int at_index);
 
       Measure::Base *get_measure(int x_measure);
    };

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -53,7 +53,7 @@ public:
 
    bool set_time_signature(int index, TimeSignature time_signature);
    TimeSignature get_time_signature(int index);
-   TimeSignature *get_time_signature_ptr(int index);
+   TimeSignature *get_time_signature_ptr(int index); // consider removing this method (having the dependent action rely on a *measure_grid and measure number)
 };
 
 

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -29,6 +29,7 @@ private:
       std::string get_name();
 
       int get_num_measures();
+      bool set_measure(int measure_x, Measure::Base *measure);
 
       Measure::Base *get_measure(int x_measure);
    };

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -30,6 +30,7 @@ private:
 
       int get_num_measures();
       bool set_measure(int measure_x, Measure::Base *measure);
+      bool insert_measure(int at_index, Measure::Base *measure);
 
       Measure::Base *get_measure(int x_measure);
    };

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 #include <string>
-#include <fullscore/models/measures/basic.h>
+#include <fullscore/models/measures/base.h>
 #include <fullscore/models/time_signature.h>
 
 

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -18,11 +18,17 @@ private:
 
    class Row
    {
-   public:
+   private:
       std::string name;
+
+   public:
       std::vector<Measure::Base *> measures;
 
       Row(int num_measures);
+
+      void set_name(std::string name);
+      std::string get_name();
+
       Measure::Base *get_measure(int x_measure);
    };
 

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -32,6 +32,7 @@ private:
       bool set_measure(int measure_x, Measure::Base *measure);
       bool insert_measure(int at_index, Measure::Base *measure);
       bool erase_measure(int at_index);
+      bool append_measure(Measure::Base *measure);
 
       Measure::Base *get_measure(int x_measure);
    };

--- a/include/fullscore/models/staff.h
+++ b/include/fullscore/models/staff.h
@@ -1,0 +1,15 @@
+#pragma once
+
+
+
+#include <string>
+
+
+
+namespace Staff
+{
+   extern int next_id;
+};
+
+
+

--- a/include/fullscore/models/staves/base.h
+++ b/include/fullscore/models/staves/base.h
@@ -1,0 +1,27 @@
+#pragma once
+
+
+
+#include <string>
+
+
+
+namespace Staff
+{
+   class Base
+   {
+   private:
+      std::string type;
+      int id;
+
+   public:
+      Base(std::string type);
+      virtual ~Base();
+      std::string get_type();
+      bool is_type(std::string type);
+      int get_id();
+   };
+};
+
+
+

--- a/include/fullscore/models/time_signature.h
+++ b/include/fullscore/models/time_signature.h
@@ -25,8 +25,8 @@ public:
    bool set_numerator(int numerator);
    bool set_denominator(Duration denominator);
 
-   bool operator==(TimeSignature &other);
-   bool operator!=(TimeSignature &other);
+   bool operator==(const TimeSignature &other) const;
+   bool operator!=(const TimeSignature &other) const;
 };
 
 

--- a/src/actions/paste_measure_from_buffer_to_measure_grid_coordinates_action.cpp
+++ b/src/actions/paste_measure_from_buffer_to_measure_grid_coordinates_action.cpp
@@ -3,6 +3,7 @@
 
 #include <fullscore/actions/paste_measure_from_buffer_to_measure_grid_coordinates_action.h>
 
+#include <fullscore/models/measures/basic.h>
 #include <fullscore/models/measure_grid.h>
 
 

--- a/src/converters/measure_grid_file_converter.cpp
+++ b/src/converters/measure_grid_file_converter.cpp
@@ -99,7 +99,8 @@ bool MeasureGridFileConverter::load()
    // the the size of the board, and resize the current measure-grid
    int grid_height = atoi(state.get("grid_height").c_str());
    int grid_width = atoi(state.get("grid_width").c_str());
-   measure_grid->voices.resize(grid_height, MeasureGrid::Row(grid_width));
+   for (unsigned i=0; i<grid_height; i++)
+      measure_grid->voices.push_back(new MeasureGrid::Row(grid_width));
 
    // grab and parse the time_signatures string
    measure_grid->time_signatures.clear();

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -53,6 +53,7 @@ bool MeasureGrid::Row::set_measure(int measure_x, Measure::Base *measure)
    // TODO move the bounds check to be handled in here
    // TODO if there is already a measure present, the deletion should be moved to here as well
    measures[measure_x] = measure;
+   return true;
 }
 
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -8,6 +8,10 @@
 
 
 
+////// MeasureGrid::Row
+
+
+
 MeasureGrid::Row::Row(int num_measures) : measures()
 {
    for (unsigned i=0; i<num_measures; i++) measures.push_back(nullptr);
@@ -20,6 +24,24 @@ Measure::Base *MeasureGrid::Row::get_measure(int x_measure)
    if (x_measure < 0 || x_measure >= measures.size()) return nullptr;
    return measures[x_measure];
 }
+
+
+
+void MeasureGrid::Row::set_name(std::string name)
+{
+   this->name = name;
+}
+
+
+
+std::string MeasureGrid::Row::get_name()
+{
+   return name;
+}
+
+
+
+////// MeasureGrid
 
 
 
@@ -205,7 +227,7 @@ bool MeasureGrid::set_voice_name(int row_number, std::string name)
 {
    if (row_number < 0) return "";
    if (row_number >= voices.size()) return "";
-   voices[row_number]->name = name;
+   voices[row_number]->set_name(name);
    return true;
 }
 
@@ -215,7 +237,7 @@ std::string MeasureGrid::get_voice_name(int row_number)
 {
    if (row_number < 0) return "";
    if (row_number >= voices.size()) return "";
-   return voices[row_number]->name;
+   return voices[row_number]->get_name();
 }
 
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -71,6 +71,26 @@ bool MeasureGrid::Row::insert_measure(int at_index, Measure::Base *measure)
 
 
 
+bool MeasureGrid::Row::erase_measure(int at_index)
+{
+   // TODO move the bounds check to here
+   // behavior that < 0 inserts are corrected to 0 and
+
+   // >= size measures default to append() should probably be handled
+   // at the MeasureGrid layer, since it would need to be implement in
+   // all of the derived classes, and is expected behavior of the MeasureGrid
+   if (at_index < 0) std::runtime_error("Cannot erase measure < 0");
+   if (at_index >= measures.size()) std::runtime_error("Cannot erase measure >= size()");
+
+   if (measures[at_index]) delete measures[at_index];
+
+   measures.erase(measures.begin() + at_index);
+
+   return true;
+}
+
+
+
 ////// MeasureGrid
 
 
@@ -229,7 +249,7 @@ bool MeasureGrid::delete_column(int index)
    // inside another class
    // This should likely be replaced with a voice[i]->delete_measure(int) function
    for (unsigned i=0; i<voices.size(); i++)
-      voices[i]->measures.erase(voices[i]->measures.begin() + index);
+      voices[i]->erase_measure(index);
 
    return true;
 }

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -48,6 +48,15 @@ int MeasureGrid::Row::get_num_measures()
 
 
 
+bool MeasureGrid::Row::set_measure(int measure_x, Measure::Base *measure)
+{
+   // TODO move the bounds check to be handled in here
+   // TODO if there is already a measure present, the deletion should be moved to here as well
+   measures[measure_x] = measure;
+}
+
+
+
 ////// MeasureGrid
 
 
@@ -87,7 +96,7 @@ bool MeasureGrid::set_measure(int x_measure, int y_staff, Measure::Base *measure
    // that a voice has measures, and the voice's measures are of Measure::Base type
    // this should likely be handled by a method on the Row, like
    // voices[i]->set_measure(x_measure, measure);
-   voices[y_staff]->measures[x_measure] = measure;
+   voices[y_staff]->set_measure(x_measure, measure);
    return true;
 }
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -21,7 +21,7 @@ MeasureGrid::Row::Row(int num_measures) : measures()
 
 Measure::Base *MeasureGrid::Row::get_measure(int x_measure)
 {
-   if (x_measure < 0 || x_measure >= measures.size()) return nullptr;
+   if (x_measure < 0 || x_measure >= get_num_measures()) return nullptr;
    return measures[x_measure];
 }
 
@@ -37,6 +37,13 @@ void MeasureGrid::Row::set_name(std::string name)
 std::string MeasureGrid::Row::get_name()
 {
    return name;
+}
+
+
+
+int MeasureGrid::Row::get_num_measures()
+{
+   return measures.size();
 }
 
 
@@ -106,7 +113,7 @@ bool MeasureGrid::in_grid_range(int x_measure, int y_staff)
 int MeasureGrid::get_num_measures() const
 {
    if (voices.empty()) return 0;
-   return voices[0]->measures.size();
+   return voices[0]->get_num_measures();
 }
 
 
@@ -130,7 +137,7 @@ void MeasureGrid::insert_staff(int index)
    {
       // TODO: IMPORTANT here we are depending on voices[0] to currectly
       // report the current number of measures
-      int num_measures = (voices.empty()) ? 8 : voices[0]->measures.size();
+      int num_measures = (voices.empty()) ? 8 : voices[0]->get_num_measures();
       voices.insert(voices.begin() + index, new Row(num_measures));
    }
 }
@@ -150,7 +157,7 @@ void MeasureGrid::append_staff()
 {
    // TODO: IMPORTANT here we are depending on voices[0] to currectly
    // report the current number of measures
-   int num_measures = (voices.empty()) ? 8 : voices[0]->measures.size();
+   int num_measures = (voices.empty()) ? 8 : voices[0]->get_num_measures();
    voices.push_back(new Row(num_measures));
 }
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -15,10 +15,10 @@ MeasureGrid::Row::Row(int num_measures) : measures()
 
 
 
-Measure::Base *MeasureGrid::Row::operator[](unsigned int index)
+Measure::Base *MeasureGrid::Row::get_measure(int x_measure)
 {
-   if (index >= measures.size()) std::cout << "measure index out of bounds" << std::endl;
-   return measures[index];
+   if (x_measure < 0 || x_measure >= measures.size()) return nullptr;
+   return measures[x_measure];
 }
 
 
@@ -38,7 +38,10 @@ Measure::Base *MeasureGrid::get_measure(int x_measure, int y_staff)
    // bounds check
    if (!in_grid_range(x_measure, y_staff)) return nullptr;
 
-   return voices[y_staff][x_measure];
+   Row *row = &voices[y_staff];
+   if (!row) return nullptr;
+
+   return row->get_measure(x_measure);
 }
 
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -91,6 +91,14 @@ bool MeasureGrid::Row::erase_measure(int at_index)
 
 
 
+bool MeasureGrid::Row::append_measure(Measure::Base *measure)
+{
+   measures.push_back(measure);
+   return true;
+}
+
+
+
 ////// MeasureGrid
 
 
@@ -267,7 +275,7 @@ void MeasureGrid::append_measure()
       // warning, this is responsible for constructing the measures
       // that are appended.  This should likely be replaced by a
       // Voice::append_column();
-      voices[i]->measures.push_back(nullptr);
+      voices[i]->append_measure(nullptr);
    }
 }
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -58,6 +58,19 @@ bool MeasureGrid::Row::set_measure(int measure_x, Measure::Base *measure)
 
 
 
+bool MeasureGrid::Row::insert_measure(int at_index, Measure::Base *measure)
+{
+   // TODO move the bounds check to here
+   // behavior that < 0 inserts are corrected to 0 and
+   // >= size measures default to append() should probably be handled
+   // at the MeasureGrid layer, since it would need to be implement in
+   // all of the derived classes, and is expected behavior of the MeasureGrid
+   measures.insert(measures.begin() + at_index, measure);
+   return true;
+}
+
+
+
 ////// MeasureGrid
 
 
@@ -194,7 +207,7 @@ void MeasureGrid::insert_measure(int index)
          // number of measures (they likely may not once there are different "staff" types)
          // TODO: this method is "constructing" the voice.  Probably should not
          // be doing this here
-         voices[i]->measures.insert(voices[i]->measures.begin() + index, nullptr);
+         voices[i]->insert_measure(index, nullptr);
       }
    }
 }

--- a/src/models/staff.cpp
+++ b/src/models/staff.cpp
@@ -1,0 +1,10 @@
+
+
+
+namespace Staff
+{
+   int next_id = 0;
+};
+
+
+

--- a/src/models/staves/base.cpp
+++ b/src/models/staves/base.cpp
@@ -1,0 +1,41 @@
+
+
+
+#include <fullscore/models/staves/base.h>
+#include <fullscore/models/staff.h>
+
+
+
+Staff::Base::Base(std::string type)
+   : type(type)
+   , id(Staff::next_id++)
+{}
+
+
+
+Staff::Base::~Base()
+{}
+
+
+
+std::string Staff::Base::get_type()
+{
+   return type;
+}
+
+
+
+bool Staff::Base::is_type(std::string type)
+{
+   return type == type;
+}
+
+
+
+int Staff::Base::get_id()
+{
+   return id;
+}
+
+
+

--- a/src/models/time_signature.cpp
+++ b/src/models/time_signature.cpp
@@ -55,14 +55,14 @@ bool TimeSignature::set_denominator(Duration denominator)
 
 
 
-bool TimeSignature::operator==(TimeSignature &other)
+bool TimeSignature::operator==(const TimeSignature &other) const
 {
    return (numerator == other.numerator) && (denominator == other.denominator);
 }
 
 
 
-bool TimeSignature::operator!=(TimeSignature &other)
+bool TimeSignature::operator!=(const TimeSignature &other) const
 {
    return !(*this == other);
 }

--- a/src/transforms/base.cpp
+++ b/src/transforms/base.cpp
@@ -1,9 +1,7 @@
 
 
 
-
 #include <fullscore/transforms/base.h>
-
 
 
 
@@ -14,11 +12,9 @@ Transform::Base::Base(std::string identifier)
 
 
 
-
 Transform::Base::~Base()
 {
 }
-
 
 
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -240,7 +240,24 @@ TEST(MeasureGridTest, can_append_a_staff)
 
 TEST(MeasureGridTest, can_insert_a_measure)
 {
-   // skip
+   MeasureGrid measure_grid(3, 1);
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      measure_grid.set_time_signature(i, TimeSignature(3, Duration(Duration::QUARTER)));
+
+   measure_grid.insert_measure(1);
+
+   std::vector<TimeSignature> expected_time_signature_order = {
+      TimeSignature(3, Duration(Duration::QUARTER)),
+      TimeSignature(4, Duration(Duration::QUARTER)),
+      TimeSignature(3, Duration(Duration::QUARTER)),
+      TimeSignature(3, Duration(Duration::QUARTER)),
+   };
+
+   ASSERT_EQ(expected_time_signature_order.size(), measure_grid.get_num_measures());
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      ASSERT_EQ(expected_time_signature_order[i], measure_grid.get_time_signature(i));
 }
 
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -367,7 +367,21 @@ TEST(MeasureGridTest, when_attempting_to_delete_a_measure_lt_zero_or_gte_num_mea
 
 TEST(MeasureGridTest, can_append_a_measure)
 {
-   // skip
+   MeasureGrid measure_grid(1, 1);
+
+   measure_grid.set_time_signature(0, TimeSignature(3, Duration(Duration::QUARTER)));
+
+   measure_grid.append_measure();
+
+   std::vector<TimeSignature> expected_time_signature_order = {
+      TimeSignature(3, Duration(Duration::QUARTER)),
+      TimeSignature(4, Duration(Duration::QUARTER)),
+   };
+
+   ASSERT_EQ(expected_time_signature_order.size(), measure_grid.get_num_measures());
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      ASSERT_EQ(expected_time_signature_order[i], measure_grid.get_time_signature(i));
 }
 
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -141,7 +141,7 @@ TEST(MeasureGridTest, can_insert_a_staff)
 
 
 
-TEST(MeasureGridTest, when_inserting_a_staff_at_index_lt_zero_inserts_at_the_begingging)
+TEST(MeasureGridTest, when_inserting_a_staff_at_index_gte_the_number_of_staves__appends_to_the_end)
 {
    MeasureGrid measure_grid(1, 2);
 
@@ -160,7 +160,7 @@ TEST(MeasureGridTest, when_inserting_a_staff_at_index_lt_zero_inserts_at_the_beg
 
 
 
-TEST(MeasureGridTest, when_inserting_a_staff_at_index_gt_the_number_of_staves_appends_to_the_end)
+TEST(MeasureGridTest, when_inserting_a_staff_at_index_lt_zero__inserts_at_the_begingging)
 {
    MeasureGrid measure_grid(1, 2);
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -143,14 +143,38 @@ TEST(MeasureGridTest, can_insert_a_staff)
 
 TEST(MeasureGridTest, when_inserting_a_staff_at_index_lt_zero_inserts_at_the_begingging)
 {
-   // skip
+   MeasureGrid measure_grid(1, 2);
+
+   measure_grid.set_voice_name(0, "voice 0");
+   measure_grid.set_voice_name(1, "voice 1");
+
+   measure_grid.insert_staff(100);
+
+   std::vector<std::string> expected_voice_name_order = { "voice 0", "voice 1", "" };
+
+   ASSERT_EQ(expected_voice_name_order.size(), measure_grid.get_num_staves());
+
+   for (int i=0; i<expected_voice_name_order.size(); i++)
+      ASSERT_EQ(expected_voice_name_order[i], measure_grid.get_voice_name(i));
 }
 
 
 
 TEST(MeasureGridTest, when_inserting_a_staff_at_index_gt_the_number_of_staves_appends_to_the_end)
 {
-   // skip
+   MeasureGrid measure_grid(1, 2);
+
+   measure_grid.set_voice_name(0, "voice 0");
+   measure_grid.set_voice_name(1, "voice 1");
+
+   measure_grid.insert_staff(-100);
+
+   std::vector<std::string> expected_voice_name_order = { "", "voice 0", "voice 1" };
+
+   ASSERT_EQ(expected_voice_name_order.size(), measure_grid.get_num_staves());
+
+   for (int i=0; i<expected_voice_name_order.size(); i++)
+      ASSERT_EQ(expected_voice_name_order[i], measure_grid.get_voice_name(i));
 }
 
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -336,6 +336,35 @@ TEST(MeasureGridTest, can_delete_measure)
 
 
 
+TEST(MeasureGridTest, when_attempting_to_delete_a_measure_lt_zero_or_gte_num_measures__returns_false_and_does_nothing_to_the_score)
+{
+   int num_columns_to_test = 4;
+   MeasureGrid measure_grid(num_columns_to_test, 1);
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      measure_grid.set_time_signature(i, TimeSignature(i+1, Duration(Duration::QUARTER)));
+
+   ASSERT_EQ(false, measure_grid.delete_column(-1));
+   ASSERT_EQ(false, measure_grid.delete_column(measure_grid.get_num_measures()));
+   ASSERT_EQ(false, measure_grid.delete_column(999));
+
+   ASSERT_EQ(num_columns_to_test, measure_grid.get_num_measures());
+
+   std::vector<TimeSignature> expected_time_signature_order = {
+      TimeSignature(1, Duration(Duration::QUARTER)),
+      TimeSignature(2, Duration(Duration::QUARTER)),
+      TimeSignature(3, Duration(Duration::QUARTER)),
+      TimeSignature(4, Duration(Duration::QUARTER)),
+   };
+
+   ASSERT_EQ(expected_time_signature_order.size(), measure_grid.get_num_measures());
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      ASSERT_EQ(expected_time_signature_order[i], measure_grid.get_time_signature(i));
+}
+
+
+
 TEST(MeasureGridTest, can_append_a_measure)
 {
    // skip

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -315,7 +315,23 @@ TEST(MeasureGridTest, when_inserting_a_measure_at_index_gte_size__appends_measur
 
 TEST(MeasureGridTest, can_delete_measure)
 {
-   // skip
+   MeasureGrid measure_grid(4, 1);
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      measure_grid.set_time_signature(i, TimeSignature(i+1, Duration(Duration::QUARTER)));
+
+   measure_grid.delete_column(1);
+   measure_grid.delete_column(1);
+
+   std::vector<TimeSignature> expected_time_signature_order = {
+      TimeSignature(1, Duration(Duration::QUARTER)),
+      TimeSignature(4, Duration(Duration::QUARTER)),
+   };
+
+   ASSERT_EQ(expected_time_signature_order.size(), measure_grid.get_num_measures());
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      ASSERT_EQ(expected_time_signature_order[i], measure_grid.get_time_signature(i));
 }
 
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -262,6 +262,29 @@ TEST(MeasureGridTest, can_insert_a_measure)
 
 
 
+TEST(MeasureGridTest, when_inserting_a_measure_at_index_lt_zero__inserts_at_index_zero)
+{
+   MeasureGrid measure_grid(2, 1);
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      measure_grid.set_time_signature(i, TimeSignature(3, Duration(Duration::QUARTER)));
+
+   measure_grid.insert_measure(-999);
+
+   std::vector<TimeSignature> expected_time_signature_order = {
+      TimeSignature(4, Duration(Duration::QUARTER)),
+      TimeSignature(3, Duration(Duration::QUARTER)),
+      TimeSignature(3, Duration(Duration::QUARTER)),
+   };
+
+   ASSERT_EQ(expected_time_signature_order.size(), measure_grid.get_num_measures());
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      ASSERT_EQ(expected_time_signature_order[i], measure_grid.get_time_signature(i));
+}
+
+
+
 TEST(MeasureGridTest, can_delete_measure)
 {
    // skip

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -285,6 +285,34 @@ TEST(MeasureGridTest, when_inserting_a_measure_at_index_lt_zero__inserts_at_inde
 
 
 
+TEST(MeasureGridTest, when_inserting_a_measure_at_index_gte_size__appends_measure_at_the_end)
+{
+   MeasureGrid measure_grid(2, 1);
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      measure_grid.set_time_signature(i, TimeSignature(3, Duration(Duration::QUARTER)));
+
+   measure_grid.insert_measure(measure_grid.get_num_measures());
+
+   measure_grid.set_time_signature(2, TimeSignature(2, Duration(Duration::QUARTER)));
+
+   measure_grid.insert_measure(999);
+
+   std::vector<TimeSignature> expected_time_signature_order = {
+      TimeSignature(3, Duration(Duration::QUARTER)),
+      TimeSignature(3, Duration(Duration::QUARTER)),
+      TimeSignature(2, Duration(Duration::QUARTER)),
+      TimeSignature(4, Duration(Duration::QUARTER)),
+   };
+
+   ASSERT_EQ(expected_time_signature_order.size(), measure_grid.get_num_measures());
+
+   for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
+      ASSERT_EQ(expected_time_signature_order[i], measure_grid.get_time_signature(i));
+}
+
+
+
 TEST(MeasureGridTest, can_delete_measure)
 {
    // skip

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <fullscore/models/measures/basic.h>
 #include <fullscore/models/measure.h>
 #include <fullscore/models/measure_grid.h>
 #include <fullscore/models/note.h>

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -113,6 +113,43 @@ TEST(MeasureGridTest, returns_false_if_coordinates_are_outside_the_measure_grid)
 
 TEST(MeasureGridTest, can_insert_a_staff)
 {
+   MeasureGrid measure_grid(1, 3);
+
+   measure_grid.set_voice_name(0, "voice 0");
+   measure_grid.set_voice_name(1, "voice 1");
+   measure_grid.set_voice_name(2, "voice 2");
+
+   measure_grid.insert_staff(1);
+   measure_grid.set_voice_name(1, "inserted voice 1");
+
+   measure_grid.insert_staff(3);
+   measure_grid.set_voice_name(3, "inserted voice 2");
+
+   std::vector<std::string> expected_voice_name_order = {
+      "voice 0",
+      "inserted voice 1",
+      "voice 1",
+      "inserted voice 2",
+      "voice 2",
+   };
+
+   ASSERT_EQ(expected_voice_name_order.size(), measure_grid.get_num_staves());
+
+   for (int i=0; i<expected_voice_name_order.size(); i++)
+      ASSERT_EQ(expected_voice_name_order[i], measure_grid.get_voice_name(i));
+}
+
+
+
+TEST(MeasureGridTest, when_inserting_a_staff_at_index_lt_zero_inserts_at_the_begingging)
+{
+   // skip
+}
+
+
+
+TEST(MeasureGridTest, when_inserting_a_staff_at_index_gt_the_number_of_staves_appends_to_the_end)
+{
    // skip
 }
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -217,7 +217,19 @@ TEST(MeasureGridTest, when_attempting_to_delete_a_staff_that_is_out_of_bounds__r
 
 TEST(MeasureGridTest, can_append_a_staff)
 {
-   // skip
+   MeasureGrid measure_grid(1, 2);
+
+   measure_grid.set_voice_name(0, "voice 0");
+   measure_grid.set_voice_name(1, "voice 1");
+
+   measure_grid.append_staff();
+
+   std::vector<std::string> expected_voice_name_order = { "voice 0", "voice 1", "" };
+
+   ASSERT_EQ(expected_voice_name_order.size(), measure_grid.get_num_staves());
+
+   for (int i=0; i<expected_voice_name_order.size(); i++)
+      ASSERT_EQ(expected_voice_name_order[i], measure_grid.get_voice_name(i));
 }
 
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -199,6 +199,22 @@ TEST(MeasureGridTest, can_delete_staff)
 
 
 
+TEST(MeasureGridTest, when_attempting_to_delete_a_staff_that_is_out_of_bounds__returns_false)
+{
+   MeasureGrid measure_grid(1, 3);
+
+   measure_grid.set_voice_name(0, "voice 0");
+   measure_grid.set_voice_name(1, "voice 1");
+   measure_grid.set_voice_name(2, "voice 2");
+
+   EXPECT_EQ(false, measure_grid.delete_staff(-1));
+   EXPECT_EQ(false, measure_grid.delete_staff(7));
+
+   ASSERT_EQ(3, measure_grid.get_num_staves());
+}
+
+
+
 TEST(MeasureGridTest, can_append_a_staff)
 {
    // skip

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -181,7 +181,20 @@ TEST(MeasureGridTest, when_inserting_a_staff_at_index_gt_the_number_of_staves_ap
 
 TEST(MeasureGridTest, can_delete_staff)
 {
-   // skip
+   MeasureGrid measure_grid(1, 3);
+
+   measure_grid.set_voice_name(0, "voice 0");
+   measure_grid.set_voice_name(1, "voice 1");
+   measure_grid.set_voice_name(2, "voice 2");
+
+   EXPECT_EQ(true, measure_grid.delete_staff(1));
+
+   std::vector<std::string> expected_voice_name_order = { "voice 0", "voice 2" };
+
+   ASSERT_EQ(expected_voice_name_order.size(), measure_grid.get_num_staves());
+
+   for (int i=0; i<expected_voice_name_order.size(); i++)
+      ASSERT_EQ(expected_voice_name_order[i], measure_grid.get_voice_name(i));
 }
 
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -148,9 +148,13 @@ TEST(MeasureGridTest, when_inserting_a_staff_at_index_gte_the_number_of_staves__
    measure_grid.set_voice_name(0, "voice 0");
    measure_grid.set_voice_name(1, "voice 1");
 
+   measure_grid.insert_staff(measure_grid.get_num_staves());
+
+   measure_grid.set_voice_name(2, "inserted voice 1");
+
    measure_grid.insert_staff(100);
 
-   std::vector<std::string> expected_voice_name_order = { "voice 0", "voice 1", "" };
+   std::vector<std::string> expected_voice_name_order = { "voice 0", "voice 1", "inserted voice 1", "" };
 
    ASSERT_EQ(expected_voice_name_order.size(), measure_grid.get_num_staves());
 

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -111,6 +111,62 @@ TEST(MeasureGridTest, returns_false_if_coordinates_are_outside_the_measure_grid)
 
 
 
+TEST(MeasureGridTest, can_insert_a_staff)
+{
+   // skip
+}
+
+
+
+TEST(MeasureGridTest, can_delete_staff)
+{
+   // skip
+}
+
+
+
+TEST(MeasureGridTest, can_append_a_staff)
+{
+   // skip
+}
+
+
+
+TEST(MeasureGridTest, can_insert_a_measure)
+{
+   // skip
+}
+
+
+
+TEST(MeasureGridTest, can_delete_measure)
+{
+   // skip
+}
+
+
+
+TEST(MeasureGridTest, can_append_a_measure)
+{
+   // skip
+}
+
+
+
+TEST(MeasureGridTest, can_get_and_set_a_time_signature)
+{
+   // skip
+}
+
+
+
+TEST(MeasureGridTest, can_get_a_pointer_to_a_time_signature)
+{
+   // skip
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/transforms/copy_test.cpp
+++ b/tests/transforms/copy_test.cpp
@@ -5,6 +5,7 @@
 
 #include <fullscore/transforms/copy_transform.h>
 
+#include <fullscore/models/measures/basic.h>
 #include <fullscore/models/measure_grid.h>
 
 

--- a/tests/transforms/reference_test.cpp
+++ b/tests/transforms/reference_test.cpp
@@ -5,6 +5,7 @@
 
 #include <fullscore/transforms/reference_transform.h>
 
+#include <fullscore/models/measures/basic.h>
 #include <fullscore/models/measure_grid.h>
 
 


### PR DESCRIPTION
## Problem

We want to start having different staff types.  This will allow a lot of different features, including cosmetic spacers between instrument groups and grand staves, in addition to the simple instrument staves that are in use now.  (the terms "voices", "staves", and "rows" are mostly synonyms at this point)

If it makes sense this could also lead to:

* staves for transposing instruments (or clef settings)
* time signature staff (concurrent different signatures could occur in the score)
* tempo staff
* rehearsal marks
* measure numbers rendering staves
* midi control

## This PR

Before measure types can be added, the `MeasureGrid` needs to be refactored in the following way:

1. `MeasureGrid` needs to have `std::vector<Row *>` rather than `std::vector<Row>`.  This is mostly what is refactored in this PR.
2. A new class, `Staff::Base *` is introduced.

A lot of tests were added for `MeasureGrid` so that the newly modified `std::vector<Row *>` is less likely to break anything.

## After this PR

Next step is to replace `MeasureGrid::Row` with `Staff::Base`, and then begin factoring out an abstraction that can be used when rendering and accessing measures/contents in rows.