### PR TITLE
Add Spacer Staff Type

### DIFF
--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -24,6 +24,8 @@ private:
 
 public:
    MeasureGrid(int num_x_measures, int num_y_staves);
+   ~MeasureGrid();
+
    Measure::Base *get_measure(int x_measure, int y_staff);
    bool set_measure(int x_measure, int y_staff, Measure::Base *measure);
    bool delete_measure(int x_measure, int y_staff);
@@ -33,9 +35,9 @@ public:
    int get_num_staves() const;
    int get_num_measures() const;
 
-   void insert_staff(int index);
+   bool insert_staff(Staff::Base *staff, int index);
    bool delete_staff(int index);
-   void append_staff();
+   bool append_staff(Staff::Base *staff);
 
    void insert_column(int index);
    bool delete_column(int index);

--- a/include/fullscore/models/staves/base.h
+++ b/include/fullscore/models/staves/base.h
@@ -20,9 +20,6 @@ namespace Staff
       int id;
       std::string name;
 
-   protected:
-      std::vector<Measure::Base *> columns;
-
    public:
       Base(std::string type);
       virtual ~Base();
@@ -32,7 +29,7 @@ namespace Staff
       void set_name(std::string name);
       std::string get_name();
 
-      int get_num_columns();
+      virtual int get_num_columns() = 0;
 
       virtual bool set_column(int column_num, Measure::Base *measure) = 0;
       virtual bool insert_column(int at_index, Measure::Base *measure) = 0;

--- a/include/fullscore/models/staves/instrument.h
+++ b/include/fullscore/models/staves/instrument.h
@@ -10,16 +10,20 @@ namespace Staff
 {
    class Instrument : public Base
    {
+   private:
+      std::vector<Measure::Base *> columns;
+
    public:
       Instrument(int num_columns);
       ~Instrument();
 
+      virtual int get_num_columns() override;
+
+      virtual Measure::Base *get_measure(int column_num) override;
       virtual bool set_column(int column_num, Measure::Base *measure) override;
       virtual bool insert_column(int at_index, Measure::Base *measure) override;
       virtual bool erase_column(int at_index) override;
       virtual bool append_column(Measure::Base *measure) override;
-
-      virtual Measure::Base *get_measure(int column_num) override;
    };
 };
 

--- a/include/fullscore/models/staves/spacer.h
+++ b/include/fullscore/models/staves/spacer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+
+
+#include <fullscore/models/staves/base.h>
+
+
+
+namespace Staff
+{
+   class Spacer : public Base
+   {
+   public:
+      Spacer(int num_columns);
+      ~Spacer();
+
+      virtual int get_num_columns() override;
+
+      virtual Measure::Base *get_measure(int column_num) override;
+      virtual bool set_column(int column_num, Measure::Base *measure) override;
+      virtual bool insert_column(int at_index, Measure::Base *measure) override;
+      virtual bool erase_column(int at_index) override;
+      virtual bool append_column(Measure::Base *measure) override;
+   };
+};
+
+
+

--- a/src/actions/append_staff_action.cpp
+++ b/src/actions/append_staff_action.cpp
@@ -4,6 +4,7 @@
 
 #include <fullscore/actions/append_staff_action.h>
 
+#include <fullscore/models/staves/instrument.h>
 #include <fullscore/models/measure_grid.h>
 
 
@@ -27,7 +28,7 @@ bool Action::AppendStaff::execute()
 {
    if (!measure_grid) return false;
 
-   measure_grid->append_staff();
+   measure_grid->append_staff(new Staff::Instrument(measure_grid->get_num_measures()));
 
    return false;
 }

--- a/src/actions/insert_staff_action.cpp
+++ b/src/actions/insert_staff_action.cpp
@@ -4,6 +4,7 @@
 
 #include <fullscore/actions/insert_staff_action.h>
 
+#include <fullscore/models/staves/instrument.h>
 #include <fullscore/models/measure_grid.h>
 
 
@@ -29,7 +30,7 @@ bool Action::InsertStaff::execute()
    if (!measure_grid) return false;
    if (at_index < 0 || at_index >= measure_grid->get_num_staves()) return false;
 
-   measure_grid->insert_staff(at_index);
+   measure_grid->insert_staff(new Staff::Instrument(measure_grid->get_num_measures()), at_index);
 
    return true;
 }

--- a/src/factories/measure_grid_factory.cpp
+++ b/src/factories/measure_grid_factory.cpp
@@ -3,9 +3,15 @@
 
 #include <fullscore/factories/measure_grid_factory.h>
 #include <fullscore/models/measures/basic.h>
+#include <fullscore/models/staves/instrument.h>
+#include <fullscore/models/staves/spacer.h>
 #include <fullscore/models/note.h>
 #include <allegro_flare/useful.h>
 #include <iostream>
+
+
+
+std::string const SPACER = "-";
 
 
 
@@ -45,30 +51,44 @@ MeasureGrid MeasureGridFactory::full_score()
       "Flute I",
       "Flute II",
       "Flute III",
+      SPACER,
       "Oboe",
       "English Horn",
+      SPACER,
       "Clarinet I",
       "Clarinet II",
       "Clarinet III",
+      SPACER,
       "Bassoon I",
       "Bassoon II",
+      SPACER,
+      SPACER,
       "Trumpet I",
       "Trumpet II",
       "Trumpet III",
+      SPACER,
       "F Horn I",
       "F Horn II",
       "F Horn III",
       "F Horn IV",
+      SPACER,
       "Trombone I",
       "Trombone II",
       "Trombone III",
       "Bass Trombone",
+      SPACER,
       "Tuba",
+      SPACER,
+      SPACER,
       "Percussion I",
       "Percussion II",
       "Percussion III",
+      SPACER,
       "Piano {Grand Staff}",
+      SPACER,
       "Harp {Grand Staff}",
+      SPACER,
+      SPACER,
       "Violin I",
       "Violin II",
       "Viola",
@@ -76,10 +96,20 @@ MeasureGrid MeasureGridFactory::full_score()
       "Bass",
    };
 
-   MeasureGrid measure_grid(20, voices.size());
+   MeasureGrid measure_grid(20, 0);
 
    for (int i=0; i<voices.size(); i++)
-      measure_grid.set_voice_name(i, voices[i]);
+   {
+      if (voices[i] == SPACER)
+      {
+         measure_grid.append_staff(new Staff::Spacer(20));
+      }
+      else
+      {
+         measure_grid.append_staff(new Staff::Instrument(20));
+         measure_grid.set_voice_name(i, voices[i]);
+      }
+   }
 
    return measure_grid;
 }

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -20,6 +20,13 @@ MeasureGrid::MeasureGrid(int num_x_measures, int num_y_staves)
 
 
 
+MeasureGrid::~MeasureGrid()
+{
+   for (int i=voices.size(); i>=0; i--) if (voices[i]) delete voices[i];
+}
+
+
+
 Measure::Base *MeasureGrid::get_measure(int x_measure, int y_staff)
 {
    // bounds check
@@ -81,21 +88,16 @@ int MeasureGrid::get_num_staves() const
 
 
 
-void MeasureGrid::insert_staff(int index)
+bool MeasureGrid::insert_staff(Staff::Base *staff, int index)
 {
+   if (!staff) return false;
+
    if (index < 0) index = 0;
 
-   if (index >= (int)voices.size())
-   {
-      append_staff();
-   }
-   else 
-   {
-      // TODO: IMPORTANT here we are depending on voices[0] to currectly
-      // report the current number of measures
-      int num_measures = (voices.empty()) ? 8 : voices[0]->get_num_columns();
-      voices.insert(voices.begin() + index, new Staff::Instrument(num_measures));
-   }
+   if (index >= (int)voices.size()) return append_staff(staff);
+   else voices.insert(voices.begin() + index, staff);
+
+   return true;
 }
 
 
@@ -110,12 +112,11 @@ bool MeasureGrid::delete_staff(int index)
 
 
 
-void MeasureGrid::append_staff()
+bool MeasureGrid::append_staff(Staff::Base *staff)
 {
-   // TODO: IMPORTANT here we are depending on voices[0] to currectly
-   // report the current number of measures
-   int num_measures = (voices.empty()) ? 8 : voices[0]->get_num_columns();
-   voices.push_back(new Staff::Instrument(num_measures));
+   if (!staff) return false;
+   voices.push_back(staff);
+   return true;
 }
 
 

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -22,7 +22,9 @@ MeasureGrid::MeasureGrid(int num_x_measures, int num_y_staves)
 
 MeasureGrid::~MeasureGrid()
 {
-   for (int i=voices.size(); i>=0; i--) if (voices[i]) delete voices[i];
+   // these should likely be destructed here or handled in some way other than being left dangling,
+   // but a measure grid is frequently created elsewhere and returned in a function
+   //for (int i=voices.size(); i>=0; i--) if (voices[i]) delete voices[i];
 }
 
 

--- a/src/models/staves/base.cpp
+++ b/src/models/staves/base.cpp
@@ -11,16 +11,12 @@ Staff::Base::Base(std::string type)
    : type(type)
    , id(Staff::next_id++)
    , name()
-   , columns()
 {}
 
 
 
 Staff::Base::~Base()
 {
-   if (!columns.empty())
-      for (int i=columns.size()-1; i>=0; i--)
-         delete columns[i];
 }
 
 
@@ -56,13 +52,6 @@ void Staff::Base::set_name(std::string name)
 std::string Staff::Base::get_name()
 {
    return name;
-}
-
-
-
-int Staff::Base::get_num_columns()
-{
-   return columns.size();
 }
 
 

--- a/src/models/staves/instrument.cpp
+++ b/src/models/staves/instrument.cpp
@@ -9,6 +9,7 @@
 
 Staff::Instrument::Instrument(int num_columns)
    : Base("instrument")
+   , columns()
 {
    for (unsigned i=0; i<num_columns; i++) columns.push_back(nullptr);
 }
@@ -16,7 +17,18 @@ Staff::Instrument::Instrument(int num_columns)
 
 
 Staff::Instrument::~Instrument()
-{}
+{
+   if (!columns.empty())
+      for (int i=columns.size()-1; i>=0; i--)
+         delete columns[i];
+}
+
+
+
+int Staff::Instrument::get_num_columns()
+{
+   return columns.size();
+}
 
 
 

--- a/src/models/staves/spacer.cpp
+++ b/src/models/staves/spacer.cpp
@@ -1,0 +1,62 @@
+
+
+
+#include <fullscore/models/staves/spacer.h>
+
+#include <fullscore/models/measures/base.h>
+
+
+
+Staff::Spacer::Spacer(int num_columns)
+   : Base("spacer")
+{}
+
+
+
+Staff::Spacer::~Spacer()
+{}
+
+
+
+bool Staff::Spacer::set_column(int column_num, Measure::Base *measure)
+{
+   throw std::runtime_error("Cannot set a measure on a Spacer column");
+}
+
+
+
+bool Staff::Spacer::insert_column(int at_index, Measure::Base *measure)
+{
+   return true;
+}
+
+
+
+bool Staff::Spacer::erase_column(int at_index)
+{
+   return true;
+}
+
+
+
+bool Staff::Spacer::append_column(Measure::Base *measure)
+{
+   return true;
+}
+
+
+
+Measure::Base *Staff::Spacer::get_measure(int column_num)
+{
+   return nullptr;
+}
+
+
+
+int Staff::Spacer::get_num_columns()
+{
+   return 0;
+}
+
+
+

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -146,7 +146,7 @@ TEST(MeasureGridTest, when_inserting_a_nullptr_staff_returns_false)
 {
    MeasureGrid measure_grid(1, 1);
 
-   measure_grid.insert_staff(nullptr, 1);
+   ASSERT_EQ(false, measure_grid.insert_staff(nullptr, 1));
 
    ASSERT_EQ(1, measure_grid.get_num_staves());
 }

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 
+#include <fullscore/models/staves/instrument.h>
 #include <fullscore/models/measures/basic.h>
 #include <fullscore/models/measure.h>
 #include <fullscore/models/measure_grid.h>
@@ -119,10 +120,10 @@ TEST(MeasureGridTest, can_insert_a_staff)
    measure_grid.set_voice_name(1, "voice 1");
    measure_grid.set_voice_name(2, "voice 2");
 
-   measure_grid.insert_staff(1);
+   measure_grid.insert_staff(new Staff::Instrument(measure_grid.get_num_measures()), 1);
    measure_grid.set_voice_name(1, "inserted voice 1");
 
-   measure_grid.insert_staff(3);
+   measure_grid.insert_staff(new Staff::Instrument(measure_grid.get_num_measures()), 3);
    measure_grid.set_voice_name(3, "inserted voice 2");
 
    std::vector<std::string> expected_voice_name_order = {
@@ -141,6 +142,17 @@ TEST(MeasureGridTest, can_insert_a_staff)
 
 
 
+TEST(MeasureGridTest, when_inserting_a_nullptr_staff_returns_false)
+{
+   MeasureGrid measure_grid(1, 1);
+
+   measure_grid.insert_staff(nullptr, 1);
+
+   ASSERT_EQ(1, measure_grid.get_num_staves());
+}
+
+
+
 TEST(MeasureGridTest, when_inserting_a_staff_at_index_gte_the_number_of_staves__appends_to_the_end)
 {
    MeasureGrid measure_grid(1, 2);
@@ -148,11 +160,11 @@ TEST(MeasureGridTest, when_inserting_a_staff_at_index_gte_the_number_of_staves__
    measure_grid.set_voice_name(0, "voice 0");
    measure_grid.set_voice_name(1, "voice 1");
 
-   measure_grid.insert_staff(measure_grid.get_num_staves());
+   measure_grid.insert_staff(new Staff::Instrument(measure_grid.get_num_measures()), measure_grid.get_num_staves());
 
    measure_grid.set_voice_name(2, "inserted voice 1");
 
-   measure_grid.insert_staff(100);
+   measure_grid.insert_staff(new Staff::Instrument(measure_grid.get_num_measures()), 100);
 
    std::vector<std::string> expected_voice_name_order = { "voice 0", "voice 1", "inserted voice 1", "" };
 
@@ -171,7 +183,7 @@ TEST(MeasureGridTest, when_inserting_a_staff_at_index_lt_zero__inserts_at_the_be
    measure_grid.set_voice_name(0, "voice 0");
    measure_grid.set_voice_name(1, "voice 1");
 
-   measure_grid.insert_staff(-100);
+   measure_grid.insert_staff(new Staff::Instrument(measure_grid.get_num_measures()), -100);
 
    std::vector<std::string> expected_voice_name_order = { "", "voice 0", "voice 1" };
 
@@ -226,7 +238,7 @@ TEST(MeasureGridTest, can_append_a_staff)
    measure_grid.set_voice_name(0, "voice 0");
    measure_grid.set_voice_name(1, "voice 1");
 
-   measure_grid.append_staff();
+   measure_grid.append_staff(new Staff::Instrument(measure_grid.get_num_staves()));
 
    std::vector<std::string> expected_voice_name_order = { "voice 0", "voice 1", "" };
 
@@ -234,6 +246,17 @@ TEST(MeasureGridTest, can_append_a_staff)
 
    for (int i=0; i<expected_voice_name_order.size(); i++)
       ASSERT_EQ(expected_voice_name_order[i], measure_grid.get_voice_name(i));
+}
+
+
+
+TEST(MeasureGridTest, when_appending_a_nullptr_staff_returns_false)
+{
+   MeasureGrid measure_grid(1, 1);
+
+   ASSERT_EQ(false, measure_grid.append_staff(nullptr));
+
+   ASSERT_EQ(1, measure_grid.get_num_measures());
 }
 
 


### PR DESCRIPTION
## Problem

Would be nice to have some dividers between the different instrument groups in the score.

## Solution

Now that staff types are in place, we can add new staff types.  Add `Staff::Spacer` type.

This required a lot of refactoring in the `MeasureGrid` which assumes that inserting (or appending) any staff will always be a `Staff::Instrument` type.  Now, the staff needs to be created externally via `new` and passed as an argument.  This caused a few cracks in the code.  These adjustments are included in this PR.

![fullscore 2017-08-05 00-02-36](https://user-images.githubusercontent.com/772949/28992692-6a41a292-7971-11e7-8505-4044b6c0a4c7.png)

Future adjustments might include having a staff report its height, and rendering bar lines within staves instead of across all staves.