### PR TITLE
Add Tempo Staff Type

### DIFF
--- a/include/fullscore/components/tempo_marking_render_component.hpp
+++ b/include/fullscore/components/tempo_marking_render_component.hpp
@@ -2,8 +2,11 @@
 
 
 
-#include <allegro5/allegro_font.h>
 #include <fullscore/models/tempo_marking.hpp>
+
+
+
+struct ALLEGRO_FONT;
 
 
 

--- a/include/fullscore/components/tempo_marking_render_component.hpp
+++ b/include/fullscore/components/tempo_marking_render_component.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+
+
+#include <allegro5/allegro_font.h>
+#include <fullscore/models/tempo_marking.hpp>
+
+
+
+class TempoMarkingRenderComponent
+{
+private:
+   ALLEGRO_FONT *font;
+   TempoMarking tempo_marking;
+   float x;
+   float y;
+
+public:
+   TempoMarkingRenderComponent(ALLEGRO_FONT *font, float x, float y, const TempoMarking &tempo_marking);
+   ~TempoMarkingRenderComponent();
+
+   void render();
+};
+
+
+

--- a/include/fullscore/models/staves/tempo.h
+++ b/include/fullscore/models/staves/tempo.h
@@ -39,6 +39,7 @@ namespace Staff
       virtual bool append_column(Measure::Base *measure) override;
 
       bool set_tempo_marking(int measure_number, float position, TempoMarking marking);
+      std::vector<std::pair<TempoMarking, float>> get_tempo_markings_in_measure(int measure_number);
    };
 };
 

--- a/include/fullscore/models/staves/tempo.h
+++ b/include/fullscore/models/staves/tempo.h
@@ -4,12 +4,27 @@
 
 #include <fullscore/models/staves/base.h>
 
+#include <fullscore/models/tempo_marking.hpp>
+
 
 
 namespace Staff
 {
    class Tempo : public Base
    {
+   private:
+      class TempoMarkingCoordinate
+      {
+      public:
+         int measure_number;
+         float position;
+         TempoMarking tempo_marking;
+
+         TempoMarkingCoordinate(int measure_number, float position, TempoMarking tempo_marking);
+      };
+
+      std::vector<TempoMarkingCoordinate> markings;
+
    public:
       Tempo(int num_columns);
       ~Tempo();
@@ -22,6 +37,8 @@ namespace Staff
       virtual bool insert_column(int at_index, Measure::Base *measure) override;
       virtual bool erase_column(int at_index) override;
       virtual bool append_column(Measure::Base *measure) override;
+
+      bool set_tempo_marking(int measure_number, float position, TempoMarking marking);
    };
 };
 

--- a/include/fullscore/models/staves/tempo.h
+++ b/include/fullscore/models/staves/tempo.h
@@ -1,0 +1,29 @@
+#pragma once
+
+
+
+#include <fullscore/models/staves/base.h>
+
+
+
+namespace Staff
+{
+   class Tempo : public Base
+   {
+   public:
+      Tempo(int num_columns);
+      ~Tempo();
+
+      virtual int get_num_columns() override;
+      virtual float get_height() override;
+
+      virtual Measure::Base *get_measure(int column_num) override;
+      virtual bool set_column(int column_num, Measure::Base *measure) override;
+      virtual bool insert_column(int at_index, Measure::Base *measure) override;
+      virtual bool erase_column(int at_index) override;
+      virtual bool append_column(Measure::Base *measure) override;
+   };
+};
+
+
+

--- a/include/fullscore/models/tempo_marking.hpp
+++ b/include/fullscore/models/tempo_marking.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+
+
+#include <fullscore/models/Duration.h>
+
+
+
+class TempoMarking
+{
+public:
+   Duration duration;
+   int bpm;
+
+   TempoMarking(Duration duration, int bpm);
+   ~TempoMarking();
+};
+
+
+

--- a/src/components/grid_render_component.cpp
+++ b/src/components/grid_render_component.cpp
@@ -8,7 +8,9 @@
 #include <allegro_flare/framework.h>
 #include <allegro_flare/useful.h>
 #include <fullscore/models/staves/base.h>
+#include <fullscore/models/staves/tempo.h>
 #include <fullscore/components/measure_render_component.h>
+#include <fullscore/components/tempo_marking_render_component.hpp>
 #include <fullscore/components/time_signature_render_component.h>
 #include <fullscore/helpers/duration_helper.h>
 #include <fullscore/helpers/grid_helper.h>
@@ -107,6 +109,17 @@ void GridRenderComponent::render()
          {
             // draw barline
             al_draw_line(x_pos_plus_width, row_middle_y-this_staff_half_height, x_pos_plus_width, row_middle_y+this_staff_half_height, color::color(color::black, 0.2), 1.0);
+         }
+         if (staff->is_type("tempo"))
+         {
+            Staff::Tempo &tempo_staff = static_cast<Staff::Tempo &>(*staff);
+            if (x == 0)
+            {
+               //Staff::Tempo::TempoMarkingCoordinate::TempoMarkingCoordinate(int measure_number, float position, TempoMarking tempo_marking)
+               TempoMarking tempo_marking = TempoMarking(Duration(Duration::QUARTER), 128);
+               TempoMarkingRenderComponent tempo_marking_render_component(text_font, x_pos, label_text_top_y, tempo_marking);
+               tempo_marking_render_component.render();
+            }
          }
          if (staff->is_type("measure_numbers"))
          {

--- a/src/components/grid_render_component.cpp
+++ b/src/components/grid_render_component.cpp
@@ -104,6 +104,7 @@ void GridRenderComponent::render()
       {
          float x_pos = GridHelper::get_length_to_measure(*grid, x) * full_measure_width;
          float x_pos_plus_width = GridHelper::get_length_to_measure(*grid, x+1) * full_measure_width;
+         float real_measure_width = x_pos_plus_width - x_pos;
 
          if (staff->is_type("instrument"))
          {
@@ -113,11 +114,15 @@ void GridRenderComponent::render()
          if (staff->is_type("tempo"))
          {
             Staff::Tempo &tempo_staff = static_cast<Staff::Tempo &>(*staff);
-            if (x == 0)
+            std::vector<std::pair<TempoMarking, float>> tempo_markings_in_measure = tempo_staff.get_tempo_markings_in_measure(x);
+
+            for (auto &marking : tempo_markings_in_measure)
             {
-               //Staff::Tempo::TempoMarkingCoordinate::TempoMarkingCoordinate(int measure_number, float position, TempoMarking tempo_marking)
-               TempoMarking tempo_marking = TempoMarking(Duration(Duration::QUARTER), 128);
-               TempoMarkingRenderComponent tempo_marking_render_component(text_font, x_pos, label_text_top_y, tempo_marking);
+               TempoMarking &tempo_marking = std::get<0>(marking);
+               float position = std::get<1>(marking);
+               float marking_x_pos = x_pos + real_measure_width * position;
+
+               TempoMarkingRenderComponent tempo_marking_render_component(text_font, marking_x_pos, label_text_top_y, tempo_marking);
                tempo_marking_render_component.render();
             }
          }

--- a/src/components/tempo_marking_render_component.cpp
+++ b/src/components/tempo_marking_render_component.cpp
@@ -3,6 +3,7 @@
 
 #include <fullscore/components/tempo_marking_render_component.hpp>
 
+#include <allegro5/allegro_font.h>
 #include <allegro_flare/color.h>
 
 

--- a/src/components/tempo_marking_render_component.cpp
+++ b/src/components/tempo_marking_render_component.cpp
@@ -1,0 +1,39 @@
+
+
+
+#include <fullscore/components/tempo_marking_render_component.hpp>
+
+#include <allegro_flare/color.h>
+
+
+
+TempoMarkingRenderComponent::TempoMarkingRenderComponent(ALLEGRO_FONT *font, float x, float y, const TempoMarking &tempo_marking)
+   : font(font)
+   , tempo_marking(tempo_marking)
+   , x(x)
+   , y(y)
+{
+   if (font == nullptr) throw std::invalid_argument("Cannot create a TempoMarkingRenderComponent with a nullptr font");
+}
+
+
+
+TempoMarkingRenderComponent::~TempoMarkingRenderComponent()
+{}
+
+
+
+void TempoMarkingRenderComponent::render()
+{
+   std::stringstream tempo_string;
+
+   tempo_string << tempo_marking.duration.denominator;
+   for (unsigned i=0; i<tempo_marking.duration.dots; i++)
+      tempo_string << ".";
+   tempo_string << " = " << tempo_marking.bpm;
+
+   al_draw_text(font, color::black, x, y, ALLEGRO_ALIGN_LEFT, tempo_string.str().c_str());
+}
+
+
+

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -6,6 +6,7 @@
 #include <fullscore/models/staves/measure_numbers.h>
 #include <fullscore/models/staves/instrument.h>
 #include <fullscore/models/staves/spacer.h>
+#include <fullscore/models/staves/tempo.h>
 #include <fullscore/models/Note.h>
 #include <allegro_flare/useful.h>
 #include <iostream>
@@ -14,6 +15,7 @@
 
 std::string const SPACER = "-";
 std::string const MEASURE_NUMBERS = "#";
+std::string const TEMPO = "!";
 
 
 
@@ -51,6 +53,7 @@ Grid GridFactory::string_quartet()
 {
    std::vector<std::string> voices = {
       MEASURE_NUMBERS,
+      TEMPO,
       "Violin I",
       "Violin II",
       "Viola",
@@ -70,6 +73,10 @@ Grid GridFactory::string_quartet()
       else if (voices[i] == SPACER)
       {
          grid.append_staff(new Staff::Spacer(NUM_MEASURES));
+      }
+      else if (voices[i] == TEMPO)
+      {
+         grid.append_staff(new Staff::Tempo(NUM_MEASURES));
       }
       else
       {
@@ -148,6 +155,10 @@ Grid GridFactory::full_score()
       else if (voices[i] == SPACER)
       {
          grid.append_staff(new Staff::Spacer(NUM_MEASURES));
+      }
+      else if (voices[i] == TEMPO)
+      {
+         grid.append_staff(new Staff::Tempo(NUM_MEASURES));
       }
       else
       {

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -76,7 +76,10 @@ Grid GridFactory::string_quartet()
       }
       else if (voices[i] == TEMPO)
       {
-         grid.append_staff(new Staff::Tempo(NUM_MEASURES));
+         Staff::Tempo *tempo_staff = new Staff::Tempo(NUM_MEASURES);
+         grid.append_staff(tempo_staff);
+         TempoMarking tempo_marking(Duration(Duration::QUARTER), 128);
+         tempo_staff->set_tempo_marking(0, 0, tempo_marking);
       }
       else
       {

--- a/src/models/staves/tempo.cpp
+++ b/src/models/staves/tempo.cpp
@@ -36,6 +36,19 @@ bool Staff::Tempo::set_tempo_marking(int measure_number, float position, TempoMa
 
 
 
+std::vector<std::pair<TempoMarking, float>> Staff::Tempo::get_tempo_markings_in_measure(int measure_number)
+{
+   std::vector<std::pair<TempoMarking, float>> result = {};
+
+   for (unsigned i=0; i<markings.size(); i++)
+      if (markings[i].measure_number == measure_number)
+         result.push_back(std::pair<TempoMarking, float>(markings[i].tempo_marking, markings[i].position));
+
+   return result;
+}
+
+
+
 bool Staff::Tempo::set_column(int column_num, Measure::Base *measure)
 {
    throw std::runtime_error("Cannot set a measure on a Tempo column");

--- a/src/models/staves/tempo.cpp
+++ b/src/models/staves/tempo.cpp
@@ -28,6 +28,7 @@ Staff::Tempo::~Tempo()
 
 bool Staff::Tempo::set_tempo_marking(int measure_number, float position, TempoMarking marking)
 {
+   if (position < 0.0 || position > 1.0) throw std::invalid_argument("Setting a tempo marking to be > 1 or < 0 is not allowed");
    markings.push_back(TempoMarkingCoordinate(measure_number, position, marking));
    return true;
 }

--- a/src/models/staves/tempo.cpp
+++ b/src/models/staves/tempo.cpp
@@ -17,6 +17,7 @@ Staff::Tempo::TempoMarkingCoordinate::TempoMarkingCoordinate(int measure_number,
 
 Staff::Tempo::Tempo(int num_columns)
    : Base("tempo")
+   , markings()
 {}
 
 

--- a/src/models/staves/tempo.cpp
+++ b/src/models/staves/tempo.cpp
@@ -7,6 +7,14 @@
 
 
 
+Staff::Tempo::TempoMarkingCoordinate::TempoMarkingCoordinate(int measure_number, float position, TempoMarking tempo_marking)
+   : measure_number(measure_number)
+   , position(position)
+   , tempo_marking(tempo_marking)
+{}
+
+
+
 Staff::Tempo::Tempo(int num_columns)
    : Base("tempo")
 {}
@@ -15,6 +23,14 @@ Staff::Tempo::Tempo(int num_columns)
 
 Staff::Tempo::~Tempo()
 {}
+
+
+
+bool Staff::Tempo::set_tempo_marking(int measure_number, float position, TempoMarking marking)
+{
+   markings.push_back(TempoMarkingCoordinate(measure_number, position, marking));
+   return true;
+}
 
 
 

--- a/src/models/staves/tempo.cpp
+++ b/src/models/staves/tempo.cpp
@@ -1,0 +1,69 @@
+
+
+
+#include <fullscore/models/staves/tempo.h>
+
+#include <fullscore/models/measures/base.h>
+
+
+
+Staff::Tempo::Tempo(int num_columns)
+   : Base("tempo")
+{}
+
+
+
+Staff::Tempo::~Tempo()
+{}
+
+
+
+bool Staff::Tempo::set_column(int column_num, Measure::Base *measure)
+{
+   throw std::runtime_error("Cannot set a measure on a Tempo column");
+}
+
+
+
+bool Staff::Tempo::insert_column(int at_index, Measure::Base *measure)
+{
+   return true;
+}
+
+
+
+bool Staff::Tempo::erase_column(int at_index)
+{
+   return true;
+}
+
+
+
+bool Staff::Tempo::append_column(Measure::Base *measure)
+{
+   return true;
+}
+
+
+
+Measure::Base *Staff::Tempo::get_measure(int column_num)
+{
+   return nullptr;
+}
+
+
+
+int Staff::Tempo::get_num_columns()
+{
+   return 0;
+}
+
+
+
+float Staff::Tempo::get_height()
+{
+   return 0.5;
+}
+
+
+

--- a/src/models/tempo_marking.cpp
+++ b/src/models/tempo_marking.cpp
@@ -1,0 +1,19 @@
+
+
+
+#include <fullscore/models/tempo_marking.hpp>
+
+
+
+TempoMarking::TempoMarking(Duration duration, int bpm)
+   : duration(duration)
+   , bpm(bpm)
+{}
+
+
+
+TempoMarking::~TempoMarking()
+{}
+
+
+

--- a/tests/components/tempo_marking_render_component_test.cpp
+++ b/tests/components/tempo_marking_render_component_test.cpp
@@ -1,0 +1,44 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/components/tempo_marking_render_component.hpp>
+
+
+
+TEST(TempoMarkingRenderComponentTest, can_be_created)
+{
+   // TODO
+}
+
+
+
+TEST(TempoMarkingRenderComponentTest, with_an_invalid_font_argument_raises_an_exception)
+{
+   TempoMarking tempo_marking(Duration(Duration::QUARTER, 3), 128);
+
+   try
+   {
+      TempoMarkingRenderComponent tempo_marking_render_component(nullptr, 0, 0, tempo_marking);
+   }
+   catch (std::invalid_argument const &e)
+   {
+      EXPECT_EQ(e.what(), std::string("Cannot create a TempoMarkingRenderComponent with a nullptr font"));
+   }
+   catch (...)
+   {
+      FAIL() << "Expected std::invalid_argument";
+   }
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/models/staves/spacer_test.cpp
+++ b/tests/models/staves/spacer_test.cpp
@@ -9,16 +9,16 @@
 
 TEST(Staff_SpacerTest, can_be_created)
 {
-   Staff::Spacer instrument(1);
+   Staff::Spacer spacer(1);
 }
 
 
 
 TEST(Staff_SpacerTest, returns_a_staff_height_of_0_5)
 {
-   Staff::Spacer instrument(1);
+   Staff::Spacer spacer(1);
 
-   ASSERT_EQ(0.5, instrument.get_height());
+   ASSERT_EQ(0.5, spacer.get_height());
 }
 
 

--- a/tests/models/staves/tempo_test.cpp
+++ b/tests/models/staves/tempo_test.cpp
@@ -1,0 +1,44 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/staves/tempo.h>
+
+
+
+TEST(Staff_TempoTest, can_be_created)
+{
+   Staff::Tempo tempo_staff(1);
+}
+
+
+
+TEST(Staff_TempoTest, when_setting_a_tempo_marking_with_a_position_lt_0_throws_an_exception)
+{
+   Staff::Tempo tempo_staff(1);
+
+   try
+   {
+      tempo_staff.set_tempo_marking(0, -1, TempoMarking(Duration(Duration::QUARTER), 128));
+   }
+   catch (std::invalid_argument const &e)
+   {
+      EXPECT_EQ(e.what(), std::string("Setting a tempo marking to be > 1 or < 0 is not allowed"));
+   }
+   catch (...)
+   {
+      FAIL() << "Expected std::invalid_argument";
+   }
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+

--- a/tests/models/staves/tempo_test.cpp
+++ b/tests/models/staves/tempo_test.cpp
@@ -34,6 +34,26 @@ TEST(Staff_TempoTest, when_setting_a_tempo_marking_with_a_position_lt_0_throws_a
 
 
 
+TEST(Staff_TempoTest, when_setting_a_tempo_marking_with_a_position_gt_0_throws_an_exception)
+{
+   Staff::Tempo tempo_staff(1);
+
+   try
+   {
+      tempo_staff.set_tempo_marking(0, 1.1, TempoMarking(Duration(Duration::QUARTER), 128));
+   }
+   catch (std::invalid_argument const &e)
+   {
+      EXPECT_EQ(e.what(), std::string("Setting a tempo marking to be > 1 or < 0 is not allowed"));
+   }
+   catch (...)
+   {
+      FAIL() << "Expected std::invalid_argument";
+   }
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
## Problem

We don't have any tempo data in our music.  

## Solution

Add a `Tempo` staff type, where tempo markings can be placed.  Also added is a `TempoMarking` model, that contains a duration and BPM.  The `Tempo` staff contains multiple `TempoMarking`s and their coordinates in the staff.

![fullscore 2017-08-27 19-32-52](https://user-images.githubusercontent.com/772949/29755029-fbd9670e-8b5e-11e7-98e5-24eb3aec8aba.png)

## Future

Simple addition would be to improve the rendering of the marking, which is simply a text string right now.  