### PR TITLE
Allow Different Staff Heights

### DIFF
--- a/include/fullscore/helpers/measure_grid_helper.h
+++ b/include/fullscore/helpers/measure_grid_helper.h
@@ -10,6 +10,7 @@ class MeasureGridHelper
 public:
    static float get_length_to_measure(const MeasureGrid &measure_grid, int measure_index);
    static float get_height_to_staff(const MeasureGrid &measure_grid, int staff_index);
+   static float get_height_of_staff(MeasureGrid &measure_grid, int staff_index);
 };
 
 

--- a/include/fullscore/helpers/measure_grid_helper.h
+++ b/include/fullscore/helpers/measure_grid_helper.h
@@ -9,6 +9,7 @@ class MeasureGridHelper
 {
 public:
    static float get_length_to_measure(const MeasureGrid &measure_grid, int measure_index);
+   static float get_height_to_staff(const MeasureGrid &measure_grid, int staff_index);
 };
 
 

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -51,7 +51,7 @@ public:
    TimeSignature get_time_signature(int index);
    TimeSignature *get_time_signature_ptr(int index); // consider removing this method (having the dependent action rely on a *measure_grid and measure number)
 
-   float get_height();
+   float get_height() const;
 };
 
 

--- a/include/fullscore/models/measure_grid.h
+++ b/include/fullscore/models/measure_grid.h
@@ -35,6 +35,7 @@ public:
    int get_num_staves() const;
    int get_num_measures() const;
 
+   Staff::Base *get_staff(int y_staff);
    bool insert_staff(Staff::Base *staff, int index);
    bool delete_staff(int index);
    bool append_staff(Staff::Base *staff);
@@ -49,6 +50,8 @@ public:
    bool set_time_signature(int index, TimeSignature time_signature);
    TimeSignature get_time_signature(int index);
    TimeSignature *get_time_signature_ptr(int index); // consider removing this method (having the dependent action rely on a *measure_grid and measure number)
+
+   float get_height();
 };
 
 

--- a/include/fullscore/models/staves/base.h
+++ b/include/fullscore/models/staves/base.h
@@ -30,6 +30,7 @@ namespace Staff
       std::string get_name();
 
       virtual int get_num_columns() = 0;
+      virtual float get_height() = 0;
 
       virtual bool set_column(int column_num, Measure::Base *measure) = 0;
       virtual bool insert_column(int at_index, Measure::Base *measure) = 0;

--- a/include/fullscore/models/staves/instrument.h
+++ b/include/fullscore/models/staves/instrument.h
@@ -18,6 +18,7 @@ namespace Staff
       ~Instrument();
 
       virtual int get_num_columns() override;
+      virtual float get_height() override;
 
       virtual Measure::Base *get_measure(int column_num) override;
       virtual bool set_column(int column_num, Measure::Base *measure) override;

--- a/include/fullscore/models/staves/spacer.h
+++ b/include/fullscore/models/staves/spacer.h
@@ -15,6 +15,7 @@ namespace Staff
       ~Spacer();
 
       virtual int get_num_columns() override;
+      virtual float get_height() override;
 
       virtual Measure::Base *get_measure(int column_num) override;
       virtual bool set_column(int column_num, Measure::Base *measure) override;

--- a/src/helpers/measure_grid_helper.cpp
+++ b/src/helpers/measure_grid_helper.cpp
@@ -4,6 +4,7 @@
 
 #include <fullscore/helpers/measure_grid_helper.h>
 
+#include <fullscore/models/staves/base.h>
 #include <fullscore/helpers/duration_helper.h>
 #include <fullscore/models/measure_grid.h>
 
@@ -21,6 +22,25 @@ float MeasureGridHelper::get_length_to_measure(const MeasureGrid &measure_grid, 
       length += DurationHelper::get_length(measure_grid.time_signatures[i]);
 
    return length;
+}
+
+
+
+
+float MeasureGridHelper::get_height_to_staff(const MeasureGrid &measure_grid, int staff_index)
+{
+   if (staff_index < 0) return 0.0;
+   if (staff_index >= measure_grid.get_num_staves()) return measure_grid.get_height();
+
+   float height = 0;
+   for (unsigned i=0; i<staff_index; i++)
+   {
+      Staff::Base *staff = measure_grid.voices[i];
+      if (!staff) throw std::runtime_error("Cannot get_height_to_staff with a nullptr staff");
+      height += staff->get_height();
+   }
+
+   return height;
 }
 
 

--- a/src/helpers/measure_grid_helper.cpp
+++ b/src/helpers/measure_grid_helper.cpp
@@ -46,3 +46,13 @@ float MeasureGridHelper::get_height_to_staff(const MeasureGrid &measure_grid, in
 
 
 
+float MeasureGridHelper::get_height_of_staff(MeasureGrid &measure_grid, int staff_index) // TODO make const
+{
+   Staff::Base *staff = measure_grid.get_staff(staff_index);
+   if (!staff) return 0.0;
+   return staff->get_height();
+}
+
+
+
+

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -220,6 +220,27 @@ bool MeasureGrid::set_time_signature(int index, TimeSignature time_signature)
 
 
 
+float MeasureGrid::get_height()
+{
+   float height = 0;
+   for (int i=0; i<get_num_staves(); i++)
+      if (voices[i]) height += voices[i]->get_height();
+   return height;
+}
+
+
+
+Staff::Base *MeasureGrid::get_staff(int y_staff)
+{
+   if (y_staff < 0 || y_staff >= voices.size()) return nullptr;
+
+   Staff::Base *staff = voices[y_staff];
+   if (!staff) return nullptr;
+   return staff;
+}
+
+
+
 TimeSignature MeasureGrid::get_time_signature(int index)
 {
    if (index < 0) return TimeSignature(0, Duration());

--- a/src/models/measure_grid.cpp
+++ b/src/models/measure_grid.cpp
@@ -220,7 +220,7 @@ bool MeasureGrid::set_time_signature(int index, TimeSignature time_signature)
 
 
 
-float MeasureGrid::get_height()
+float MeasureGrid::get_height() const
 {
    float height = 0;
    for (int i=0; i<get_num_staves(); i++)

--- a/src/models/staves/instrument.cpp
+++ b/src/models/staves/instrument.cpp
@@ -32,6 +32,13 @@ int Staff::Instrument::get_num_columns()
 
 
 
+float Staff::Instrument::get_height()
+{
+   return 1.0;
+}
+
+
+
 bool Staff::Instrument::set_column(int column_num, Measure::Base *measure)
 {
    if (column_num < 0) return false;

--- a/src/models/staves/spacer.cpp
+++ b/src/models/staves/spacer.cpp
@@ -60,3 +60,10 @@ int Staff::Spacer::get_num_columns()
 
 
 
+float Staff::Spacer::get_height()
+{
+   return 0.5;
+}
+
+
+

--- a/src/widgets/measure_grid_editor.cpp
+++ b/src/widgets/measure_grid_editor.cpp
@@ -94,20 +94,20 @@ void UIMeasureGridEditor::on_draw()
 
       // measure box outline
       if (is_measure_target_mode())
-         al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, measure_cursor_y*STAFF_HEIGHT,
-            CACHED_get_measure_cursor_real_x+measure_width, measure_cursor_y*STAFF_HEIGHT+STAFF_HEIGHT,
+         al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
+            CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+STAFF_HEIGHT,
             4, 4, color::color(color::black, 0.3), 2.0);
    }
 
    // measure box fill
-   al_draw_filled_rounded_rectangle(CACHED_get_measure_cursor_real_x, measure_cursor_y*STAFF_HEIGHT,
-      CACHED_get_measure_cursor_real_x+measure_width, measure_cursor_y*STAFF_HEIGHT+STAFF_HEIGHT,
+   al_draw_filled_rounded_rectangle(CACHED_get_measure_cursor_real_x, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
+      CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+STAFF_HEIGHT,
       4, 4, color::color(color::aliceblue, 0.2));
 
    // measure box outline
    if (is_measure_target_mode())
-      al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, measure_cursor_y*STAFF_HEIGHT,
-         CACHED_get_measure_cursor_real_x+measure_width, measure_cursor_y*STAFF_HEIGHT+STAFF_HEIGHT,
+      al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
+         CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+STAFF_HEIGHT,
          4, 4, color::color(color::aliceblue, 0.7), 2.0);
 
    // left bar (blinking)
@@ -205,7 +205,7 @@ float UIMeasureGridEditor::get_measure_cursor_real_x()
 
 float UIMeasureGridEditor::get_measure_cursor_real_y()
 {
-   return measure_cursor_y * STAFF_HEIGHT;
+   return MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y) * STAFF_HEIGHT;
 }
 
 

--- a/src/widgets/measure_grid_editor.cpp
+++ b/src/widgets/measure_grid_editor.cpp
@@ -55,7 +55,7 @@ void UIMeasureGridEditor::on_draw()
 {
    // get_width_of_score
    float measure_grid_real_width = MeasureGridHelper::get_length_to_measure(measure_grid, measure_grid.get_num_measures()) * FULL_MEASURE_WIDTH;
-   float measure_grid_real_height = measure_grid.get_num_staves() * STAFF_HEIGHT;
+   float measure_grid_real_height = measure_grid.get_height() * STAFF_HEIGHT;
 
    // draw the bounding box for the widget
    float pt, pr, pb, pl;

--- a/src/widgets/measure_grid_editor.cpp
+++ b/src/widgets/measure_grid_editor.cpp
@@ -95,26 +95,26 @@ void UIMeasureGridEditor::on_draw()
       // measure box outline
       if (is_measure_target_mode())
          al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
-            CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+STAFF_HEIGHT,
+            CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+MeasureGridHelper::get_height_of_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
             4, 4, color::color(color::black, 0.3), 2.0);
    }
 
    // measure box fill
    al_draw_filled_rounded_rectangle(CACHED_get_measure_cursor_real_x, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
-      CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+STAFF_HEIGHT,
+      CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+MeasureGridHelper::get_height_of_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
       4, 4, color::color(color::aliceblue, 0.2));
 
    // measure box outline
    if (is_measure_target_mode())
       al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
-         CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+STAFF_HEIGHT,
+         CACHED_get_measure_cursor_real_x+measure_width, MeasureGridHelper::get_height_to_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT+MeasureGridHelper::get_height_of_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
          4, 4, color::color(color::aliceblue, 0.7), 2.0);
 
    // left bar (blinking)
 
    ALLEGRO_COLOR cursor_color = color::color(color::white, sin(Framework::time_now*5) + 0.5);
    al_draw_line(CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y,
-         CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y+STAFF_HEIGHT,
+         CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y+MeasureGridHelper::get_height_of_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
          cursor_color, 3.0);
 
    // draw a hilight box at the focused note
@@ -128,7 +128,7 @@ void UIMeasureGridEditor::on_draw()
             CACHED_get_measure_cursor_real_x + note_real_offset_x,
             CACHED_get_measure_cursor_real_y,
             CACHED_get_measure_cursor_real_x + note_real_offset_x + real_note_width,
-            CACHED_get_measure_cursor_real_y + STAFF_HEIGHT,
+            CACHED_get_measure_cursor_real_y + MeasureGridHelper::get_height_of_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
             6,
             6,
             color::color(color::pink, 0.4)
@@ -140,7 +140,7 @@ void UIMeasureGridEditor::on_draw()
                CACHED_get_measure_cursor_real_x + note_real_offset_x,
                CACHED_get_measure_cursor_real_y,
                CACHED_get_measure_cursor_real_x + note_real_offset_x + real_note_width,
-               CACHED_get_measure_cursor_real_y + STAFF_HEIGHT,
+               CACHED_get_measure_cursor_real_y + MeasureGridHelper::get_height_of_staff(measure_grid, measure_cursor_y)*STAFF_HEIGHT,
                6,
                6,
                color::mix(color::color(color::pink, 0.8), color::black, 0.3),

--- a/tests/measure_grid_helper_test.cpp
+++ b/tests/measure_grid_helper_test.cpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 
+#include <fullscore/models/staves/instrument.h>
+#include <fullscore/models/staves/spacer.h>
 #include <fullscore/helpers/measure_grid_helper.h>
 #include <fullscore/models/measure_grid.h>
 #include <fullscore/models/note.h>
@@ -51,6 +53,32 @@ TEST(MeasureGridHelperTest, returns_the_length_to_the_measure_with_non_4_4_time_
    ASSERT_EQ(MeasureGridHelper::get_length_to_measure(measure_grid, 4), 3.0625); // + 0.3125
    ASSERT_EQ(MeasureGridHelper::get_length_to_measure(measure_grid, 5), 5.5625); // + 2.5
    ASSERT_EQ(MeasureGridHelper::get_length_to_measure(measure_grid, 6), 6.6875); // + 1.125
+}
+
+
+
+
+TEST(MeasureGridHelperTest, can_get_its_height)
+{
+   MeasureGrid measure_grid(1, 0);
+
+   Staff::Instrument instrument1(1);
+   Staff::Spacer spacer1(1);
+   Staff::Instrument instrument2(1);
+   Staff::Spacer spacer2(1);
+   Staff::Spacer spacer3(1);
+
+   measure_grid.append_staff(&instrument1);
+   measure_grid.append_staff(&spacer1);
+   measure_grid.append_staff(&instrument2);
+   measure_grid.append_staff(&spacer2);
+   measure_grid.append_staff(&spacer3);
+
+   ASSERT_EQ(0.0, MeasureGridHelper::get_height_to_staff(measure_grid, 0));
+   ASSERT_EQ(1.0, MeasureGridHelper::get_height_to_staff(measure_grid, 1));
+   ASSERT_EQ(1.5, MeasureGridHelper::get_height_to_staff(measure_grid, 2));
+   ASSERT_EQ(2.5, MeasureGridHelper::get_height_to_staff(measure_grid, 3));
+   ASSERT_EQ(3.0, MeasureGridHelper::get_height_to_staff(measure_grid, 4));
 }
 
 

--- a/tests/measure_grid_helper_test.cpp
+++ b/tests/measure_grid_helper_test.cpp
@@ -84,6 +84,32 @@ TEST(MeasureGridHelperTest, can_get_its_height)
 
 
 
+TEST(MeasureGridHelperTest, can_get_height_of_a_staff)
+{
+   MeasureGrid measure_grid(1, 0);
+
+   Staff::Instrument instrument1(1);
+   Staff::Spacer spacer1(1);
+   Staff::Instrument instrument2(1);
+   Staff::Spacer spacer2(1);
+   Staff::Spacer spacer3(1);
+
+   measure_grid.append_staff(&instrument1);
+   measure_grid.append_staff(&spacer1);
+   measure_grid.append_staff(&instrument2);
+   measure_grid.append_staff(&spacer2);
+   measure_grid.append_staff(&spacer3);
+
+   ASSERT_EQ(1.0, MeasureGridHelper::get_height_of_staff(measure_grid, 0));
+   ASSERT_EQ(0.5, MeasureGridHelper::get_height_of_staff(measure_grid, 1));
+   ASSERT_EQ(1.0, MeasureGridHelper::get_height_of_staff(measure_grid, 2));
+   ASSERT_EQ(0.5, MeasureGridHelper::get_height_of_staff(measure_grid, 3));
+   ASSERT_EQ(0.5, MeasureGridHelper::get_height_of_staff(measure_grid, 4));
+}
+
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/measure_grid_test.cpp
+++ b/tests/measure_grid_test.cpp
@@ -5,6 +5,8 @@
 
 #include <fullscore/models/staves/instrument.h>
 #include <fullscore/models/measures/basic.h>
+#include <fullscore/models/staves/instrument.h>
+#include <fullscore/models/staves/spacer.h>
 #include <fullscore/models/measure.h>
 #include <fullscore/models/measure_grid.h>
 #include <fullscore/models/note.h>
@@ -405,6 +407,76 @@ TEST(MeasureGridTest, can_append_a_measure)
 
    for (unsigned i=0; i<measure_grid.get_num_measures(); i++)
       ASSERT_EQ(expected_time_signature_order[i], measure_grid.get_time_signature(i));
+}
+
+
+
+TEST(MeasureGridTest, can_get_its_height)
+{
+   MeasureGrid measure_grid(1, 0);
+
+   Staff::Instrument instrument1(1);
+   Staff::Instrument instrument2(1);
+   Staff::Spacer spacer1(1);
+   Staff::Spacer spacer2(1);
+   Staff::Spacer spacer3(1);
+
+   measure_grid.append_staff(&instrument1);
+   measure_grid.append_staff(&instrument2);
+   measure_grid.append_staff(&spacer1);
+   measure_grid.append_staff(&spacer2);
+   measure_grid.append_staff(&spacer3);
+
+   ASSERT_EQ(3.5, measure_grid.get_height());
+}
+
+
+
+TEST(MeasureGridTest, can_get_a_staff)
+{
+   MeasureGrid measure_grid(1, 0);
+
+   Staff::Instrument instrument1(1);
+   Staff::Instrument instrument2(1);
+   Staff::Spacer spacer1(1);
+   Staff::Spacer spacer2(1);
+   Staff::Spacer spacer3(1);
+
+   measure_grid.append_staff(&instrument1);
+   measure_grid.append_staff(&instrument2);
+   measure_grid.append_staff(&spacer1);
+   measure_grid.append_staff(&spacer2);
+   measure_grid.append_staff(&spacer3);
+
+   ASSERT_EQ(&instrument1, measure_grid.get_staff(0));
+   ASSERT_EQ(&instrument2, measure_grid.get_staff(1));
+   ASSERT_EQ(&spacer1, measure_grid.get_staff(2));
+   ASSERT_EQ(&spacer2, measure_grid.get_staff(3));
+   ASSERT_EQ(&spacer3, measure_grid.get_staff(4));
+}
+
+
+
+TEST(MeasureGridTest, when_getting_a_staff_out_of_bounds__returns_nullptr)
+{
+   MeasureGrid measure_grid(0, 1);
+
+   Staff::Instrument instrument1(1);
+   Staff::Instrument instrument2(1);
+   Staff::Spacer spacer1(1);
+   Staff::Spacer spacer2(1);
+   Staff::Spacer spacer3(1);
+
+   measure_grid.append_staff(&instrument1);
+   measure_grid.append_staff(&instrument2);
+   measure_grid.append_staff(&spacer1);
+   measure_grid.append_staff(&spacer2);
+   measure_grid.append_staff(&spacer3);
+
+   ASSERT_EQ(nullptr, measure_grid.get_staff(-1));
+   ASSERT_EQ(nullptr, measure_grid.get_staff(-100));
+   ASSERT_EQ(nullptr, measure_grid.get_staff(measure_grid.get_num_staves()));
+   ASSERT_EQ(nullptr, measure_grid.get_staff(9999));
 }
 
 

--- a/tests/models/staves/instrument_test.cpp
+++ b/tests/models/staves/instrument_test.cpp
@@ -1,0 +1,33 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/staves/instrument.h>
+
+
+
+TEST(Staff_InstrumentTest, can_be_created)
+{
+   Staff::Instrument instrument(1);
+}
+
+
+
+TEST(Staff_InstrumentTest, returns_a_staff_height_of_1)
+{
+   Staff::Instrument instrument(1);
+
+   ASSERT_EQ(1.0, instrument.get_height());
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/models/staves/spacer_test.cpp
+++ b/tests/models/staves/spacer_test.cpp
@@ -1,0 +1,33 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/staves/spacer.h>
+
+
+
+TEST(Staff_SpacerTest, can_be_created)
+{
+   Staff::Spacer instrument(1);
+}
+
+
+
+TEST(Staff_SpacerTest, returns_a_staff_height_of_0_5)
+{
+   Staff::Spacer instrument(1);
+
+   ASSERT_EQ(0.5, instrument.get_height());
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
## Problem

Staves are all the same height, regardless of type.  Different types should be able to set their own custom height.

## Solution

* Add a pure virtual `get_height()` function to `Staff::Base`
* Update the rendering so that there can be varying heights of staves

![fullscore 2017-08-05 02-14-57](https://user-images.githubusercontent.com/772949/28993419-e5da0fd6-7983-11e7-95b9-a86a95aeba29.png)
