### PR TITLE
Add Pitch Context To Rendering

### DIFF
--- a/include/fullscore/components/measure_render_component.h
+++ b/include/fullscore/components/measure_render_component.h
@@ -10,6 +10,7 @@ class MusicEngraver;
 class MeasureRenderComponent
 {
 private:
+   Measure::Base *context;
    Measure::Base *measure;
    MusicEngraver *music_engraver;
    float full_measure_width;
@@ -20,7 +21,7 @@ private:
    bool showing_debug_data;
 
 public:
-   MeasureRenderComponent(Measure::Base *measure, MusicEngraver *music_engraver, float full_measure_width, float x_pos, float y_pos, float row_middle_y, float staff_height, bool showing_debug_data);
+   MeasureRenderComponent(Measure::Base *context, Measure::Base *measure, MusicEngraver *music_engraver, float full_measure_width, float x_pos, float y_pos, float row_middle_y, float staff_height, bool showing_debug_data);
 
    void render();
 };

--- a/src/components/grid_render_component.cpp
+++ b/src/components/grid_render_component.cpp
@@ -133,7 +133,8 @@ void GridRenderComponent::render()
          Measure::Base *measure = grid->get_measure(x,y);
          if (!measure) continue;
 
-         MeasureRenderComponent measure_render_component(measure, music_engraver, full_measure_width, x_pos, y_counter, row_middle_y, this_staff_height, showing_debug_data);
+         static Measure::Basic *context_measure = new Measure::Basic({Note(0), Note(2), Note(4), Note(5), Note(7), Note(9), Note(11)});
+         MeasureRenderComponent measure_render_component(context_measure, measure, music_engraver, full_measure_width, x_pos, y_counter, row_middle_y, this_staff_height, showing_debug_data);
          measure_render_component.render();
       }
 

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -23,8 +23,22 @@ float __get_measure_width(Measure::Base *m)  // TODO: should probably use a help
 
 
 
-MeasureRenderComponent::MeasureRenderComponent(Measure::Base *measure, MusicEngraver *music_engraver, float full_measure_width, float x_pos, float y_pos, float row_middle_y, float staff_height, bool showing_debug_data)
-   : measure(measure)
+std::string __get_context_pitch(Measure::Base *context, Note *note)
+{
+   if (!context && !note) return "E";
+
+   std::vector<Note> notes = context->get_notes_copy();
+   if (notes.empty()) return "=";
+
+   int context_pitch = notes[note->pitch.scale_degree % notes.size()].pitch.scale_degree;
+   return tostring(context_pitch);
+}
+
+
+
+MeasureRenderComponent::MeasureRenderComponent(Measure::Base *context, Measure::Base *measure, MusicEngraver *music_engraver, float full_measure_width, float x_pos, float y_pos, float row_middle_y, float staff_height, bool showing_debug_data)
+   : context(context)
+   , measure(measure)
    , music_engraver(music_engraver)
    , full_measure_width(full_measure_width)
    , x_pos(x_pos)
@@ -74,6 +88,9 @@ void MeasureRenderComponent::render()
 
          al_draw_text(text_font, color::white, x_cursor, y_pos, 0, tostring(note.pitch.scale_degree).c_str());
          al_draw_text(text_font, color::white, x_cursor, y_pos+20, 0, (tostring(note.duration.denominator) + "(" + tostring(note.duration.dots) + ")").c_str());
+
+         std::string context_pitch_str = __get_context_pitch(context, &note);
+         al_draw_text(text_font, color::red, x_cursor, y_pos-20, ALLEGRO_FLAGS_EMPTY, context_pitch_str.c_str());
 
          x_cursor += width;
       }

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -23,7 +23,7 @@ float __get_measure_width(Measure::Base *m)  // TODO: should probably use a help
 
 
 
-std::string __get_context_pitch(Measure::Base *context, Note *note)
+std::tuple<std::string, std::string> __get_context_pitch_and_extension(Measure::Base *context, Note *note)
 {
    if (!context && !note) return "E";
 
@@ -31,7 +31,9 @@ std::string __get_context_pitch(Measure::Base *context, Note *note)
    if (notes.empty()) return "=";
 
    int context_pitch = notes[note->pitch.scale_degree % notes.size()].pitch.scale_degree;
-   return tostring(context_pitch);
+   int context_extension = (int)note->pitch.scale_degree / notes.size();
+
+   return std::tuple<std::string, std::string>(tostring(context_pitch), tostring(context_extension));
 }
 
 
@@ -89,8 +91,9 @@ void MeasureRenderComponent::render()
          al_draw_text(text_font, color::white, x_cursor, y_pos, 0, tostring(note.pitch.scale_degree).c_str());
          al_draw_text(text_font, color::white, x_cursor, y_pos+20, 0, (tostring(note.duration.denominator) + "(" + tostring(note.duration.dots) + ")").c_str());
 
-         std::string context_pitch_str = __get_context_pitch(context, &note);
-         al_draw_text(text_font, color::red, x_cursor, y_pos-20, ALLEGRO_FLAGS_EMPTY, context_pitch_str.c_str());
+         std::tuple<std::string, std::string> context_pitch = __get_context_pitch_and_extension(context, &note);
+         al_draw_text(text_font, color::red, x_cursor, y_pos-30, ALLEGRO_FLAGS_EMPTY, std::get<0>(context_pitch).c_str());
+         al_draw_text(text_font, color::red, x_cursor, y_pos-15, ALLEGRO_FLAGS_EMPTY, std::get<1>(context_pitch).c_str());
 
          x_cursor += width;
       }


### PR DESCRIPTION
## Problem

Note pitches are not absolute.  Their final pitch is relative to context.  No contexts are present in FullScore.

## Solution

Add a hacky way to render the note's result pitch (as a number in debug mode) to get a taste of what contexts will be like.