### PR TITLE
Improve Harmonic Analysis Symbol Rendering

### DIFF
--- a/include/fullscore/components/harmonic_analysis_symbol_render_component.hpp
+++ b/include/fullscore/components/harmonic_analysis_symbol_render_component.hpp
@@ -14,12 +14,13 @@ class HarmonicAnalysisSymbolRenderComponent
 {
 private:
    HarmonicAnalysisSymbol symbol;
-   ALLEGRO_FONT *font;
+   ALLEGRO_FONT *large_font;
+   ALLEGRO_FONT *small_font;
    float x;
    float y;
 
 public:
-   HarmonicAnalysisSymbolRenderComponent(ALLEGRO_FONT *font, float x, float y, HarmonicAnalysisSymbol symbol);
+   HarmonicAnalysisSymbolRenderComponent(ALLEGRO_FONT *large_font, ALLEGRO_FONT *small_font, float x, float y, HarmonicAnalysisSymbol symbol);
    void render();
 };
 

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -31,6 +31,7 @@ public:
    static std::string get_chord_quality_symbol_string(chord_quality_t chord_quality);
    static std::string get_roman_numeral_string(int number, chord_quality_t chord_quality);
    static std::string get_accidental_string(int accidental);
+   static std::string get_extensions_string(std::vector<int> extensions);
 };
 
 

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -29,6 +29,7 @@ public:
 
    static std::string get_chord_quality_string(chord_quality_t chord_quality, bool abbreviated=false);
    static std::string get_roman_numeral_string(int number, chord_quality_t chord_quality);
+   static std::string get_accidental_string(int accidental);
 };
 
 

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -28,6 +28,7 @@ public:
    ~HarmonicAnalysisSymbol();
 
    static std::string get_chord_quality_string(chord_quality_t chord_quality, bool abbreviated=false);
+   static std::string get_chord_quality_symbol_string(chord_quality_t chord_quality);
    static std::string get_roman_numeral_string(int number, chord_quality_t chord_quality);
    static std::string get_accidental_string(int accidental);
 };

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -28,7 +28,7 @@ public:
    ~HarmonicAnalysisSymbol();
 
    static std::string get_chord_quality_string(chord_quality_t chord_quality, bool abbreviated=false);
-   static std::string get_roman_numeral_string(int number, bool quality_is_major);
+   static std::string get_roman_numeral_string(int number, chord_quality_t chord_quality);
 };
 
 

--- a/include/fullscore/models/harmonic_analysis_symbol.h
+++ b/include/fullscore/models/harmonic_analysis_symbol.h
@@ -28,6 +28,7 @@ public:
    ~HarmonicAnalysisSymbol();
 
    static std::string get_chord_quality_string(chord_quality_t chord_quality, bool abbreviated=false);
+   static std::string get_roman_numeral_string(int number, bool quality_is_major);
 };
 
 

--- a/src/components/grid_render_component.cpp
+++ b/src/components/grid_render_component.cpp
@@ -88,6 +88,7 @@ void GridRenderComponent::render()
       float this_staff_half_height = this_staff_height * 0.5;
 
       ALLEGRO_FONT *text_font = Framework::font("plantin-mt-light.ttf 22");
+      ALLEGRO_FONT *analysis_font = Framework::font("plantin-mt-light.ttf 36");
 
       // draw the row name
       float row_middle_y = y_counter + this_staff_height * 0.5;
@@ -139,7 +140,7 @@ void GridRenderComponent::render()
                HarmonicAnalysisSymbol &harmonic_analysis_symbol = std::get<1>(marking);
                float marking_x_pos = x_pos + (full_measure_width * 0.25 * beat_coordinate.get_x_offset());
 
-               HarmonicAnalysisSymbolRenderComponent harmonic_analysis_symbol_render_component(text_font, marking_x_pos, label_text_top_y, harmonic_analysis_symbol);
+               HarmonicAnalysisSymbolRenderComponent harmonic_analysis_symbol_render_component(analysis_font, text_font, marking_x_pos, label_text_top_y, harmonic_analysis_symbol);
                harmonic_analysis_symbol_render_component.render();
             }
          }

--- a/src/components/harmonic_analysis_symbol_render_component.cpp
+++ b/src/components/harmonic_analysis_symbol_render_component.cpp
@@ -4,14 +4,15 @@
 #include <fullscore/components/harmonic_analysis_symbol_render_component.hpp>
 
 #include <allegro5/allegro_font.h>
+#include <allegro_flare/useful.h>
 #include <allegro_flare/color.h>
-#include <sstream>
 
 
 
-HarmonicAnalysisSymbolRenderComponent::HarmonicAnalysisSymbolRenderComponent(ALLEGRO_FONT *font, float x, float y, HarmonicAnalysisSymbol symbol)
+HarmonicAnalysisSymbolRenderComponent::HarmonicAnalysisSymbolRenderComponent(ALLEGRO_FONT *large_font, ALLEGRO_FONT *small_font, float x, float y, HarmonicAnalysisSymbol symbol)
    : symbol(symbol)
-   , font(font)
+   , large_font(large_font)
+   , small_font(small_font)
    , x(x)
    , y(y)
 {}
@@ -20,14 +21,20 @@ HarmonicAnalysisSymbolRenderComponent::HarmonicAnalysisSymbolRenderComponent(ALL
 
 void HarmonicAnalysisSymbolRenderComponent::render()
 {
-   if (!font) throw std::invalid_argument("Cannot render HarmonicAnalysisSymbol with a nullptr font");
-   std::stringstream ss;
+   if (!large_font) throw std::invalid_argument("Cannot render HarmonicAnalysisSymbol with a nullptr large_font");
+   if (!small_font) throw std::invalid_argument("Cannot render HarmonicAnalysisSymbol with a nullptr small_font");
 
-   ss << symbol.fundamental.scale_degree
-      << ":" << symbol.fundamental.accidental
-      << ":" << HarmonicAnalysisSymbol::get_chord_quality_string(symbol.chord_quality);
+   std::string roman_numeral_string = HarmonicAnalysisSymbol::get_roman_numeral_string(symbol.fundamental.scale_degree, symbol.chord_quality);
+   std::string accidental = HarmonicAnalysisSymbol::get_accidental_string(symbol.fundamental.accidental);
 
-   al_draw_text(font, color::black, x, y, ALLEGRO_ALIGN_CENTER, ss.str().c_str());
+   float roman_numeral_text_width = al_get_text_width(large_font, roman_numeral_string.c_str());
+   float line_height = al_get_font_line_height(large_font);
+
+   std::string quality = HarmonicAnalysisSymbol::get_chord_quality_string(symbol.chord_quality, true);
+
+   al_draw_text(large_font, color::black, x, y, ALLEGRO_ALIGN_CENTER, roman_numeral_string.c_str());
+   al_draw_text(small_font, color::black, x-roman_numeral_text_width/2, y, ALLEGRO_ALIGN_RIGHT, accidental.c_str());
+   al_draw_text(small_font, color::black, x+roman_numeral_text_width/2, y, ALLEGRO_ALIGN_LEFT, quality.c_str());
 }
 
 

--- a/src/components/harmonic_analysis_symbol_render_component.cpp
+++ b/src/components/harmonic_analysis_symbol_render_component.cpp
@@ -31,7 +31,6 @@ void HarmonicAnalysisSymbolRenderComponent::render()
 
    float roman_numeral_text_width = al_get_text_width(large_font, roman_numeral_string.c_str());
    float quality_symbol_text_width = al_get_text_width(small_font, quality_symbol.c_str());
-   float line_height = al_get_font_line_height(large_font);
 
    al_draw_text(large_font, color::black, x, y, ALLEGRO_ALIGN_CENTER, roman_numeral_string.c_str());
    al_draw_text(small_font, color::black, x-roman_numeral_text_width/2, y, ALLEGRO_ALIGN_RIGHT, accidental.c_str());

--- a/src/components/harmonic_analysis_symbol_render_component.cpp
+++ b/src/components/harmonic_analysis_symbol_render_component.cpp
@@ -30,11 +30,11 @@ void HarmonicAnalysisSymbolRenderComponent::render()
    float roman_numeral_text_width = al_get_text_width(large_font, roman_numeral_string.c_str());
    float line_height = al_get_font_line_height(large_font);
 
-   std::string quality = HarmonicAnalysisSymbol::get_chord_quality_string(symbol.chord_quality, true);
+   std::string quality_symbol = HarmonicAnalysisSymbol::get_chord_quality_symbol_string(symbol.chord_quality);
 
    al_draw_text(large_font, color::black, x, y, ALLEGRO_ALIGN_CENTER, roman_numeral_string.c_str());
    al_draw_text(small_font, color::black, x-roman_numeral_text_width/2, y, ALLEGRO_ALIGN_RIGHT, accidental.c_str());
-   al_draw_text(small_font, color::black, x+roman_numeral_text_width/2, y, ALLEGRO_ALIGN_LEFT, quality.c_str());
+   al_draw_text(small_font, color::black, x+roman_numeral_text_width/2, y, ALLEGRO_ALIGN_LEFT, quality_symbol.c_str());
 }
 
 

--- a/src/components/harmonic_analysis_symbol_render_component.cpp
+++ b/src/components/harmonic_analysis_symbol_render_component.cpp
@@ -26,11 +26,10 @@ void HarmonicAnalysisSymbolRenderComponent::render()
 
    std::string roman_numeral_string = HarmonicAnalysisSymbol::get_roman_numeral_string(symbol.fundamental.scale_degree, symbol.chord_quality);
    std::string accidental = HarmonicAnalysisSymbol::get_accidental_string(symbol.fundamental.accidental);
+   std::string quality_symbol = HarmonicAnalysisSymbol::get_chord_quality_symbol_string(symbol.chord_quality);
 
    float roman_numeral_text_width = al_get_text_width(large_font, roman_numeral_string.c_str());
    float line_height = al_get_font_line_height(large_font);
-
-   std::string quality_symbol = HarmonicAnalysisSymbol::get_chord_quality_symbol_string(symbol.chord_quality);
 
    al_draw_text(large_font, color::black, x, y, ALLEGRO_ALIGN_CENTER, roman_numeral_string.c_str());
    al_draw_text(small_font, color::black, x-roman_numeral_text_width/2, y, ALLEGRO_ALIGN_RIGHT, accidental.c_str());

--- a/src/components/harmonic_analysis_symbol_render_component.cpp
+++ b/src/components/harmonic_analysis_symbol_render_component.cpp
@@ -26,14 +26,17 @@ void HarmonicAnalysisSymbolRenderComponent::render()
 
    std::string roman_numeral_string = HarmonicAnalysisSymbol::get_roman_numeral_string(symbol.fundamental.scale_degree, symbol.chord_quality);
    std::string accidental = HarmonicAnalysisSymbol::get_accidental_string(symbol.fundamental.accidental);
+   std::string extensions_string = HarmonicAnalysisSymbol::get_extensions_string(symbol.extensions);
    std::string quality_symbol = HarmonicAnalysisSymbol::get_chord_quality_symbol_string(symbol.chord_quality);
 
    float roman_numeral_text_width = al_get_text_width(large_font, roman_numeral_string.c_str());
+   float quality_symbol_text_width = al_get_text_width(small_font, quality_symbol.c_str());
    float line_height = al_get_font_line_height(large_font);
 
    al_draw_text(large_font, color::black, x, y, ALLEGRO_ALIGN_CENTER, roman_numeral_string.c_str());
    al_draw_text(small_font, color::black, x-roman_numeral_text_width/2, y, ALLEGRO_ALIGN_RIGHT, accidental.c_str());
    al_draw_text(small_font, color::black, x+roman_numeral_text_width/2, y, ALLEGRO_ALIGN_LEFT, quality_symbol.c_str());
+   al_draw_multiline_text(small_font, color::black, x+roman_numeral_text_width/2+quality_symbol_text_width + 3, y, 10, al_get_font_line_height(small_font)*0.8, 0, extensions_string.c_str());
 }
 
 

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -81,8 +81,31 @@ Grid GridFactory::string_quartet()
       {
          Staff::HarmonicAnalysis *staff = new Staff::HarmonicAnalysis(NUM_MEASURES);
          grid.append_staff(staff);
-         HarmonicAnalysisSymbol harmonic_analysis_symbol(Pitch(3, -1), HarmonicAnalysisSymbol::MAJOR, 1, {});
-         staff->set_symbol(GridHorizontalCoordinate(1, 2), harmonic_analysis_symbol);
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(0, 0),
+            HarmonicAnalysisSymbol(Pitch(6, -1), HarmonicAnalysisSymbol::DIMINISHED, 1, {})
+         );
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(1, 2),
+            HarmonicAnalysisSymbol(Pitch(9, 0), HarmonicAnalysisSymbol::MAJOR, 1, {})
+         );
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(2, 0),
+            HarmonicAnalysisSymbol(Pitch(10, 0), HarmonicAnalysisSymbol::MINOR, 1, {})
+         );
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(3, 2),
+            HarmonicAnalysisSymbol(Pitch(4, 0), HarmonicAnalysisSymbol::AUGMENTED, 1, {})
+         );
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(4, 0),
+            HarmonicAnalysisSymbol(Pitch(3, 0), HarmonicAnalysisSymbol::MAJOR, 1, {})
+         );
       }
       else if (voices[i] == TEMPO)
       {

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -34,8 +34,10 @@ std::string HarmonicAnalysisSymbol::get_chord_quality_string(chord_quality_t cho
 
 
 
-std::string HarmonicAnalysisSymbol::get_roman_numeral_string(int number, bool quality_is_major)
+std::string HarmonicAnalysisSymbol::get_roman_numeral_string(int number, chord_quality_t chord_quality)
 {
+   bool quality_is_major = (chord_quality == MAJOR || chord_quality == AUGMENTED);
+
    switch(number)
    {
    case 0: return quality_is_major ? "O" : "o"; break;

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -34,3 +34,25 @@ std::string HarmonicAnalysisSymbol::get_chord_quality_string(chord_quality_t cho
 
 
 
+std::string HarmonicAnalysisSymbol::get_roman_numeral_string(int number, bool quality_is_major)
+{
+   switch(number)
+   {
+   case 0: return quality_is_major ? "O" : "o"; break;
+   case 1: return quality_is_major ? "I" : "i"; break;
+   case 2: return quality_is_major ? "II" : "ii"; break;
+   case 3: return quality_is_major ? "III" : "iii"; break;
+   case 4: return quality_is_major ? "IV" : "iv"; break;
+   case 5: return quality_is_major ? "V" : "v"; break;
+   case 6: return quality_is_major ? "VI" : "vi"; break;
+   case 7: return quality_is_major ? "VII" : "vii"; break;
+   case 8: return quality_is_major ? "IIX" : "iix"; break;
+   case 9: return quality_is_major ? "IX" : "ix"; break;
+   case 10: return quality_is_major ? "X" : "x"; break;
+   case 11: return quality_is_major ? "XI" : "xi"; break;
+   default: return "--"; break;
+   }
+}
+
+
+

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -92,3 +92,17 @@ std::string HarmonicAnalysisSymbol::get_accidental_string(int accidental)
 
 
 
+std::string HarmonicAnalysisSymbol::get_extensions_string(std::vector<int> extensions)
+{
+   std::stringstream ss;
+   int num_extensions = extensions.size();
+   for (unsigned i=0; i<num_extensions; i++)
+   {
+      ss << extensions[i];
+      if (i != num_extensions-1) ss << "\n";
+   }
+   return ss.str();
+}
+
+
+

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -3,6 +3,8 @@
 
 #include <fullscore/models/harmonic_analysis_symbol.h>
 
+#include <sstream>
+
 
 
 HarmonicAnalysisSymbol::HarmonicAnalysisSymbol(Pitch fundamental, chord_quality_t chord_quality, int inversion, std::vector<int> extensions)
@@ -54,6 +56,16 @@ std::string HarmonicAnalysisSymbol::get_roman_numeral_string(int number, chord_q
    case 11: return quality_is_major ? "XI" : "xi"; break;
    default: return "--"; break;
    }
+}
+
+
+
+std::string HarmonicAnalysisSymbol::get_accidental_string(int accidental)
+{
+   std::stringstream ss;
+   while (accidental < 0) { ss << "b"; accidental++; }
+   while (accidental > 0) { ss << "#"; accidental--; }
+   return ss.str();
 }
 
 

--- a/src/models/harmonic_analysis_symbol.cpp
+++ b/src/models/harmonic_analysis_symbol.cpp
@@ -36,6 +36,28 @@ std::string HarmonicAnalysisSymbol::get_chord_quality_string(chord_quality_t cho
 
 
 
+std::string HarmonicAnalysisSymbol::get_chord_quality_symbol_string(chord_quality_t chord_quality)
+{
+   switch(chord_quality)
+   {
+   case HarmonicAnalysisSymbol::MAJOR:
+   case HarmonicAnalysisSymbol::MINOR:
+      return "";
+      break;
+   case HarmonicAnalysisSymbol::AUGMENTED:
+      return "+";
+      break;
+   case HarmonicAnalysisSymbol::DIMINISHED:
+      return "o";
+      break;
+   default:
+      return "";
+      break;
+   }
+}
+
+
+
 std::string HarmonicAnalysisSymbol::get_roman_numeral_string(int number, chord_quality_t chord_quality)
 {
    bool quality_is_major = (chord_quality == MAJOR || chord_quality == AUGMENTED);

--- a/tests/models/harmonic_analysis_symbol_test.cpp
+++ b/tests/models/harmonic_analysis_symbol_test.cpp
@@ -21,8 +21,11 @@ TEST(HarmonicAnalysisSymbolTest, returns_major_and_minor_roman_numerals_for_valu
 
    for (int i=0; i<expected_major_values.size(); i++)
    {
-      ASSERT_EQ(expected_major_values[i], HarmonicAnalysisSymbol::get_roman_numeral_string(i, true));
-      ASSERT_EQ(expected_minor_values[i], HarmonicAnalysisSymbol::get_roman_numeral_string(i, false));
+      ASSERT_EQ(expected_major_values[i], HarmonicAnalysisSymbol::get_roman_numeral_string(i, HarmonicAnalysisSymbol::MAJOR));
+      ASSERT_EQ(expected_major_values[i], HarmonicAnalysisSymbol::get_roman_numeral_string(i, HarmonicAnalysisSymbol::AUGMENTED));
+
+      ASSERT_EQ(expected_minor_values[i], HarmonicAnalysisSymbol::get_roman_numeral_string(i, HarmonicAnalysisSymbol::MINOR));
+      ASSERT_EQ(expected_minor_values[i], HarmonicAnalysisSymbol::get_roman_numeral_string(i, HarmonicAnalysisSymbol::DIMINISHED));
    }
 }
 
@@ -32,13 +35,13 @@ TEST(HarmonicAnalysisSymbolTest, with_a_scale_degree_that_does_not_exist_returns
 {
    std::string expected_string = "--";
 
-   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(12, true));
-   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(999, true));
-   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(-1, true));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(12, HarmonicAnalysisSymbol::MAJOR));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(999, HarmonicAnalysisSymbol::MAJOR));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(-1, HarmonicAnalysisSymbol::MAJOR));
 
-   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(12, false));
-   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(999, false));
-   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(-1, false));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(12, HarmonicAnalysisSymbol::MINOR));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(999, HarmonicAnalysisSymbol::MINOR));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(-1, HarmonicAnalysisSymbol::MINOR));
 }
 
 

--- a/tests/models/harmonic_analysis_symbol_test.cpp
+++ b/tests/models/harmonic_analysis_symbol_test.cpp
@@ -46,6 +46,19 @@ TEST(HarmonicAnalysisSymbolTest, with_a_scale_degree_that_does_not_exist_returns
 
 
 
+TEST(HarmonicAnalysisSymbolTest, returns_a_string_from_accidental)
+{
+   ASSERT_EQ("b", HarmonicAnalysisSymbol::get_accidental_string(-1));
+   ASSERT_EQ("bbb", HarmonicAnalysisSymbol::get_accidental_string(-3));
+
+   ASSERT_EQ("", HarmonicAnalysisSymbol::get_accidental_string(0));
+
+   ASSERT_EQ("#", HarmonicAnalysisSymbol::get_accidental_string(1));
+   ASSERT_EQ("###", HarmonicAnalysisSymbol::get_accidental_string(3));
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/models/harmonic_analysis_symbol_test.cpp
+++ b/tests/models/harmonic_analysis_symbol_test.cpp
@@ -59,6 +59,17 @@ TEST(HarmonicAnalysisSymbolTest, returns_a_string_from_accidental)
 
 
 
+TEST(HarmonicAnalysisSymbolTest, returns_a_string_for_a_chord_quality_symbol)
+{
+   ASSERT_EQ("o", HarmonicAnalysisSymbol::get_chord_quality_symbol_string(HarmonicAnalysisSymbol::DIMINISHED));
+   ASSERT_EQ("+", HarmonicAnalysisSymbol::get_chord_quality_symbol_string(HarmonicAnalysisSymbol::AUGMENTED));
+
+   ASSERT_EQ("", HarmonicAnalysisSymbol::get_chord_quality_symbol_string(HarmonicAnalysisSymbol::MAJOR));
+   ASSERT_EQ("", HarmonicAnalysisSymbol::get_chord_quality_symbol_string(HarmonicAnalysisSymbol::MINOR));
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/models/harmonic_analysis_symbol_test.cpp
+++ b/tests/models/harmonic_analysis_symbol_test.cpp
@@ -70,6 +70,13 @@ TEST(HarmonicAnalysisSymbolTest, returns_a_string_for_a_chord_quality_symbol)
 
 
 
+TEST(HarmonicAnalysisSymbol, returns_an_extension_string_by_interploating_newlines)
+{
+   ASSERT_EQ("6\n4\n12", HarmonicAnalysisSymbol::get_extensions_string({ 6, 4, 12 }));
+}
+
+
+
 int main(int argc, char **argv)
 {
    ::testing::InitGoogleTest(&argc, argv);

--- a/tests/models/harmonic_analysis_symbol_test.cpp
+++ b/tests/models/harmonic_analysis_symbol_test.cpp
@@ -1,0 +1,53 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/harmonic_analysis_symbol.h>
+
+
+
+TEST(HarmonicAnalysisSymbolTest, can_be_created)
+{
+   HarmonicAnalysisSymbol harmonic_analysis_symbol(0, HarmonicAnalysisSymbol::MAJOR, 0, {});
+}
+
+
+
+TEST(HarmonicAnalysisSymbolTest, returns_major_and_minor_roman_numerals_for_values_0_to_11)
+{
+   std::vector<std::string> expected_major_values = { "O", "I", "II", "III", "IV", "V", "VI", "VII", "IIX", "IX", "X", "XI" };
+   std::vector<std::string> expected_minor_values = { "o", "i", "ii", "iii", "iv", "v", "vi", "vii", "iix", "ix", "x", "xi" };
+
+   for (int i=0; i<expected_major_values.size(); i++)
+   {
+      ASSERT_EQ(expected_major_values[i], HarmonicAnalysisSymbol::get_roman_numeral_string(i, true));
+      ASSERT_EQ(expected_minor_values[i], HarmonicAnalysisSymbol::get_roman_numeral_string(i, false));
+   }
+}
+
+
+
+TEST(HarmonicAnalysisSymbolTest, with_a_scale_degree_that_does_not_exist_returns_dashes)
+{
+   std::string expected_string = "--";
+
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(12, true));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(999, true));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(-1, true));
+
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(12, false));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(999, false));
+   ASSERT_EQ(expected_string, HarmonicAnalysisSymbol::get_roman_numeral_string(-1, false));
+}
+
+
+
+int main(int argc, char **argv)
+{
+   ::testing::InitGoogleTest(&argc, argv);
+   return RUN_ALL_TESTS();
+}
+
+
+


### PR DESCRIPTION
Current rendering of `HarmonicAnalysisSymbols` is very rudimentary, basically just a string dump.  This PR improves the rendering to be much more familiar:

<img width="289" alt="fullscore 2017-10-08 02-55-41" src="https://user-images.githubusercontent.com/772949/31319902-85504e80-ac39-11e7-80aa-e794e334a3f6.png">

And also provides support for non-diatonic chord analysis symbols:

<img width="511" alt="fullscore 2017-10-08 03-01-16" src="https://user-images.githubusercontent.com/772949/31314693-07994582-abd5-11e7-97de-11a408205adf.png">
