### PR TITLE
Add Basic Plotter

### DIFF
--- a/bin/data/config/config.cfg
+++ b/bin/data/config/config.cfg
@@ -6,3 +6,7 @@ background_color_hex = #e0dad4
 
 resolution_x = 2320
 resolution_y = 1380
+
+[FULLSCORE_SETTINGS]
+
+init_template = testing_template

--- a/include/fullscore/app_controller.h
+++ b/include/fullscore/app_controller.h
@@ -18,8 +18,8 @@
 class AppController : public UIScreen
 {
 public:
+   Config &config;
    SimpleNotificationScreen *simple_notification_screen;
-
    Action::Queue action_queue;
    UIFollowCamera follow_camera;
    UIGridEditor *current_grid_editor;
@@ -33,7 +33,7 @@ public:
    KeyboardCommandMapper normal_mode_note_keyboard_mappings;
    KeyboardCommandMapper normal_mode_measure_keyboard_mappings;
 
-   AppController(Display *display);
+   AppController(Display *display, Config &config);
    void primary_timer_func() override;
    void key_char_func() override;
    void on_message(UIWidget *sender, std::string message) override;

--- a/include/fullscore/factories/grid_factory.h
+++ b/include/fullscore/factories/grid_factory.h
@@ -13,6 +13,7 @@ public:
    static Grid big_score();
    static Grid full_score();
    static Grid string_quartet();
+   static Grid testing_template();
    static Grid create(std::string identifier);
 };
 

--- a/include/fullscore/models/measures/plotted.h
+++ b/include/fullscore/models/measures/plotted.h
@@ -6,20 +6,16 @@
 
 
 
-namespace Plotter { class Base; }
-
-
-
 namespace Measure
 {
    class Plotted : public Base
    {
    private:
-      Plotter::Base *plotter;
-      std::vector<Note> get_plotted_notes();
+      std::vector<Note> notes;
 
    public:
-      Plotted(Plotter::Base *plotter);
+      Plotted(std::vector<Note> notes = {});
+      ~Plotted();
 
       virtual int get_num_notes() override;
       virtual std::vector<Note> get_notes_copy() override;

--- a/include/fullscore/models/plotter.h
+++ b/include/fullscore/models/plotter.h
@@ -1,0 +1,13 @@
+#pragma once
+
+
+
+namespace Plotter
+{
+   std::string const TYPE_IDENTIFIER_BASE        = "base";
+   std::string const TYPE_IDENTIFIER_BASIC       = "basic";
+   std::string const TYPE_IDENTIFIER_DESTINATION = "destination";
+};
+
+
+

--- a/include/fullscore/models/plotters/basic.h
+++ b/include/fullscore/models/plotters/basic.h
@@ -1,0 +1,32 @@
+#pragma once
+
+
+
+#include <fullscore/models/plotters/base.h>
+#include <fullscore/models/Note.h>
+
+
+
+class Grid;
+
+
+
+namespace Plotter
+{
+   class Basic : public Base
+   {
+   private:
+      Grid *grid;
+      int barline_num;
+      Note note;
+
+   public:
+      Basic(Grid *grid, int barline_num, Note note);
+      ~Basic();
+
+      bool plot() override;
+   };
+}
+
+
+

--- a/programs/fullscore.cpp
+++ b/programs/fullscore.cpp
@@ -16,7 +16,7 @@ int main(int argc, char *argv[])
          config.get_or_default_int("GLOBAL_SETTINGS", "resolution_x", 800),
          config.get_or_default_int("GLOBAL_SETTINGS", "resolution_y", 600)
       );
-   AppController app_controller(d);
+   AppController app_controller(d, config);
    Framework::run_loop();
 
    return 0;

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -3,7 +3,7 @@
 
 #include <fullscore/app_controller.h>
 
-#include <fullscore/models/plotters/destination.h>
+#include <fullscore/models/plotters/basic.h>
 #include <fullscore/factories/action_factory.h>
 #include <fullscore/factories/grid_factory.h>
 #include <fullscore/models/floating_measure.h>
@@ -35,23 +35,18 @@ AppController::AppController(Display *display)
 
 
 
-   Plotter::Destination *destination_plotter = new Plotter::Destination();
+   Plotter::Basic basic_plotter_1 = Plotter::Basic(&current_grid_editor->grid, 3, Note(-1, Duration(Duration::HALF, 1)));
+   basic_plotter_1.plot();
 
-   std::vector<GridCoordinate> destinations = {
-      GridCoordinate(&current_grid_editor->grid, 2, 3, 0),
-      GridCoordinate(&current_grid_editor->grid, 3, 2, 0),
-      GridCoordinate(&current_grid_editor->grid, 4, 3, 0)
-   };
-
-   for (auto &destination : destinations) destination_plotter->add_destination(destination);
-
-   destination_plotter->plot();
+   Plotter::Basic basic_plotter_2 = Plotter::Basic(&current_grid_editor->grid, 5, Note(-3, Duration(Duration::HALF, 1)));
+   basic_plotter_2.plot();
 
 
-
+/*
    Measure::Basic *basic_measure = new Measure::Basic({ Note(1), Note(-5), Note(3) });
    Staff::Base *staff_to_put_measure = Staff::find_first_of_type(Staff::TYPE_IDENTIFIER_INSTRUMENT);
    FloatingMeasure *floating_measure = new FloatingMeasure(GridCoordinate(&current_grid_editor->grid, staff_to_put_measure->get_id(), 2), basic_measure->get_id());
+*/
 
 
 

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -3,7 +3,6 @@
 
 #include <fullscore/app_controller.h>
 
-#include <fullscore/models/plotters/basic.h>
 #include <fullscore/factories/action_factory.h>
 #include <fullscore/factories/grid_factory.h>
 #include <fullscore/models/floating_measure.h>
@@ -32,23 +31,6 @@ AppController::AppController(Display *display)
    UIScreen::draw_focused_outline = false;
 
    set_current_grid_editor(create_new_grid_editor("string_quartet"));
-
-
-
-   Plotter::Basic basic_plotter_1 = Plotter::Basic(&current_grid_editor->grid, 3, Note(-1, Duration(Duration::HALF, 1)));
-   basic_plotter_1.plot();
-
-   Plotter::Basic basic_plotter_2 = Plotter::Basic(&current_grid_editor->grid, 5, Note(-3, Duration(Duration::HALF, 1)));
-   basic_plotter_2.plot();
-
-
-/*
-   Measure::Basic *basic_measure = new Measure::Basic({ Note(1), Note(-5), Note(3) });
-   Staff::Base *staff_to_put_measure = Staff::find_first_of_type(Staff::TYPE_IDENTIFIER_INSTRUMENT);
-   FloatingMeasure *floating_measure = new FloatingMeasure(GridCoordinate(&current_grid_editor->grid, staff_to_put_measure->get_id(), 2), basic_measure->get_id());
-*/
-
-
 
    set_keyboard_input_mappings();
 }

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -13,8 +13,9 @@
 
 
 
-AppController::AppController(Display *display)
+AppController::AppController(Display *display, Config &config)
    : UIScreen(display)
+   , config(config)
    , simple_notification_screen(new SimpleNotificationScreen(display, Framework::font("DroidSans.ttf 20")))
    , action_queue("master_queue")
    , follow_camera(this)
@@ -30,7 +31,8 @@ AppController::AppController(Display *display)
 {
    UIScreen::draw_focused_outline = false;
 
-   set_current_grid_editor(create_new_grid_editor("string_quartet"));
+   std::string init_template_identifier = config.get_or_default_str("FULLSCORE_SETTINGS", "init_template", "string_quartet");
+   set_current_grid_editor(create_new_grid_editor(init_template_identifier));
 
    set_keyboard_input_mappings();
 }

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -227,12 +227,103 @@ Grid GridFactory::full_score()
 
 
 
+Grid GridFactory::testing_template()
+{
+   std::vector<std::string> voices = {
+      MEASURE_NUMBERS,
+      TEMPO,
+      "Violin I",
+      "Violin II",
+      "Viola",
+      "Cello",
+      HARMONIC_ANALYSIS,
+   };
+
+   const int NUM_MEASURES = 20;
+
+   Grid grid(NUM_MEASURES, 0);
+
+   for (int i=0; i<voices.size(); i++)
+   {
+      if (voices[i] == MEASURE_NUMBERS)
+      {
+         grid.append_staff(new Staff::MeasureNumbers(NUM_MEASURES));
+      }
+      else if (voices[i] == SPACER)
+      {
+         grid.append_staff(new Staff::Spacer(NUM_MEASURES));
+      }
+      else if (voices[i] == HARMONIC_ANALYSIS)
+      {
+         Staff::HarmonicAnalysis *staff = new Staff::HarmonicAnalysis(NUM_MEASURES);
+         grid.append_staff(staff);
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(0, 0),
+            HarmonicAnalysisSymbol(Pitch(6, -1), HarmonicAnalysisSymbol::DIMINISHED, 1, {})
+         );
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(1, 2),
+            HarmonicAnalysisSymbol(Pitch(9, 0), HarmonicAnalysisSymbol::MAJOR, 1, {})
+         );
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(2, 0),
+            HarmonicAnalysisSymbol(Pitch(10, 0), HarmonicAnalysisSymbol::MINOR, 1, {})
+         );
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(3, 2),
+            HarmonicAnalysisSymbol(Pitch(4, 0), HarmonicAnalysisSymbol::AUGMENTED, 1, {})
+         );
+
+         staff->set_symbol(
+            GridHorizontalCoordinate(4, 0),
+            HarmonicAnalysisSymbol(Pitch(3, 0), HarmonicAnalysisSymbol::MAJOR, 1, {})
+         );
+      }
+      else if (voices[i] == TEMPO)
+      {
+         Staff::Tempo *tempo_staff = new Staff::Tempo(NUM_MEASURES);
+         grid.append_staff(tempo_staff);
+         TempoMarking tempo_marking(Duration(Duration::QUARTER), 128);
+         tempo_staff->set_tempo_marking(0, 0, tempo_marking);
+      }
+      else
+      {
+         grid.append_staff(new Staff::Instrument(NUM_MEASURES));
+         grid.set_voice_name(i, voices[i]);
+      }
+   }
+
+
+
+   Plotter::Basic basic_plotter_1 = Plotter::Basic(&grid, 3, Note(-1, Duration(Duration::HALF, 1)));
+   basic_plotter_1.plot();
+
+   Plotter::Basic basic_plotter_2 = Plotter::Basic(&grid, 5, Note(-3, Duration(Duration::HALF, 1)));
+   basic_plotter_2.plot();
+
+
+/*
+   Measure::Basic *basic_measure = new Measure::Basic({ Note(1), Note(-5), Note(3) });
+   Staff::Base *staff_to_put_measure = Staff::find_first_of_type(Staff::TYPE_IDENTIFIER_INSTRUMENT);
+   FloatingMeasure *floating_measure = new FloatingMeasure(GridCoordinate(&current_grid_editor->grid, staff_to_put_measure->get_id(), 2), basic_measure->get_id());
+*/
+
+   return grid;
+}
+
+
+
 Grid GridFactory::create(std::string identifier)
 {
    if (identifier == "big_score") return big_score();
    if (identifier == "twinkle_twinkle") return twinkle_twinkle_little_star();
    if (identifier == "full_score") return full_score();
    if (identifier == "string_quartet") return string_quartet();
+   if (identifier == "testing_template") return testing_template();
 
    std::cout << "Could not find score " << identifier << std::endl;
    return Grid(4, 1);

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -3,6 +3,7 @@
 
 #include <fullscore/factories/grid_factory.h>
 #include <fullscore/models/measures/basic.h>
+#include <fullscore/models/plotters/basic.h>
 #include <fullscore/models/staves/harmonic_analysis.h>
 #include <fullscore/models/staves/measure_numbers.h>
 #include <fullscore/models/staves/instrument.h>
@@ -120,6 +121,24 @@ Grid GridFactory::string_quartet()
          grid.set_voice_name(i, voices[i]);
       }
    }
+
+
+
+   Plotter::Basic basic_plotter_1 = Plotter::Basic(&grid, 3, Note(-1, Duration(Duration::HALF, 1)));
+   basic_plotter_1.plot();
+
+   Plotter::Basic basic_plotter_2 = Plotter::Basic(&grid, 5, Note(-3, Duration(Duration::HALF, 1)));
+   basic_plotter_2.plot();
+
+
+/*
+   Measure::Basic *basic_measure = new Measure::Basic({ Note(1), Note(-5), Note(3) });
+   Staff::Base *staff_to_put_measure = Staff::find_first_of_type(Staff::TYPE_IDENTIFIER_INSTRUMENT);
+   FloatingMeasure *floating_measure = new FloatingMeasure(GridCoordinate(&current_grid_editor->grid, staff_to_put_measure->get_id(), 2), basic_measure->get_id());
+*/
+
+
+
 
    return grid;
 }

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -61,7 +61,6 @@ Grid GridFactory::string_quartet()
       "Violin II",
       "Viola",
       "Cello",
-      HARMONIC_ANALYSIS,
    };
 
    const int NUM_MEASURES = 20;
@@ -73,40 +72,6 @@ Grid GridFactory::string_quartet()
       if (voices[i] == MEASURE_NUMBERS)
       {
          grid.append_staff(new Staff::MeasureNumbers(NUM_MEASURES));
-      }
-      else if (voices[i] == SPACER)
-      {
-         grid.append_staff(new Staff::Spacer(NUM_MEASURES));
-      }
-      else if (voices[i] == HARMONIC_ANALYSIS)
-      {
-         Staff::HarmonicAnalysis *staff = new Staff::HarmonicAnalysis(NUM_MEASURES);
-         grid.append_staff(staff);
-
-         staff->set_symbol(
-            GridHorizontalCoordinate(0, 0),
-            HarmonicAnalysisSymbol(Pitch(6, -1), HarmonicAnalysisSymbol::DIMINISHED, 1, {})
-         );
-
-         staff->set_symbol(
-            GridHorizontalCoordinate(1, 2),
-            HarmonicAnalysisSymbol(Pitch(9, 0), HarmonicAnalysisSymbol::MAJOR, 1, {})
-         );
-
-         staff->set_symbol(
-            GridHorizontalCoordinate(2, 0),
-            HarmonicAnalysisSymbol(Pitch(10, 0), HarmonicAnalysisSymbol::MINOR, 1, {})
-         );
-
-         staff->set_symbol(
-            GridHorizontalCoordinate(3, 2),
-            HarmonicAnalysisSymbol(Pitch(4, 0), HarmonicAnalysisSymbol::AUGMENTED, 1, {})
-         );
-
-         staff->set_symbol(
-            GridHorizontalCoordinate(4, 0),
-            HarmonicAnalysisSymbol(Pitch(3, 0), HarmonicAnalysisSymbol::MAJOR, 1, {})
-         );
       }
       else if (voices[i] == TEMPO)
       {
@@ -121,24 +86,6 @@ Grid GridFactory::string_quartet()
          grid.set_voice_name(i, voices[i]);
       }
    }
-
-
-
-   Plotter::Basic basic_plotter_1 = Plotter::Basic(&grid, 3, Note(-1, Duration(Duration::HALF, 1)));
-   basic_plotter_1.plot();
-
-   Plotter::Basic basic_plotter_2 = Plotter::Basic(&grid, 5, Note(-3, Duration(Duration::HALF, 1)));
-   basic_plotter_2.plot();
-
-
-/*
-   Measure::Basic *basic_measure = new Measure::Basic({ Note(1), Note(-5), Note(3) });
-   Staff::Base *staff_to_put_measure = Staff::find_first_of_type(Staff::TYPE_IDENTIFIER_INSTRUMENT);
-   FloatingMeasure *floating_measure = new FloatingMeasure(GridCoordinate(&current_grid_editor->grid, staff_to_put_measure->get_id(), 2), basic_measure->get_id());
-*/
-
-
-
 
    return grid;
 }

--- a/src/models/measures/plotted.cpp
+++ b/src/models/measures/plotted.cpp
@@ -3,53 +3,44 @@
 
 #include <fullscore/models/measures/plotted.h>
 
-#include <fullscore/models/plotters/destination.h>
 #include <fullscore/models/measure.h>
 #include <fullscore/models/Note.h>
 #include <allegro_flare/useful.h>
 
 
 
-Measure::Plotted::Plotted(Plotter::Base *plotter)
+Measure::Plotted::Plotted(std::vector<Note> notes)
    : Base(Measure::TYPE_IDENTIFIER_PLOTTED)
-   , plotter(plotter)
-{}
-
-
-
-std::vector<Note> Measure::Plotted::get_plotted_notes()
+   , notes(notes)
 {
-   if (!plotter)
-   {
-      Note returned_note = Note(0, Duration::WHOLE);
-      returned_note.is_rest = true;
-      return { returned_note };
-   }
+}
 
-   // some placeholder code
-   // TODO figure out how to place notes into a plotted staff
-   return { Note(0), Note(3), Note(4), Note(5) };
+
+
+Measure::Plotted::~Plotted()
+{
 }
 
 
 
 bool Measure::Plotted::set_notes(std::vector<Note> notes)
 {
-   return false;
+   this->notes = notes;
+   return true;
 }
 
 
 
 int Measure::Plotted::get_num_notes()
 {
-   return get_plotted_notes().size();
+   return notes.size();
 }
 
 
 
 std::vector<Note> Measure::Plotted::get_notes_copy()
 {
-   return get_plotted_notes();
+   return notes;
 }
 
 

--- a/src/models/plotters/basic.cpp
+++ b/src/models/plotters/basic.cpp
@@ -1,0 +1,50 @@
+
+
+
+#include <fullscore/models/plotters/basic.h>
+
+#include <fullscore/models/measures/plotted.h>
+#include <fullscore/models/staves/base.h>
+#include <fullscore/models/plotter.h>
+#include <fullscore/models/grid.h>
+#include <fullscore/models/floating_measure.h>
+
+
+
+Plotter::Basic::Basic(Grid *grid, int barline_num, Note note)
+   : Base(Plotter::TYPE_IDENTIFIER_BASIC)
+   , grid(grid)
+   , barline_num(barline_num)
+   , note(note)
+{
+}
+
+
+
+Plotter::Basic::~Basic()
+{
+}
+
+
+
+bool Plotter::Basic::plot()
+{
+   if (!grid) throw std::runtime_error("Cannot plot with a nullptr grid");
+
+   for (unsigned i=0; i<grid->get_num_staves(); i++)
+   {
+      Staff::Base *staff = grid->get_staff(i);
+
+      if (staff->is_type("instrument"))
+      {
+         int staff_id = staff->get_id();
+         Measure::Base* plotted_measure = new Measure::Plotted({ note }); // < this automatically adds the measure to the base
+         new FloatingMeasure(GridCoordinate(grid, staff_id, barline_num), plotted_measure->get_id());
+      }
+   }
+
+   return true;
+}
+
+
+

--- a/src/models/plotters/destination.cpp
+++ b/src/models/plotters/destination.cpp
@@ -93,7 +93,7 @@ bool Plotter::Destination::plot()
       }
 
       // create the measure
-      Measure::Plotted *plotted_measure = new Measure::Plotted(this);
+      Measure::Plotted *plotted_measure = new Measure::Plotted({ Note(2, Duration::QUARTER) });
 
       if (!destination_grid->set_measure(barline_num, staff_id, plotted_measure))
       {

--- a/src/models/plotters/destination.cpp
+++ b/src/models/plotters/destination.cpp
@@ -5,13 +5,14 @@
 
 #include <fullscore/models/measures/plotted.h>
 #include <fullscore/models/grid.h>
+#include <fullscore/models/plotter.h>
 #include <allegro_flare/useful.h>
 #include <algorithm>
 
 
 
 Plotter::Destination::Destination()
-   : Base("destination")
+   : Base(Plotter::TYPE_IDENTIFIER_DESTINATION)
    , destinations()
 {}
 


### PR DESCRIPTION
## Simplify the Plotter Way

`Plotter::Destination` was an initial attempt to get plotters into the master branch.  It worked, but plotters need to be able to support potting to `FloatingMeasure`s.  And, there needs to be a clearer relationship between the plotted measure and its plotter.

This PR introduces a `Plotter::Basic` that very basically plots the given note onto all instruments at a given barline.

`Plotter::Destination` is updated, but should probably just be removed (or updated to be a little more practical).

## Extra Improvements

To clean up `AppController` from getting contaminated from all the testing code, I've moved all of the score developer-testing code into a score template called `testing_templte`.  Also, I created a config key, `init_template`, that represents the identifier of the template to use during startup.