### PR TITLE
Improve UX Design Clues of Measure; Add Actions

### DIFF
--- a/include/fullscore/actions/transforms/Ascend.h
+++ b/include/fullscore/actions/transforms/Ascend.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+#include <vector>
+#include <fullscore/actions/base.h>
+
+
+
+class Note;
+
+namespace Action
+{
+   namespace Transform
+   {
+      class Ascend : public Base
+      {
+      private:
+         std::vector<Note> *notes;
+
+      public:
+         Ascend(std::vector<Note> *notes);
+         ~Ascend();
+
+         bool execute() override;
+      };
+   }
+}
+
+
+

--- a/include/fullscore/actions/transforms/Descend.h
+++ b/include/fullscore/actions/transforms/Descend.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+#include <vector>
+#include <fullscore/actions/base.h>
+
+
+
+class Note;
+
+namespace Action
+{
+   namespace Transform
+   {
+      class Descend : public Base
+      {
+      private:
+         std::vector<Note> *notes;
+
+      public:
+         Descend(std::vector<Note> *notes);
+         ~Descend();
+
+         bool execute() override;
+      };
+   }
+}
+
+
+

--- a/include/fullscore/actions/transforms/SplitNote.h
+++ b/include/fullscore/actions/transforms/SplitNote.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+#include <vector>
+#include <fullscore/actions/base.h>
+
+
+
+class Note;
+
+namespace Action
+{
+   namespace Transform
+   {
+      class SplitNote : public Base
+      {
+      private:
+         std::vector<Note> *notes;
+
+      public:
+         SplitNote(std::vector<Note> *notes);
+         ~SplitNote();
+
+         bool execute() override;
+      };
+   };
+};
+
+
+

--- a/include/fullscore/transforms/ascend_transform.h
+++ b/include/fullscore/transforms/ascend_transform.h
@@ -1,0 +1,22 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+
+
+namespace Transform
+{
+   class Ascend : public Base
+   {
+   public:
+      Ascend();
+      ~Ascend();
+
+      virtual std::vector<Note> transform(std::vector<Note> n) override;
+   };
+};
+
+
+

--- a/include/fullscore/transforms/descend_transform.h
+++ b/include/fullscore/transforms/descend_transform.h
@@ -1,0 +1,22 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+
+
+namespace Transform
+{
+   class Descend : public Base
+   {
+   public:
+      Descend();
+      ~Descend();
+
+      virtual std::vector<Note> transform(std::vector<Note> n) override;
+   };
+};
+
+
+

--- a/include/fullscore/transforms/split_note_transform.h
+++ b/include/fullscore/transforms/split_note_transform.h
@@ -1,0 +1,22 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+
+
+namespace Transform
+{
+   class SplitNote : public Base
+   {
+   public:
+      SplitNote();
+      ~SplitNote();
+
+      virtual std::vector<Note> transform(std::vector<Note> n) override;
+   };
+}
+
+
+

--- a/src/actions/transforms/Ascend.cpp
+++ b/src/actions/transforms/Ascend.cpp
@@ -1,0 +1,33 @@
+
+
+
+#include <fullscore/actions/transforms/Ascend.h>
+
+#include <fullscore/transforms/ascend_transform.h>
+#include <fullscore/models/Note.h>
+
+
+
+Action::Transform::Ascend::Ascend(std::vector<Note> *notes)
+   : Base("ascend")
+   , notes(notes)
+{}
+
+
+
+Action::Transform::Ascend::~Ascend()
+{}
+
+
+
+bool Action::Transform::Ascend::execute()
+{
+   if (!notes) throw std::runtime_error("Cannot perform Ascend action on nullptr notes");
+
+   *notes = ::Transform::Ascend().transform(*notes);
+
+   return true;
+}
+
+
+

--- a/src/actions/transforms/Descend.cpp
+++ b/src/actions/transforms/Descend.cpp
@@ -1,0 +1,33 @@
+
+
+
+#include <fullscore/actions/transforms/Descend.h>
+
+#include <fullscore/transforms/descend_transform.h>
+#include <fullscore/models/Note.h>
+
+
+
+Action::Transform::Descend::Descend(std::vector<Note> *notes)
+   : Base("descend")
+   , notes(notes)
+{}
+
+
+
+Action::Transform::Descend::~Descend()
+{}
+
+
+
+bool Action::Transform::Descend::execute()
+{
+   if (!notes) throw std::runtime_error("Cannot perform Descend action on nullptr notes");
+
+   *notes = ::Transform::Descend().transform(*notes);
+
+   return true;
+}
+
+
+

--- a/src/actions/transforms/SplitNote.cpp
+++ b/src/actions/transforms/SplitNote.cpp
@@ -1,0 +1,34 @@
+
+
+
+#include <fullscore/actions/transforms/SplitNote.h>
+
+#include <fullscore/transforms/split_note_transform.h>
+#include <fullscore/models/Note.h>
+
+
+
+Action::Transform::SplitNote::SplitNote(std::vector<Note> *notes)
+   : Base("split_note")
+   , notes(notes)
+{}
+
+
+
+Action::Transform::SplitNote::~SplitNote()
+{}
+
+
+
+bool Action::Transform::SplitNote::execute()
+{
+   if (!notes) throw std::runtime_error("Cannot split_note on nullptr notes");
+
+   ::Transform::SplitNote split_note_transform;
+   *notes = split_note_transform.transform(*notes);
+
+   return true;
+}
+
+
+

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -107,7 +107,8 @@ std::string AppController::find_action_identifier(UIGridEditor::mode_t mode, UIG
       {
       case ALLEGRO_KEY_F: return "transpose_up"; break;
       case ALLEGRO_KEY_D: return "transpose_down"; break;
-      case ALLEGRO_KEY_S: if (shift) { return "set_stack_measure"; } else { return "half_duration"; } break;
+      case ALLEGRO_KEY_3: if (shift) { return "set_stack_measure"; } break; // #
+      case ALLEGRO_KEY_S: return "half_duration"; break;
       case ALLEGRO_KEY_G: return "double_duration"; break;
       case ALLEGRO_KEY_7: if (shift) { return "set_reference_by_id_measure"; } break;
       case ALLEGRO_KEY_8: if (shift) { return "set_reference_by_coordinate_measure"; } break;

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -125,7 +125,9 @@ std::string AppController::find_action_identifier(UIGridEditor::mode_t mode, UIG
       case ALLEGRO_KEY_A:
          if (edit_mode_target == UIGridEditor::edit_mode_target_t::NOTE_TARGET) { return "insert_note_after"; }
          break;
-      case ALLEGRO_KEY_I: return "insert_note"; break;
+      case ALLEGRO_KEY_I:
+         if (edit_mode_target == UIGridEditor::edit_mode_target_t::NOTE_TARGET) { return "insert_note"; }
+         break;
       case ALLEGRO_KEY_F2: return "toggle_show_debug_data"; break;
       case ALLEGRO_KEY_SPACE: return "toggle_playback"; break;
       case ALLEGRO_KEY_Q: return "reset_playback"; break;

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -4,9 +4,11 @@
 
 #include <fullscore/app_controller.h>
 
-#include <fullscore/actions/transforms/AppendNote.h>
 #include <fullscore/actions/transforms/AddDot.h>
+#include <fullscore/actions/transforms/AppendNote.h>
+#include <fullscore/actions/transforms/Ascend.h>
 #include <fullscore/actions/transforms/ClearMeasure.h>
+#include <fullscore/actions/transforms/Descend.h>
 #include <fullscore/actions/transforms/DoubleDuration.h>
 #include <fullscore/actions/transforms/EraseNote.h>
 #include <fullscore/actions/transforms/HalfDuration.h>
@@ -106,8 +108,14 @@ std::string AppController::find_action_identifier(UIGridEditor::mode_t mode, UIG
    if (mode == UIGridEditor::NORMAL_MODE)
       switch(al_keycode)
       {
-      case ALLEGRO_KEY_F: return "transpose_up"; break;
-      case ALLEGRO_KEY_D: return "transpose_down"; break;
+      case ALLEGRO_KEY_F:
+         if (ctrl && edit_mode_target == UIGridEditor::edit_mode_target_t::MEASURE_TARGET) { return "ascend"; }
+         return "transpose_up";
+         break;
+      case ALLEGRO_KEY_D:
+         if (ctrl && edit_mode_target == UIGridEditor::edit_mode_target_t::MEASURE_TARGET) { return "descend"; }
+         return "transpose_down";
+         break;
       case ALLEGRO_KEY_S: if (shift) { return "split_note"; }; return "half_duration"; break;
       case ALLEGRO_KEY_G: return "double_duration"; break;
       case ALLEGRO_KEY_7: if (shift) { return "set_reference_by_id_measure"; } break;
@@ -303,6 +311,10 @@ Action::Base *AppController::create_action(std::string action_name)
    }
    else if (action_name == "erase_note")
       action = new Action::Transform::EraseNote(notes, current_grid_editor->note_cursor_x);
+   else if (action_name == "ascend")
+      action = new Action::Transform::Ascend(notes);
+   else if (action_name == "descend")
+      action = new Action::Transform::Descend(notes);
    else if (action_name == "add_dot")
       action = new Action::Transform::AddDot(single_note);
    else if (action_name == "remove_dot")

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -287,10 +287,19 @@ Action::Base *AppController::create_action(std::string action_name)
          return action_queue;
       }
    }
+   else if (action_name == "invert")
+   {
+      if (current_grid_editor->is_note_target_mode()) action = new Action::Transform::Invert(single_note);
+      else
+      {
+         if (!notes) { std::cout << "cannot invert_note on nullptr notes" << std::endl; return nullptr; }
+         Action::Queue *action_queue = new Action::Queue(action_name);
+         for (auto &note : *notes) action_queue->add_action(new Action::Transform::Invert(&note));
+         return action_queue;
+      }
+   }
    else if (action_name == "erase_note")
       action = new Action::Transform::EraseNote(notes, current_grid_editor->note_cursor_x);
-   else if (action_name == "invert")
-      action = new Action::Transform::Invert(single_note, 0);
    else if (action_name == "add_dot")
       action = new Action::Transform::AddDot(single_note);
    else if (action_name == "remove_dot")

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -122,7 +122,9 @@ std::string AppController::find_action_identifier(UIGridEditor::mode_t mode, UIG
          else if (edit_mode_target == UIGridEditor::edit_mode_target_t::MEASURE_TARGET) { return "delete_measure"; }
          break;
       case ALLEGRO_KEY_Z: return "retrograde"; break;
-      case ALLEGRO_KEY_A: return "insert_note_after"; break;
+      case ALLEGRO_KEY_A:
+         if (edit_mode_target == UIGridEditor::edit_mode_target_t::NOTE_TARGET) { return "insert_note_after"; }
+         break;
       case ALLEGRO_KEY_I: return "insert_note"; break;
       case ALLEGRO_KEY_F2: return "toggle_show_debug_data"; break;
       case ALLEGRO_KEY_SPACE: return "toggle_playback"; break;

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -15,6 +15,7 @@
 #include <fullscore/actions/transforms/Octatonic1.h>
 #include <fullscore/actions/transforms/RemoveDot.h>
 #include <fullscore/actions/transforms/Retrograde.h>
+#include <fullscore/actions/transforms/SplitNote.h>
 #include <fullscore/actions/transforms/ToggleRest.h>
 #include <fullscore/actions/transforms/TransposeUp.h>
 #include <fullscore/actions/transforms/TransposeDown.h>
@@ -107,8 +108,7 @@ std::string AppController::find_action_identifier(UIGridEditor::mode_t mode, UIG
       {
       case ALLEGRO_KEY_F: return "transpose_up"; break;
       case ALLEGRO_KEY_D: return "transpose_down"; break;
-      case ALLEGRO_KEY_3: if (shift) { return "set_stack_measure"; } break; // #
-      case ALLEGRO_KEY_S: return "half_duration"; break;
+      case ALLEGRO_KEY_S: if (shift) { return "split_note"; }; return "half_duration"; break;
       case ALLEGRO_KEY_G: return "double_duration"; break;
       case ALLEGRO_KEY_7: if (shift) { return "set_reference_by_id_measure"; } break;
       case ALLEGRO_KEY_8: if (shift) { return "set_reference_by_coordinate_measure"; } break;
@@ -146,7 +146,7 @@ std::string AppController::find_action_identifier(UIGridEditor::mode_t mode, UIG
       case ALLEGRO_KEY_O: return "octatonic_1_transform"; break;
       case ALLEGRO_KEY_TAB: return "toggle_edit_mode_target"; break;
       case ALLEGRO_KEY_2: return "set_time_signature_numerator_2"; break;
-      case ALLEGRO_KEY_3: return "set_time_signature_numerator_3"; break;
+      case ALLEGRO_KEY_3: if (shift) { return "set_stack_measure"; }; return "set_time_signature_numerator_3"; break;
       case ALLEGRO_KEY_4: return "set_time_signature_numerator_4"; break;
       case ALLEGRO_KEY_5: return "set_time_signature_numerator_5"; break;
       }
@@ -311,6 +311,8 @@ Action::Base *AppController::create_action(std::string action_name)
       action = new Action::SetCommandMode(current_grid_editor, command_bar);
    else if (action_name == "set_normal_mode")
       action = new Action::SetNormalMode(current_grid_editor, command_bar);
+   else if (action_name == "split_note")
+      action = new Action::Transform::SplitNote(notes);
    else if (action_name == "retrograde")
       action = new Action::Transform::Retrograde(notes);
    else if (action_name == "octatonic_1_transform")

--- a/src/transforms/ascend_transform.cpp
+++ b/src/transforms/ascend_transform.cpp
@@ -1,0 +1,39 @@
+
+
+
+
+#include <fullscore/transforms/ascend_transform.h>
+
+
+
+
+Transform::Ascend::Ascend()
+   : Base("ascend")
+{
+}
+
+
+
+
+Transform::Ascend::~Ascend()
+{
+}
+
+
+
+
+std::vector<Note> Transform::Ascend::transform(std::vector<Note> n)
+{
+   if (n.empty()) return {};
+
+   int initial_scale_degree = n[0].pitch.scale_degree;
+
+   for (unsigned i=0; i<n.size(); i++)
+      n[i].pitch = Pitch(initial_scale_degree + i, 0);
+
+   return n;
+}
+
+
+
+

--- a/src/transforms/descend_transform.cpp
+++ b/src/transforms/descend_transform.cpp
@@ -1,0 +1,39 @@
+
+
+
+
+#include <fullscore/transforms/descend_transform.h>
+
+
+
+
+Transform::Descend::Descend()
+   : Base("descend")
+{
+}
+
+
+
+
+Transform::Descend::~Descend()
+{
+}
+
+
+
+
+std::vector<Note> Transform::Descend::transform(std::vector<Note> n)
+{
+   if (n.empty()) return {};
+
+   int initial_scale_degree = n[0].pitch.scale_degree;
+
+   for (unsigned i=0; i<n.size(); i++)
+      n[i].pitch = Pitch(initial_scale_degree - i, 0);
+
+   return n;
+}
+
+
+
+

--- a/src/transforms/split_note_transform.cpp
+++ b/src/transforms/split_note_transform.cpp
@@ -1,0 +1,39 @@
+
+
+
+#include <fullscore/transforms/split_note_transform.h>
+
+#include <fullscore/transforms/half_duration_transform.h>
+
+
+
+Transform::SplitNote::SplitNote()
+   : Base("split_note")
+{
+}
+
+
+
+Transform::SplitNote::~SplitNote()
+{
+}
+
+
+
+std::vector<Note> Transform::SplitNote::transform(std::vector<Note> n)
+{
+   std::vector<Note> results = {};
+
+   for (auto &note : n)
+   {
+      results.push_back(note);
+      results.push_back(note);
+   }
+
+   results = ::Transform::HalfDuration().transform(results);
+
+   return  results;
+}
+
+
+

--- a/src/widgets/grid_editor.cpp
+++ b/src/widgets/grid_editor.cpp
@@ -133,19 +133,6 @@ void UIGridEditor::on_draw()
             6,
             color::color(color::pink, 0.4)
          );
-
-      // note box outline
-      if (is_note_target_mode())
-         al_draw_rounded_rectangle(
-               CACHED_get_measure_cursor_real_x + note_real_offset_x,
-               CACHED_get_measure_cursor_real_y,
-               CACHED_get_measure_cursor_real_x + note_real_offset_x + real_note_width,
-               CACHED_get_measure_cursor_real_y + GridHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
-               6,
-               6,
-               color::mix(color::color(color::pink, 0.8), color::black, 0.3),
-               2.0
-            );
    }
 
    // draw the playhead

--- a/src/widgets/grid_editor.cpp
+++ b/src/widgets/grid_editor.cpp
@@ -118,7 +118,7 @@ void UIGridEditor::on_draw()
          cursor_color, 3.0);
 
    // draw a hilight box at the focused note
-   if (note)
+   if (is_note_target_mode() && note)
    {
       float note_real_offset_x = get_measure_length_to_note(measure, note_cursor_x) * FULL_MEASURE_WIDTH;
       float real_note_width = DurationHelper::get_length(note->duration.denominator, note->duration.dots) * FULL_MEASURE_WIDTH;

--- a/src/widgets/grid_editor.cpp
+++ b/src/widgets/grid_editor.cpp
@@ -88,16 +88,7 @@ void UIGridEditor::on_draw()
    // draw the measure
 
    float measure_width = get_measure_width(measure) * FULL_MEASURE_WIDTH;
-   if (measure && measure->get_num_notes() == 0)
-   {
-      measure_width = 16;
-
-      // measure box outline
-      if (is_measure_target_mode())
-         al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
-            CACHED_get_measure_cursor_real_x+measure_width, GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT+GridHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
-            4, 4, color::color(color::black, 0.3), 2.0);
-   }
+   if (measure && measure->get_num_notes() == 0) measure_width = 16;
 
    // measure box fill
    al_draw_filled_rounded_rectangle(CACHED_get_measure_cursor_real_x, GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
@@ -106,9 +97,32 @@ void UIGridEditor::on_draw()
 
    // measure box outline
    if (is_measure_target_mode())
-      al_draw_rounded_rectangle(CACHED_get_measure_cursor_real_x, GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
-         CACHED_get_measure_cursor_real_x+measure_width, GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT+GridHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
-         4, 4, color::color(color::aliceblue, 0.7), 2.0);
+   {
+      float thickness = 2.0;
+      float h_thickness = thickness * 0.5;
+
+      al_draw_rounded_rectangle(
+            CACHED_get_measure_cursor_real_x - h_thickness*2,
+            GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT - h_thickness*2,
+            CACHED_get_measure_cursor_real_x+measure_width + h_thickness*2,
+            GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT+GridHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT + h_thickness*2,
+            4,
+            4,
+            color::color(color::black, 0.3),
+            thickness
+         );
+
+      al_draw_rounded_rectangle(
+            CACHED_get_measure_cursor_real_x - h_thickness,
+            GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT - h_thickness,
+            CACHED_get_measure_cursor_real_x+measure_width + h_thickness,
+            GridHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT+GridHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT + h_thickness,
+            4,
+            4,
+            color::color(color::aliceblue, 0.7),
+            thickness
+         );
+   }
 
    // left bar (blinking)
 

--- a/tests/actions/split_note_action_test.cpp
+++ b/tests/actions/split_note_action_test.cpp
@@ -1,0 +1,46 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/actions/transforms/SplitNote.h>
+
+#include <fullscore/models/Duration.h>
+#include <fullscore/models/Note.h>
+
+
+
+TEST(SplitNoteActionTest, splits_the_source_notes_into_half)
+{
+   std::vector<Note> source_notes = {
+         Note(3, Duration::HALF),
+         Note(5, Duration::WHOLE),
+         Note(7, Duration::QUARTER),
+      };
+
+   ::Action::Transform::SplitNote split_note_action(&source_notes);
+
+   std::vector<Note> expected_notes = {
+      Note(3, Duration::QUARTER),
+      Note(3, Duration::QUARTER),
+      Note(5, Duration::HALF),
+      Note(5, Duration::HALF),
+      Note(7, Duration::EIGHTH),
+      Note(7, Duration::EIGHTH),
+   };
+
+   ASSERT_EQ(true, split_note_action.execute());
+
+   ASSERT_EQ(expected_notes, source_notes);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/transforms/ascend_transform_test.cpp
+++ b/tests/transforms/ascend_transform_test.cpp
@@ -1,0 +1,42 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/transforms/ascend_transform.h>
+
+
+
+TEST(AscendTransformTest, causes_subsequent_pitches_to_ascend_from_the_initial_scale_degree)
+{
+   std::vector<Note> notes = {
+      Note(2, Duration::HALF),
+      Note(-6, Duration::QUARTER),
+      Note(8, Duration::HALF),
+      Note(4, Duration::WHOLE),
+      Note(5, Duration::SIXTEENTH),
+   };
+
+   std::vector<Note> expected_notes = {
+      Note(2, Duration::HALF),
+      Note(3, Duration::QUARTER),
+      Note(4, Duration::HALF),
+      Note(5, Duration::WHOLE),
+      Note(6, Duration::SIXTEENTH),
+   };
+
+   std::vector<Note> returned_notes = Transform::Ascend().transform(notes);
+
+   ASSERT_EQ(expected_notes, returned_notes);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/transforms/descend_transform_test.cpp
+++ b/tests/transforms/descend_transform_test.cpp
@@ -1,0 +1,42 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/transforms/descend_transform.h>
+
+
+
+TEST(DescendTransformTest, causes_subsequent_pitches_to_descend_from_the_initial_scale_degree)
+{
+   std::vector<Note> notes = {
+      Note(2, Duration::HALF),
+      Note(-6, Duration::QUARTER),
+      Note(8, Duration::HALF),
+      Note(4, Duration::WHOLE),
+      Note(5, Duration::SIXTEENTH),
+   };
+
+   std::vector<Note> expected_notes = {
+      Note(2, Duration::HALF),
+      Note(1, Duration::QUARTER),
+      Note(0, Duration::HALF),
+      Note(-1, Duration::WHOLE),
+      Note(-2, Duration::SIXTEENTH),
+   };
+
+   std::vector<Note> returned_notes = Transform::Descend().transform(notes);
+
+   ASSERT_EQ(expected_notes, returned_notes);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/transforms/split_note_test.cpp
+++ b/tests/transforms/split_note_test.cpp
@@ -1,0 +1,39 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/transforms/split_note_transform.h>
+
+
+
+TEST(SplitNoteTest, splits_notes_into_half)
+{
+   std::vector<Note> returned_notes = ::Transform::SplitNote().transform({
+         Note(3, Duration::HALF),
+         Note(5, Duration::WHOLE),
+         Note(7, Duration::QUARTER),
+      });
+
+   std::vector<Note> expected_notes = {
+      Note(3, Duration::QUARTER),
+      Note(3, Duration::QUARTER),
+      Note(5, Duration::HALF),
+      Note(5, Duration::HALF),
+      Note(7, Duration::EIGHTH),
+      Note(7, Duration::EIGHTH),
+   };
+
+   ASSERT_EQ(expected_notes, returned_notes);
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
# Problem

It's difficult to tell the difference when in `MEASURE_MODE` or `NOTE_MODE` edit modes.

# Solution

Change the design subtly for more clarity

![measure mode - fullscore 2017-08-08 12-18-15](https://user-images.githubusercontent.com/772949/29082551-d6624e08-7c33-11e7-89cc-f86cada97cf5.png)
![note_mode - fullscore 2017-08-08 12-19-00](https://user-images.githubusercontent.com/772949/29082558-d99bfc5e-7c33-11e7-8d0d-42a2229d1bd0.png)

It makes it easier to see what mode is being set

![i m actually composing here - fullscore 2017-08-07 17-41-51](https://user-images.githubusercontent.com/772949/29082635-182c9eec-7c34-11e7-9757-4dc1a0233033.png)


#  Rearrange Some Keyboard Inputs

* Use <kbd>#</kbd> to set a stack measure in the grid
* add "split_note" and "ascend" and "descend" transforms/actions