### PR TITLE
Add String Quartet

### DIFF
--- a/bin/data/config/config.cfg
+++ b/bin/data/config/config.cfg
@@ -1,6 +1,6 @@
 [ALLEGRO_FLARE]
 
-background_color_hex = #abc788
+background_color_hex = #e0dad4
 
 [GLOBAL_SETTINGS]
 

--- a/include/fullscore/components/grid_render_component.h
+++ b/include/fullscore/components/grid_render_component.h
@@ -2,7 +2,6 @@
 
 
 
-
 class Grid;
 class MusicEngraver;
 class ReferenceCursor;
@@ -25,7 +24,6 @@ public:
 
    void render();
 };
-
 
 
 

--- a/include/fullscore/factories/grid_factory.h
+++ b/include/fullscore/factories/grid_factory.h
@@ -12,6 +12,7 @@ public:
    static Grid twinkle_twinkle_little_star();
    static Grid big_score();
    static Grid full_score();
+   static Grid string_quartet();
    static Grid create(std::string identifier);
 };
 

--- a/include/fullscore/transforms/notes_at_transform.h
+++ b/include/fullscore/transforms/notes_at_transform.h
@@ -1,0 +1,25 @@
+#pragma once
+
+
+
+#include <fullscore/transforms/base.h>
+
+
+
+namespace Transform
+{
+   class NotesAt : public Base
+   {
+   private:
+      std::vector<int> indexes;
+
+   public:
+      NotesAt(std::vector<int> indexes);
+      ~NotesAt();
+
+      virtual std::vector<Note> transform(std::vector<Note> notes) override;
+   };
+}
+
+
+

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -28,7 +28,7 @@ AppController::AppController(Display *display)
 {
    UIScreen::draw_focused_outline = false;
 
-   set_current_grid_editor(create_new_grid_editor("full_score"));
+   set_current_grid_editor(create_new_grid_editor("string_quartet"));
 
    set_keyboard_input_mappings();
 }

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -47,6 +47,43 @@ Grid GridFactory::big_score()
 
 
 
+Grid GridFactory::string_quartet()
+{
+   std::vector<std::string> voices = {
+      MEASURE_NUMBERS,
+      "Violin I",
+      "Violin II",
+      "Viola",
+      "Cello",
+      "Bass",
+   };
+
+   const int NUM_MEASURES = 20;
+
+   Grid grid(NUM_MEASURES, 0);
+
+   for (int i=0; i<voices.size(); i++)
+   {
+      if (voices[i] == MEASURE_NUMBERS)
+      {
+         grid.append_staff(new Staff::MeasureNumbers(NUM_MEASURES));
+      }
+      else if (voices[i] == SPACER)
+      {
+         grid.append_staff(new Staff::Spacer(NUM_MEASURES));
+      }
+      else
+      {
+         grid.append_staff(new Staff::Instrument(NUM_MEASURES));
+         grid.set_voice_name(i, voices[i]);
+      }
+   }
+
+   return grid;
+}
+
+
+
 Grid GridFactory::full_score()
 {
    std::vector<std::string> voices = {
@@ -130,6 +167,7 @@ Grid GridFactory::create(std::string identifier)
    if (identifier == "big_score") return big_score();
    if (identifier == "twinkle_twinkle") return twinkle_twinkle_little_star();
    if (identifier == "full_score") return full_score();
+   if (identifier == "string_quartet") return string_quartet();
 
    std::cout << "Could not find score " << identifier << std::endl;
    return Grid(4, 1);

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -55,7 +55,6 @@ Grid GridFactory::string_quartet()
       "Violin II",
       "Viola",
       "Cello",
-      "Bass",
    };
 
    const int NUM_MEASURES = 20;

--- a/src/transforms/notes_at_transform.cpp
+++ b/src/transforms/notes_at_transform.cpp
@@ -1,0 +1,36 @@
+
+
+
+#include <fullscore/transforms/notes_at_transform.h>
+
+
+
+Transform::NotesAt::NotesAt(std::vector<int> indexes)
+   : Base("notes_at")
+   , indexes(indexes)
+{
+}
+
+
+
+Transform::NotesAt::~NotesAt()
+{
+}
+
+
+
+std::vector<Note> Transform::NotesAt::transform(std::vector<Note> source)
+{
+   std::vector<Note> result = {};
+
+   for (unsigned i=0; i<indexes.size(); i++)
+   {
+      if (i >= source.size()) continue;
+      result.push_back(source[i]);
+   }
+
+   return result;
+}
+
+
+


### PR DESCRIPTION
## Problem

Using the `"full_score"` template isn't conducive to writing music in FullScore.  Would be nice to try starting with a template that is a little more accessible.

## Solution

Add a "string_quartet" template.  Make it the default.  Also, change the background color.

![fullscore 2017-08-27 17-11-38](https://user-images.githubusercontent.com/772949/29753996-d7a51f5e-8b4a-11e7-9263-5fdbc5f66d90.png)

## Also

A `NotesAt` transform was added.  It's not used for anything yet, because there isn't a clear straightforward way to set the "arguments" of what note indexes to use.