### PR TITLE
Append Note To a Measure With KEY_A

### DIFF
--- a/include/fullscore/actions/transforms/append_note_action.h
+++ b/include/fullscore/actions/transforms/append_note_action.h
@@ -2,11 +2,9 @@
 
 
 
-
 #include <vector>
 #include <fullscore/actions/action_base.h>
 #include <fullscore/models/note.h>
-
 
 
 
@@ -25,7 +23,6 @@ namespace Action
       bool execute() override;
    };
 };
-
 
 
 

--- a/include/fullscore/actions/transforms/append_note_action.h
+++ b/include/fullscore/actions/transforms/append_note_action.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+
+#include <vector>
+#include <fullscore/actions/action_base.h>
+#include <fullscore/models/note.h>
+
+
+
+
+namespace Action
+{
+   class AppendNoteTransform : public Base
+   {
+   private:
+      std::vector<Note> *notes;
+      Note note;
+
+   public:
+      AppendNoteTransform(std::vector<Note> *notes, Note note);
+      ~AppendNoteTransform();
+
+      bool execute() override;
+   };
+};
+
+
+
+

--- a/include/fullscore/transforms/append_note_transform.h
+++ b/include/fullscore/transforms/append_note_transform.h
@@ -1,0 +1,25 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+#include <fullscore/models/note.h>
+
+
+
+namespace Transform
+{
+   class AppendNote : public Base
+   {
+   public:
+      Note note;
+
+      AppendNote(Note note);
+      ~AppendNote();
+      virtual std::vector<Note> transform(std::vector<Note> n) override;
+   };
+}
+
+
+

--- a/src/actions/transforms/append_note_action.cpp
+++ b/src/actions/transforms/append_note_action.cpp
@@ -1,0 +1,38 @@
+
+
+
+
+#include <fullscore/actions/transforms/append_note_action.h>
+
+#include <fullscore/transforms/append_note_transform.h>
+
+
+
+Action::AppendNoteTransform::AppendNoteTransform(std::vector<Note> *notes, Note note)
+   : Base("append_note")
+   , notes(notes)
+   , note(note)
+{}
+
+
+
+
+Action::AppendNoteTransform::~AppendNoteTransform()
+{}
+
+
+
+
+bool Action::AppendNoteTransform::execute()
+{
+   if (!notes) throw std::runtime_error("Cannot append note to NULL notes");
+
+   ::Transform::AppendNote append_note_transform(note);
+   *notes = append_note_transform.transform(*notes);
+
+   return true;
+}
+
+
+
+

--- a/src/actions/transforms/append_note_action.cpp
+++ b/src/actions/transforms/append_note_action.cpp
@@ -1,7 +1,6 @@
 
 
 
-
 #include <fullscore/actions/transforms/append_note_action.h>
 
 #include <fullscore/transforms/append_note_transform.h>
@@ -16,10 +15,8 @@ Action::AppendNoteTransform::AppendNoteTransform(std::vector<Note> *notes, Note 
 
 
 
-
 Action::AppendNoteTransform::~AppendNoteTransform()
 {}
-
 
 
 
@@ -32,7 +29,6 @@ bool Action::AppendNoteTransform::execute()
 
    return true;
 }
-
 
 
 

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -4,6 +4,7 @@
 
 #include <fullscore/app_controller.h>
 
+#include <fullscore/actions/transforms/append_note_action.h>
 #include <fullscore/actions/transforms/add_dot_transform_action.h>
 #include <fullscore/actions/transforms/clear_measure_transform_action.h>
 #include <fullscore/actions/transforms/double_duration_transform_action.h>
@@ -118,6 +119,7 @@ std::string AppController::find_action_identifier(UIMeasureGridEditor::mode_t mo
          else if (edit_mode_target == UIMeasureGridEditor::edit_mode_target_t::MEASURE_TARGET) { return "delete_measure"; }
          break;
       case ALLEGRO_KEY_Z: return "retrograde"; break;
+      case ALLEGRO_KEY_A: return "append_note"; break;
       case ALLEGRO_KEY_I: return "insert_note"; break;
       case ALLEGRO_KEY_F2: return "toggle_show_debug_data"; break;
       case ALLEGRO_KEY_SPACE: return "toggle_playback"; break;
@@ -292,6 +294,8 @@ Action::Base *AppController::create_action(std::string action_name)
       action = new Action::Octatonic1Transform(notes);
    else if (action_name == "insert_note")
       action = new Action::InsertNoteTransform(notes, current_measure_grid_editor->note_cursor_x, Note());
+   else if (action_name == "append_note")
+      action = new Action::AppendNoteTransform(notes, Note());
    else if (action_name == "toggle_show_debug_data")
       action = new Action::ToggleShowDebugData(current_measure_grid_editor);
    else if (action_name == "toggle_playback")

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -119,7 +119,7 @@ std::string AppController::find_action_identifier(UIMeasureGridEditor::mode_t mo
          else if (edit_mode_target == UIMeasureGridEditor::edit_mode_target_t::MEASURE_TARGET) { return "delete_measure"; }
          break;
       case ALLEGRO_KEY_Z: return "retrograde"; break;
-      case ALLEGRO_KEY_A: return "append_note"; break;
+      case ALLEGRO_KEY_A: return "insert_note_after"; break;
       case ALLEGRO_KEY_I: return "insert_note"; break;
       case ALLEGRO_KEY_F2: return "toggle_show_debug_data"; break;
       case ALLEGRO_KEY_SPACE: return "toggle_playback"; break;
@@ -294,8 +294,12 @@ Action::Base *AppController::create_action(std::string action_name)
       action = new Action::Octatonic1Transform(notes);
    else if (action_name == "insert_note")
       action = new Action::InsertNoteTransform(notes, current_measure_grid_editor->note_cursor_x, Note());
-   else if (action_name == "append_note")
-      action = new Action::AppendNoteTransform(notes, Note());
+   else if (action_name == "insert_note_after")
+   {
+      action = new Action::Queue("insert_note_after: insert_note and move_cursor_right");
+      static_cast<Action::Queue *>(action)->add_action(new Action::InsertNoteTransform(notes, current_measure_grid_editor->note_cursor_x+1, Note()));
+      static_cast<Action::Queue *>(action)->add_action(new Action::MoveCursorRight(current_measure_grid_editor));
+   }
    else if (action_name == "toggle_show_debug_data")
       action = new Action::ToggleShowDebugData(current_measure_grid_editor);
    else if (action_name == "toggle_playback")

--- a/src/transforms/append_note_transform.cpp
+++ b/src/transforms/append_note_transform.cpp
@@ -1,0 +1,36 @@
+
+
+
+
+#include <fullscore/transforms/append_note_transform.h>
+
+#include <allegro_flare/useful.h>
+
+
+
+
+Transform::AppendNote::AppendNote(Note note)
+   : Base("append_note")
+   , note(note)
+{
+}
+
+
+
+
+Transform::AppendNote::~AppendNote()
+{
+}
+
+
+
+
+std::vector<Note> Transform::AppendNote::transform(std::vector<Note> notes)
+{
+	notes.push_back(note);
+   return notes;
+}
+
+
+
+

--- a/src/transforms/append_note_transform.cpp
+++ b/src/transforms/append_note_transform.cpp
@@ -1,11 +1,9 @@
 
 
 
-
 #include <fullscore/transforms/append_note_transform.h>
 
 #include <allegro_flare/useful.h>
-
 
 
 
@@ -17,20 +15,17 @@ Transform::AppendNote::AppendNote(Note note)
 
 
 
-
 Transform::AppendNote::~AppendNote()
 {
 }
 
 
 
-
 std::vector<Note> Transform::AppendNote::transform(std::vector<Note> notes)
 {
-	notes.push_back(note);
+   notes.push_back(note);
    return notes;
 }
-
 
 
 

--- a/src/transforms/insert_note_transform.cpp
+++ b/src/transforms/insert_note_transform.cpp
@@ -28,7 +28,7 @@ Transform::InsertNote::~InsertNote()
 
 std::vector<Note> Transform::InsertNote::transform(std::vector<Note> notes)
 {
-   position = limit<int>(0, notes.size()-1, position);
+   position = limit<int>(0, notes.size(), position);
 	notes.insert(notes.begin() + position, note);
    return notes;
 }

--- a/tests/transforms/insert_note_test.cpp
+++ b/tests/transforms/insert_note_test.cpp
@@ -1,0 +1,39 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/transforms/insert_note_transform.h>
+
+
+
+TEST(InsertNoteTransformTest, can_insert_notes_at_the_end)
+{
+   std::vector<Note> notes = {
+      Note(2),
+      Note(3),
+   };
+
+   Transform::InsertNote insert_note_transform(notes.size(), Note(4));
+
+   std::vector<Note> expected_notes = {
+      Note(2),
+      Note(3),
+      Note(4),
+   };
+
+   std::vector<Note> returned_notes = insert_note_transform.transform(notes);
+
+   ASSERT_EQ(expected_notes, returned_notes);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
## Problem

It's only possible to insert notes prior to the cursor.  This is kind of annoying because usually you're almost always appending notes when building a measure.

## Solution

Append notes to a measure with `KEY_A`.  This is done by creating an `Action::Queue` that 1) uses `InsertNote` to put a note after the cursor position and a 2) `MoveCursorRight` action to move the cursor to the newly created note.

Also, along the way, I created an `AppendNote` action.  But it appends a note to the measure and wasn't really useful for this purpose.  I've left it in because why not. 🙂