### PR TITLE
Add HarmonicAnalysis Pieces

### DIFF
--- a/include/fullscore/components/harmonic_analysis_symbol_render_component.hpp
+++ b/include/fullscore/components/harmonic_analysis_symbol_render_component.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+
+
+#include <fullscore/models/harmonic_analysis_symbol.h>
+
+
+
+class HarmonicAnalysisSymbolRenderComponent
+{
+private:
+   HarmonicAnalysisSymbol symbol;
+   float x;
+   float y;
+
+public:
+   HarmonicAnalysisSymbolRenderComponent(float x, float y, HarmonicAnalysisSymbol symbol);
+   void render();
+};
+
+
+

--- a/include/fullscore/components/harmonic_analysis_symbol_render_component.hpp
+++ b/include/fullscore/components/harmonic_analysis_symbol_render_component.hpp
@@ -6,15 +6,20 @@
 
 
 
+struct ALLEGRO_FONT;
+
+
+
 class HarmonicAnalysisSymbolRenderComponent
 {
 private:
    HarmonicAnalysisSymbol symbol;
+   ALLEGRO_FONT *font;
    float x;
    float y;
 
 public:
-   HarmonicAnalysisSymbolRenderComponent(float x, float y, HarmonicAnalysisSymbol symbol);
+   HarmonicAnalysisSymbolRenderComponent(ALLEGRO_FONT *font, float x, float y, HarmonicAnalysisSymbol symbol);
    void render();
 };
 

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -20,7 +20,7 @@ public:
    };
 
    Pitch fundamental;
-   chord_quality_t quality;
+   chord_quality_t chord_quality;
    int inversion;
    std::vector<int> extensions;
 

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -1,0 +1,31 @@
+#pragma once
+
+
+
+#include <fullscore/models/pitch.h>
+#include <vector>
+
+
+
+class HarmonicAnalysisSymbol
+{
+public:
+   enum chord_quality_t
+   {
+      MAJOR=1,
+      MINOR=2,
+      AUGMENTED=3,
+      DIMINISHED=4,
+   };
+
+   Pitch fundamental;
+   chord_quality_t quality;
+   int inversion;
+   std::vector<int> extensions;
+
+   HarmonicAnalysisSymbol();
+   ~HarmonicAnalysisSymbol();
+};
+
+
+

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -27,7 +27,7 @@ public:
    HarmonicAnalysisSymbol();
    ~HarmonicAnalysisSymbol();
 
-   static std::string get_chord_quality_string(chord_quality_t chord_quality);
+   static std::string get_chord_quality_string(chord_quality_t chord_quality, bool abbreviated=false);
 };
 
 

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -3,6 +3,7 @@
 
 
 #include <fullscore/models/pitch.h>
+#include <string>
 #include <vector>
 
 
@@ -25,6 +26,8 @@ public:
 
    HarmonicAnalysisSymbol();
    ~HarmonicAnalysisSymbol();
+
+   static std::string get_chord_quality_string(chord_quality_t chord_quality);
 };
 
 

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -24,7 +24,7 @@ public:
    int inversion;
    std::vector<int> extensions;
 
-   HarmonicAnalysisSymbol();
+   HarmonicAnalysisSymbol(Pitch fundamental, chord_quality_t chord_quality, int inversion, std::vector<int> extensions);
    ~HarmonicAnalysisSymbol();
 
    static std::string get_chord_quality_string(chord_quality_t chord_quality, bool abbreviated=false);

--- a/include/fullscore/models/staves/harmonic_analysis.h
+++ b/include/fullscore/models/staves/harmonic_analysis.h
@@ -3,6 +3,7 @@
 
 
 #include <fullscore/models/staves/base.h>
+#include <fullscore/models/harmonic_analysis_symbol.h>
 
 
 
@@ -12,6 +13,18 @@ namespace Staff
    {
    private:
       int num_columns;
+
+      class HarmonicAnalysisSymbolPlacement
+      {
+      public:
+         HarmonicAnalysisSymbol symbol;
+         int measure_num;
+         int beat;
+
+         HarmonicAnalysisSymbolPlacement(HarmonicAnalysisSymbol symbol, int measure_num, int beat);
+      };
+
+      std::vector<HarmonicAnalysisSymbolPlacement> symbols;
 
    public:
       HarmonicAnalysis(int num_columns);
@@ -25,6 +38,9 @@ namespace Staff
       virtual bool insert_column(int at_index, Measure::Base *measure) override;
       virtual bool erase_column(int at_index) override;
       virtual bool append_column(Measure::Base *measure) override;
+
+      std::vector<std::pair<int, HarmonicAnalysisSymbol>> get_symbols_in_measure(int measure_num);
+      void set_symbol(HarmonicAnalysisSymbol symbol, int measure_num, int beat);
    };
 };
 

--- a/include/fullscore/models/staves/harmonic_analysis.h
+++ b/include/fullscore/models/staves/harmonic_analysis.h
@@ -1,0 +1,32 @@
+#pragma once
+
+
+
+#include <fullscore/models/staves/base.h>
+
+
+
+namespace Staff
+{
+   class HarmonicAnalysis : public Base
+   {
+   private:
+      int num_columns;
+
+   public:
+      HarmonicAnalysis(int num_columns);
+      ~HarmonicAnalysis();
+
+      virtual int get_num_columns() override;
+      virtual float get_height() override;
+
+      virtual Measure::Base *get_measure(int column_num) override;
+      virtual bool set_column(int column_num, Measure::Base *measure) override;
+      virtual bool insert_column(int at_index, Measure::Base *measure) override;
+      virtual bool erase_column(int at_index) override;
+      virtual bool append_column(Measure::Base *measure) override;
+   };
+};
+
+
+

--- a/src/components/grid_render_component.cpp
+++ b/src/components/grid_render_component.cpp
@@ -8,7 +8,9 @@
 #include <allegro_flare/framework.h>
 #include <allegro_flare/useful.h>
 #include <fullscore/models/staves/base.h>
+#include <fullscore/models/staves/harmonic_analysis.h>
 #include <fullscore/models/staves/tempo.h>
+#include <fullscore/components/harmonic_analysis_symbol_render_component.hpp>
 #include <fullscore/components/measure_render_component.h>
 #include <fullscore/components/tempo_marking_render_component.hpp>
 #include <fullscore/components/time_signature_render_component.h>
@@ -124,6 +126,21 @@ void GridRenderComponent::render()
 
                TempoMarkingRenderComponent tempo_marking_render_component(text_font, marking_x_pos, label_text_top_y, tempo_marking);
                tempo_marking_render_component.render();
+            }
+         }
+         if (staff->is_type("harmonic_analysis"))
+         {
+            Staff::HarmonicAnalysis &harmonic_analysis_staff = static_cast<Staff::HarmonicAnalysis &>(*staff);
+            std::vector<std::pair<int, HarmonicAnalysisSymbol>> harmonic_analysis_symbols_in_measure = harmonic_analysis_staff.get_symbols_in_measure(x);
+
+            for (auto &marking : harmonic_analysis_symbols_in_measure)
+            {
+               int beat = std::get<0>(marking);
+               HarmonicAnalysisSymbol &harmonic_analysis_symbol = std::get<1>(marking);
+               float marking_x_pos = x_pos + (full_measure_width * 0.25 * beat);
+
+               HarmonicAnalysisSymbolRenderComponent harmonic_analysis_symbol_render_component(text_font, marking_x_pos, label_text_top_y, harmonic_analysis_symbol);
+               harmonic_analysis_symbol_render_component.render();
             }
          }
          if (staff->is_type("measure_numbers"))

--- a/src/components/harmonic_analysis_symbol_render_component.cpp
+++ b/src/components/harmonic_analysis_symbol_render_component.cpp
@@ -25,8 +25,7 @@ void HarmonicAnalysisSymbolRenderComponent::render()
 
    ss << symbol.fundamental.scale_degree
       << ":" << symbol.fundamental.accidental
-      << ":" << HarmonicAnalysisSymbol::get_chord_quality_string(symbol.chord_quality)
-      << std::endl;
+      << ":" << HarmonicAnalysisSymbol::get_chord_quality_string(symbol.chord_quality);
 
    al_draw_text(font, color::black, x, y, ALLEGRO_ALIGN_CENTER, ss.str().c_str());
 }

--- a/src/components/harmonic_analysis_symbol_render_component.cpp
+++ b/src/components/harmonic_analysis_symbol_render_component.cpp
@@ -3,10 +3,15 @@
 
 #include <fullscore/components/harmonic_analysis_symbol_render_component.hpp>
 
+#include <allegro5/allegro_font.h>
+#include <allegro_flare/color.h>
+#include <sstream>
 
 
-HarmonicAnalysisSymbolRenderComponent::HarmonicAnalysisSymbolRenderComponent(float x, float y, HarmonicAnalysisSymbol symbol)
+
+HarmonicAnalysisSymbolRenderComponent::HarmonicAnalysisSymbolRenderComponent(ALLEGRO_FONT *font, float x, float y, HarmonicAnalysisSymbol symbol)
    : symbol(symbol)
+   , font(font)
    , x(x)
    , y(y)
 {}
@@ -15,7 +20,15 @@ HarmonicAnalysisSymbolRenderComponent::HarmonicAnalysisSymbolRenderComponent(flo
 
 void HarmonicAnalysisSymbolRenderComponent::render()
 {
-   // TODO
+   if (!font) throw std::invalid_argument("Cannot render HarmonicAnalysisSymbol with a nullptr font");
+   std::stringstream ss;
+
+   ss << symbol.fundamental.scale_degree
+      << ":" << symbol.fundamental.accidental
+      << ":" << HarmonicAnalysisSymbol::get_chord_quality_string(symbol.chord_quality)
+      << std::endl;
+
+   al_draw_text(font, color::black, x, y, ALLEGRO_ALIGN_CENTER, ss.str().c_str());
 }
 
 

--- a/src/components/harmonic_analysis_symbol_render_component.cpp
+++ b/src/components/harmonic_analysis_symbol_render_component.cpp
@@ -1,0 +1,22 @@
+
+
+
+#include <fullscore/components/harmonic_analysis_symbol_render_component.hpp>
+
+
+
+HarmonicAnalysisSymbolRenderComponent::HarmonicAnalysisSymbolRenderComponent(float x, float y, HarmonicAnalysisSymbol symbol)
+   : symbol(symbol)
+   , x(x)
+   , y(y)
+{}
+
+
+
+void HarmonicAnalysisSymbolRenderComponent::render()
+{
+   // TODO
+}
+
+
+

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -3,6 +3,7 @@
 
 #include <fullscore/factories/grid_factory.h>
 #include <fullscore/models/measures/basic.h>
+#include <fullscore/models/staves/harmonic_analysis.h>
 #include <fullscore/models/staves/measure_numbers.h>
 #include <fullscore/models/staves/instrument.h>
 #include <fullscore/models/staves/spacer.h>
@@ -16,6 +17,7 @@
 std::string const SPACER = "-";
 std::string const MEASURE_NUMBERS = "#";
 std::string const TEMPO = "!";
+std::string const HARMONIC_ANALYSIS = "V";
 
 
 
@@ -58,6 +60,7 @@ Grid GridFactory::string_quartet()
       "Violin II",
       "Viola",
       "Cello",
+      HARMONIC_ANALYSIS,
    };
 
    const int NUM_MEASURES = 20;
@@ -73,6 +76,13 @@ Grid GridFactory::string_quartet()
       else if (voices[i] == SPACER)
       {
          grid.append_staff(new Staff::Spacer(NUM_MEASURES));
+      }
+      else if (voices[i] == HARMONIC_ANALYSIS)
+      {
+         Staff::HarmonicAnalysis *staff = new Staff::HarmonicAnalysis(NUM_MEASURES);
+         grid.append_staff(staff);
+         HarmonicAnalysisSymbol harmonic_analysis_symbol(Pitch(3, -1), HarmonicAnalysisSymbol::MAJOR, 1, {});
+         staff->set_symbol(harmonic_analysis_symbol, 1, 2);
       }
       else if (voices[i] == TEMPO)
       {

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -5,11 +5,11 @@
 
 
 
-HarmonicAnalysisSymbol::HarmonicAnalysisSymbol()
-   : fundamental(0, 0)
-   , chord_quality(MAJOR)
-   , inversion(0)
-   , extensions()
+HarmonicAnalysisSymbol::HarmonicAnalysisSymbol(Pitch fundamental, chord_quality_t chord_quality, int inversion, std::vector<int> extensions)
+   : fundamental(fundamental)
+   , chord_quality(chord_quality)
+   , inversion(inversion)
+   , extensions(extensions)
 {}
 
 

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -19,3 +19,18 @@ HarmonicAnalysisSymbol::~HarmonicAnalysisSymbol()
 
 
 
+std::string HarmonicAnalysisSymbol::get_chord_quality_string(chord_quality_t chord_quality)
+{
+   switch(chord_quality)
+   {
+      case HarmonicAnalysisSymbol::MAJOR: return "major";
+      case HarmonicAnalysisSymbol::MINOR: return "minor";
+      case HarmonicAnalysisSymbol::AUGMENTED: return "augmented";
+      case HarmonicAnalysisSymbol::DIMINISHED: return "diminished";
+   }
+
+   return "[undef]";
+}
+
+
+

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -7,7 +7,7 @@
 
 HarmonicAnalysisSymbol::HarmonicAnalysisSymbol()
    : fundamental(0, 0)
-   , quality(MAJOR)
+   , chord_quality(MAJOR)
    , inversion(0)
    , extensions()
 {}

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -19,14 +19,14 @@ HarmonicAnalysisSymbol::~HarmonicAnalysisSymbol()
 
 
 
-std::string HarmonicAnalysisSymbol::get_chord_quality_string(chord_quality_t chord_quality)
+std::string HarmonicAnalysisSymbol::get_chord_quality_string(chord_quality_t chord_quality, bool abbreviated)
 {
    switch(chord_quality)
    {
-      case HarmonicAnalysisSymbol::MAJOR: return "major";
-      case HarmonicAnalysisSymbol::MINOR: return "minor";
-      case HarmonicAnalysisSymbol::AUGMENTED: return "augmented";
-      case HarmonicAnalysisSymbol::DIMINISHED: return "diminished";
+      case HarmonicAnalysisSymbol::MAJOR: return abbreviated ? "maj" : "major";
+      case HarmonicAnalysisSymbol::MINOR: return abbreviated ? "min" : "minor";
+      case HarmonicAnalysisSymbol::AUGMENTED: return abbreviated ? "aug" : "augmented";
+      case HarmonicAnalysisSymbol::DIMINISHED: return abbreviated ? "dim" : "diminished";
    }
 
    return "[undef]";

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -1,0 +1,21 @@
+
+
+
+#include <fullscore/models/harmonic_analysis_symbol.h>
+
+
+
+HarmonicAnalysisSymbol::HarmonicAnalysisSymbol()
+   : fundamental(0, 0)
+   , quality(MAJOR)
+   , inversion(0)
+   , extensions()
+{}
+
+
+
+HarmonicAnalysisSymbol::~HarmonicAnalysisSymbol()
+{}
+
+
+

--- a/src/models/measures/harmonic_analysis.cpp
+++ b/src/models/measures/harmonic_analysis.cpp
@@ -7,9 +7,18 @@
 
 
 
+Staff::HarmonicAnalysis::HarmonicAnalysisSymbolPlacement::HarmonicAnalysisSymbolPlacement(HarmonicAnalysisSymbol symbol, int measure_num, int beat)
+   : symbol(symbol)
+   , measure_num(measure_num)
+   , beat(beat)
+{}
+
+
+
 Staff::HarmonicAnalysis::HarmonicAnalysis(int num_columns)
    : Base("harmonic_analysis")
    , num_columns(num_columns)
+   , symbols()
 {}
 
 
@@ -68,6 +77,26 @@ int Staff::HarmonicAnalysis::get_num_columns()
 float Staff::HarmonicAnalysis::get_height()
 {
    return 0.9;
+}
+
+
+
+std::vector<std::pair<int, HarmonicAnalysisSymbol>> Staff::HarmonicAnalysis::get_symbols_in_measure(int measure_num)
+{
+   std::vector<std::pair<int, HarmonicAnalysisSymbol>> result = {};
+
+   for (unsigned i=0; i<symbols.size(); i++)
+      if (symbols[i].measure_num == measure_num)
+         result.push_back(std::pair<int, HarmonicAnalysisSymbol>(symbols[i].beat, symbols[i].symbol));
+
+   return result;
+}
+
+
+
+void Staff::HarmonicAnalysis::set_symbol(HarmonicAnalysisSymbol symbol, int measure_num, int beat)
+{
+   symbols.push_back({symbol, measure_num, beat});
 }
 
 

--- a/src/models/measures/harmonic_analysis.cpp
+++ b/src/models/measures/harmonic_analysis.cpp
@@ -1,0 +1,74 @@
+
+
+
+#include <fullscore/models/staves/harmonic_analysis.h>
+
+#include <fullscore/models/measures/base.h>
+
+
+
+Staff::HarmonicAnalysis::HarmonicAnalysis(int num_columns)
+   : Base("harmonic_analysis")
+   , num_columns(num_columns)
+{}
+
+
+
+Staff::HarmonicAnalysis::~HarmonicAnalysis()
+{}
+
+
+
+bool Staff::HarmonicAnalysis::set_column(int column_num, Measure::Base *measure)
+{
+   throw std::runtime_error("Cannot set a measure on a HarmonicAnalysis column");
+}
+
+
+
+bool Staff::HarmonicAnalysis::insert_column(int at_index, Measure::Base *measure)
+{
+   num_columns++;
+   return true;
+}
+
+
+
+bool Staff::HarmonicAnalysis::erase_column(int at_index)
+{
+   if (at_index < 0 || at_index >= num_columns) return false;
+   num_columns--;
+   return true;
+}
+
+
+
+bool Staff::HarmonicAnalysis::append_column(Measure::Base *measure)
+{
+   num_columns++;
+   return true;
+}
+
+
+
+Measure::Base *Staff::HarmonicAnalysis::get_measure(int column_num)
+{
+   return nullptr;
+}
+
+
+
+int Staff::HarmonicAnalysis::get_num_columns()
+{
+   return num_columns;
+}
+
+
+
+float Staff::HarmonicAnalysis::get_height()
+{
+   return 0.9;
+}
+
+
+


### PR DESCRIPTION
This PR adds the ability to add harmonic analysis data into the score.  Now, this picture below is _not_ from FullScore, but rather an illustration of what I'm talking about when I'm referring to a harmonic analysis:

<img width="696" alt="harmonic analysis - google search 2017-09-22 22-08-05" src="https://user-images.githubusercontent.com/772949/30769189-95d4fdd6-9fe2-11e7-8dcd-61e33574d142.png">

This PR adds 3 components:

1. `HarmonicAnalysisSymbol` - These are the individual symbols that appear in the harmonic analysis, and has the following components: fundamental, chord quality, inversion, and note extensions.  In this case, extensions are only integers and should probably be `Note`s eventually.
2. `HarmonicAnalysisStaff` - Simply a staff type that has any number of `HarmonicAnalysisSymbol`s located within the score by measure number and beat.  (beats are measured in integers, should probably be float representing a beat address at some point).
3. `HarmonicAnalysisSymbolRenderer` - A component that is in charge of properly drawing a `HarmonicAnalysisSymbol` to the screen.

Keep in mind, this feature does not _perform_ any analysis, it simply provides the ability to add symbols to a custom staff at the model level.