### PR TITLE
Have Horizontal Guideline on Staves

### DIFF
--- a/include/fullscore/helpers/measure_grid_helper.h
+++ b/include/fullscore/helpers/measure_grid_helper.h
@@ -11,6 +11,7 @@ public:
    static float get_length_to_measure(const MeasureGrid &measure_grid, int measure_index);
    static float get_height_to_staff(const MeasureGrid &measure_grid, int staff_index);
    static float get_height_of_staff(MeasureGrid &measure_grid, int staff_index);
+   static float get_width(const MeasureGrid &measure_grid);
 };
 
 

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -92,6 +92,13 @@ void MeasureGridRenderComponent::render()
       float label_text_top_y = row_middle_y - al_get_font_line_height(text_font) * 0.5;
       al_draw_text(text_font, color::black, -30, label_text_top_y, ALLEGRO_ALIGN_RIGHT, measure_grid->get_voice_name(y).c_str());
 
+      // horizontal guide line for the staff
+      if (staff->is_type("instrument"))
+      {
+         float width = MeasureGridHelper::get_width(*measure_grid);
+         al_draw_line(0, row_middle_y, width * full_measure_width, row_middle_y, color::color(color::black, 0.2), 1.0);
+      }
+
       // draw the measures
       for (int x=0; x<measure_grid->get_num_measures(); x++)
       {

--- a/src/components/measure_grid_render_component.cpp
+++ b/src/components/measure_grid_render_component.cpp
@@ -66,9 +66,6 @@ void MeasureGridRenderComponent::render()
       TimeSignature time_signature = measure_grid->get_time_signature(x);
       TimeSignatureRenderComponent time_signature_render_component(&time_signature);
 
-      // draw barline
-      al_draw_line(x_pos, 0, x_pos, staff_height * measure_grid->get_height(), color::color(color::black, 0.2), 1.0);
-
       // draw time signature
       if (time_signature != previous_time_signature) time_signature_render_component.render(x_pos, -50);
 
@@ -84,6 +81,7 @@ void MeasureGridRenderComponent::render()
       if (!staff) continue;
 
       float this_staff_height = staff_height * staff->get_height();
+      float this_staff_half_height = this_staff_height * 0.5;
 
       ALLEGRO_FONT *text_font = Framework::font("DroidSans.ttf 20");
 
@@ -102,9 +100,21 @@ void MeasureGridRenderComponent::render()
       // draw the measures
       for (int x=0; x<measure_grid->get_num_measures(); x++)
       {
-         // draw the reference_cursor
          float x_pos = MeasureGridHelper::get_length_to_measure(*measure_grid, x) * full_measure_width;
+         float x_pos_plus_width = MeasureGridHelper::get_length_to_measure(*measure_grid, x+1) * full_measure_width;
 
+         if (staff->is_type("instrument"))
+         {
+            // draw barline
+            al_draw_line(x_pos_plus_width, row_middle_y-this_staff_half_height, x_pos_plus_width, row_middle_y+this_staff_half_height, color::color(color::black, 0.2), 1.0);
+         }
+         if (staff->is_type("measure_numbers"))
+         {
+            al_draw_text(text_font, color::black, x_pos+5, label_text_top_y, ALLEGRO_ALIGN_LEFT, tostring(x).c_str());
+            continue;
+         }
+
+         // draw the reference_cursor
          bool draw_reference_cursor = (y == reference_cursor_y && x == reference_cursor_x);
          if (draw_reference_cursor)
          {
@@ -119,12 +129,7 @@ void MeasureGridRenderComponent::render()
                   color::darkorange);
          }
 
-         if (staff->is_type("measure_numbers"))
-         {
-            al_draw_text(text_font, color::black, x_pos+5, label_text_top_y, ALLEGRO_ALIGN_LEFT, tostring(x).c_str());
-            continue;
-         }
-
+         // draw the measure
          Measure::Base *measure = measure_grid->get_measure(x,y);
          if (!measure) continue;
 

--- a/src/helpers/measure_grid_helper.cpp
+++ b/src/helpers/measure_grid_helper.cpp
@@ -27,6 +27,17 @@ float MeasureGridHelper::get_length_to_measure(const MeasureGrid &measure_grid, 
 
 
 
+float MeasureGridHelper::get_width(const MeasureGrid &measure_grid)
+{
+   float length = 0;
+   for (unsigned i=0; i<measure_grid.time_signatures.size(); i++)
+      length += DurationHelper::get_length(measure_grid.time_signatures[i]);
+   return length;
+}
+
+
+
+
 float MeasureGridHelper::get_height_to_staff(const MeasureGrid &measure_grid, int staff_index)
 {
    if (staff_index < 0) return 0.0;

--- a/tests/measure_grid_helper_test.cpp
+++ b/tests/measure_grid_helper_test.cpp
@@ -58,7 +58,25 @@ TEST(MeasureGridHelperTest, returns_the_length_to_the_measure_with_non_4_4_time_
 
 
 
-TEST(MeasureGridHelperTest, can_get_its_height)
+TEST(MeasureGridHelperTest, can_get_the_width_of_a_measure_grid)
+{
+   MeasureGrid measure_grid(0, 1);
+
+   measure_grid.append_measure();
+   measure_grid.append_measure();
+   measure_grid.append_measure();
+   measure_grid.append_measure();
+   measure_grid.append_measure();
+
+   measure_grid.set_time_signature(3, TimeSignature(3, Duration(Duration::EIGHTH)));
+
+   ASSERT_EQ(4.375, MeasureGridHelper::get_width(measure_grid));
+}
+
+
+
+
+TEST(MeasureGridHelperTest, can_get_its_height_up_to_a_staff)
 {
    MeasureGrid measure_grid(1, 0);
 


### PR DESCRIPTION
## Problem

Horizontal visual clues for staves could be improved.

## Solution

Render `Staff::Instrument` type staves with a horizontal guideline.  Also, only render barlines at the staff level, not at the global `MeasureGrid` level.

![fullscore 2017-08-05 11-39-12](https://user-images.githubusercontent.com/772949/28996666-e53ea808-79d2-11e7-8331-5996b34dc7f1.png)