### PR TITLE
Allow Note Coloring

### DIFF
--- a/include/fullscore/models/Note.h
+++ b/include/fullscore/models/Note.h
@@ -3,12 +3,12 @@
 
 
 #include <fullscore/models/Duration.h>
-
 #include <fullscore/models/pitch.h>
+#include <allegro_flare/attributes.h>
 
 
 
-class Note
+class Note : public Attributes
 {
 public:
    Pitch pitch;

--- a/include/fullscore/models/Note.h
+++ b/include/fullscore/models/Note.h
@@ -11,6 +11,8 @@
 class Note : public Attributes
 {
 public:
+   static const std::string HILIGHT_COLOR_IDENTIFIER;
+
    Pitch pitch;
    Duration duration;
    int is_rest;

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -3,6 +3,7 @@
 
 #include <fullscore/components/measure_render_component.h>
 
+#include <allegro_flare/allegro_color_attribute_datatype.h>
 #include <allegro_flare/framework.h>
 #include <allegro_flare/color.h>
 #include <allegro_flare/useful_php.h>
@@ -74,8 +75,9 @@ void MeasureRenderComponent::render()
 
       if (note.exists(Note::HILIGHT_COLOR_IDENTIFIER))
       {
-         std::string hilight_color = note.get_as_string(Note::HILIGHT_COLOR_IDENTIFIER);
-         al_draw_filled_rectangle(x_cursor, y_pos, x_cursor+width, y_pos+staff_height, color::name(hilight_color.c_str()));
+         ALLEGRO_COLOR col;
+         note.get_as_custom(&col, AllegroColorAttributeDatatype::IDENTIFIER, Note::HILIGHT_COLOR_IDENTIFIER);
+         al_draw_filled_rectangle(x_cursor, y_pos, x_cursor+width, y_pos+staff_height, col);
       }
 
       x_cursor += width;

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -65,6 +65,23 @@ void MeasureRenderComponent::render()
    if (measure->get_num_notes() > 0)
       measure_width = __get_measure_width(measure) * full_measure_width;
 
+   // draw hilight info on the note
+   float x_cursor = x_pos;
+
+   for (auto &note : measure->get_notes_copy())
+   {
+      float width = DurationHelper::get_length(note.duration.denominator, note.duration.dots) * full_measure_width;
+
+      if (note.exists("hilight_color"))
+      {
+         std::string hilight_color = note.get_as_string("hilight_color");
+         al_draw_filled_rectangle(x_cursor, y_pos, x_cursor+width, y_pos+staff_height, color::name(hilight_color.c_str()));
+      }
+
+      x_cursor += width;
+   }
+
+   // draw the hilight selection box for the measure
    if (measure->is_type(Measure::TYPE_IDENTIFIER_REFERENCE_BY_COORDINATE))
       measure_block_color = color::color(color::yellow, 0.1);
    if (measure->is_type(Measure::TYPE_IDENTIFIER_REFERENCE_BY_ID))

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -72,9 +72,9 @@ void MeasureRenderComponent::render()
    {
       float width = DurationHelper::get_length(note.duration.denominator, note.duration.dots) * full_measure_width;
 
-      if (note.exists("hilight_color"))
+      if (note.exists(Note::HILIGHT_COLOR_IDENTIFIER))
       {
-         std::string hilight_color = note.get_as_string("hilight_color");
+         std::string hilight_color = note.get_as_string(Note::HILIGHT_COLOR_IDENTIFIER);
          al_draw_filled_rectangle(x_cursor, y_pos, x_cursor+width, y_pos+staff_height, color::name(hilight_color.c_str()));
       }
 

--- a/src/models/note.cpp
+++ b/src/models/note.cpp
@@ -27,3 +27,7 @@ bool Note::operator==(const Note &other) const
 
 
 
+const std::string Note::HILIGHT_COLOR_IDENTIFIER = "hilight_color";
+
+
+


### PR DESCRIPTION
## Not Using the Approach in this PR

It looks awesome and hopefully I'll be able to keep the style for something in the future.

However, the approach makes too many demands on the `Note` model, which should be essentially atomic.  I'm going to look into using a `NotePlotter` which should remove the need for the `Note` to have any context about how it was derived.

<img width="787" alt="fullscore 2017-09-30 23-49-53" src="https://user-images.githubusercontent.com/772949/31051770-6ab847bc-a63f-11e7-99d2-0ed27b1b8c76.png">