### PR TITLE
Fix Coordinate Classes

### DIFF
--- a/include/fullscore/models/floating_measure.h
+++ b/include/fullscore/models/floating_measure.h
@@ -11,14 +11,14 @@ class FloatingMeasure
 {
 private:
    int id;
-   GridCoordinate coordinate;
+   GridCoordinate grid_coordinate;
    int measure_id;
 
 public:
-   FloatingMeasure(GridCoordinate coordinate, int measure_id);
+   FloatingMeasure(GridCoordinate grid_coordinate, int measure_id);
    ~FloatingMeasure();
 
-   GridCoordinate get_coordinate();
+   GridCoordinate get_grid_coordinate();
    int get_measure_id();
    int get_id();
 

--- a/include/fullscore/models/grid_coordinate.h
+++ b/include/fullscore/models/grid_coordinate.h
@@ -2,23 +2,24 @@
 
 
 
+#include <fullscore/models/grid_horizontal_coordinate.h>
+
+
+
 class GridCoordinate
 {
 private:
    int staff_id;
-   int barline_num;
-   int beat_num;
+   GridHorizontalCoordinate grid_horizontal_coordinate;
 
 public:
-   GridCoordinate(int staff_id=0, int barline_num=0, int beat_num=0);
+   GridCoordinate(int staff_id=0, GridHorizontalCoordinate grid_horizontal_coordinate={});
 
    void set_staff_id(int staff_id);
-   void set_barline_num(int barline_num);
-   void set_beat_num(int beat_num);
+   void set_grid_horizontal_coordinate(GridHorizontalCoordinate grid_horizontal_coordinate);
 
    int get_staff_id();
-   int get_barline_num();
-   int get_beat_num();
+   GridHorizontalCoordinate get_grid_horizontal_coordinate();
 
    bool operator==(const GridCoordinate &other) const;
    bool operator!=(const GridCoordinate &other) const;

--- a/include/fullscore/models/grid_coordinate.h
+++ b/include/fullscore/models/grid_coordinate.h
@@ -2,27 +2,20 @@
 
 
 
-class Grid;
-
-
-
 class GridCoordinate
 {
 private:
-   Grid *grid;
    int staff_id;
    int barline_num;
    int beat_num;
 
 public:
-   GridCoordinate(Grid *grid=nullptr, int staff_id=0, int barline_num=0, int beat_num=0);
+   GridCoordinate(int staff_id=0, int barline_num=0, int beat_num=0);
 
-   void set_grid(Grid *grid);
    void set_staff_id(int staff_id);
    void set_barline_num(int barline_num);
    void set_beat_num(int beat_num);
 
-   Grid *get_grid();
    int get_staff_id();
    int get_barline_num();
    int get_beat_num();

--- a/include/fullscore/models/staves/base.h
+++ b/include/fullscore/models/staves/base.h
@@ -22,7 +22,7 @@ namespace Staff
       std::string name;
 
    public:
-      Base(std::string type);
+      Base(std::string type, std::string name=std::string());
       virtual ~Base();
       std::string get_type();
       bool is_type(std::string type);

--- a/include/fullscore/models/staves/instrument.h
+++ b/include/fullscore/models/staves/instrument.h
@@ -11,7 +11,7 @@ namespace Staff
    class Instrument : public Base
    {
    public:
-      Instrument();
+      Instrument(std::string name = std::string());
       ~Instrument();
 
       virtual float get_height() override;

--- a/src/components/grid_render_component.cpp
+++ b/src/components/grid_render_component.cpp
@@ -150,7 +150,7 @@ void GridRenderComponent::render()
 
          for (auto &floating_measure : FloatingMeasure::find_at_staff_and_barline(staff->get_id(), x))
          {
-            float floating_measure_x_offset = floating_measure->get_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset() * full_measure_width / 4.0;
+            float floating_measure_x_offset = floating_measure->get_grid_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset() * full_measure_width / 4.0;
             Measure::Base *floating_measure_measure = Measure::find(floating_measure->get_measure_id(), Measure::FIND_OPTION_RAISE_NOT_FOUND);
             MeasureRenderComponent measure_render_component(context_measure, floating_measure_measure, music_engraver, full_measure_width, x_pos + floating_measure_x_offset, y_counter, row_middle_y, this_staff_height, showing_debug_data);
             measure_render_component.render();

--- a/src/components/grid_render_component.cpp
+++ b/src/components/grid_render_component.cpp
@@ -150,7 +150,7 @@ void GridRenderComponent::render()
 
          for (auto &floating_measure : FloatingMeasure::find_at_staff_and_barline(staff->get_id(), x))
          {
-            float floating_measure_x_offset = floating_measure->get_coordinate().get_beat_num() * full_measure_width / 4.0;
+            float floating_measure_x_offset = floating_measure->get_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset() * full_measure_width / 4.0;
             Measure::Base *floating_measure_measure = Measure::find(floating_measure->get_measure_id(), Measure::FIND_OPTION_RAISE_NOT_FOUND);
             MeasureRenderComponent measure_render_component(context_measure, floating_measure_measure, music_engraver, full_measure_width, x_pos + floating_measure_x_offset, y_counter, row_middle_y, this_staff_height, showing_debug_data);
             measure_render_component.render();

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -246,8 +246,8 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
    {
       Staff::Base *current_cursor_staff = current_grid_editor->grid.get_staff(current_grid_editor->measure_cursor_y);
       int current_staff_id = current_cursor_staff->get_id();
-      int current_measure_num = current_grid_editor->measure_cursor_x;
-      GridCoordinate grid_coordinate(current_staff_id, current_measure_num, 0);
+      int current_barline_num = current_grid_editor->measure_cursor_x;
+      GridCoordinate grid_coordinate(current_staff_id, GridHorizontalCoordinate(current_barline_num, 0));
       Measure::Base *static_measure = new Measure::Basic({0, 0, 0, 0});
 
       action = new Action::CreateFloatingMeasure(grid_coordinate, static_measure->get_id());

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -247,7 +247,7 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
       Staff::Base *current_cursor_staff = current_grid_editor->grid.get_staff(current_grid_editor->measure_cursor_y);
       int current_staff_id = current_cursor_staff->get_id();
       int current_measure_num = current_grid_editor->measure_cursor_x;
-      GridCoordinate grid_coordinate(&current_grid_editor->grid, current_staff_id, current_measure_num, 0);
+      GridCoordinate grid_coordinate(current_staff_id, current_measure_num, 0);
       Measure::Base *static_measure = new Measure::Basic({0, 0, 0, 0});
 
       action = new Action::CreateFloatingMeasure(grid_coordinate, static_measure->get_id());

--- a/src/models/floating_measure.cpp
+++ b/src/models/floating_measure.cpp
@@ -71,7 +71,7 @@ std::vector<FloatingMeasure *> FloatingMeasure::find_at_staff_and_barline(int st
 
    for (auto &element : pool_elements)
    {
-      if (element->coordinate.get_staff_id() == staff_id && element->coordinate.get_barline_num() == barline_num)
+      if (element->coordinate.get_staff_id() == staff_id && element->coordinate.get_grid_horizontal_coordinate().get_barline_num() == barline_num)
          results.push_back(element);
    }
 

--- a/src/models/floating_measure.cpp
+++ b/src/models/floating_measure.cpp
@@ -5,9 +5,9 @@
 
 
 
-FloatingMeasure::FloatingMeasure(GridCoordinate coordinate, int measure_id)
+FloatingMeasure::FloatingMeasure(GridCoordinate grid_coordinate, int measure_id)
    : id(FloatingMeasure::next_id++)
-   , coordinate(coordinate)
+   , grid_coordinate(grid_coordinate)
    , measure_id(measure_id)
 {
    pool_elements.push_back(this);
@@ -29,9 +29,9 @@ FloatingMeasure::~FloatingMeasure()
 
 
 
-GridCoordinate FloatingMeasure::get_coordinate()
+GridCoordinate FloatingMeasure::get_grid_coordinate()
 {
-   return coordinate;
+   return grid_coordinate;
 }
 
 
@@ -71,7 +71,7 @@ std::vector<FloatingMeasure *> FloatingMeasure::find_at_staff_and_barline(int st
 
    for (auto &element : pool_elements)
    {
-      if (element->coordinate.get_staff_id() == staff_id && element->coordinate.get_grid_horizontal_coordinate().get_barline_num() == barline_num)
+      if (element->grid_coordinate.get_staff_id() == staff_id && element->grid_coordinate.get_grid_horizontal_coordinate().get_barline_num() == barline_num)
          results.push_back(element);
    }
 

--- a/src/models/grid_coordinate.cpp
+++ b/src/models/grid_coordinate.cpp
@@ -7,10 +7,9 @@
 
 
 
-GridCoordinate::GridCoordinate(int staff_id, int barline_num, int beat_num)
+GridCoordinate::GridCoordinate(int staff_id, GridHorizontalCoordinate grid_horizontal_coordinate)
    : staff_id(staff_id)
-   , barline_num(barline_num)
-   , beat_num(beat_num)
+   , grid_horizontal_coordinate(grid_horizontal_coordinate)
 {}
 
 
@@ -22,16 +21,9 @@ void GridCoordinate::set_staff_id(int staff_id)
 
 
 
-void GridCoordinate::set_barline_num(int barline_num)
+void GridCoordinate::set_grid_horizontal_coordinate(GridHorizontalCoordinate grid_horizontal_coordinate)
 {
-   this->barline_num = barline_num;
-}
-
-
-
-void GridCoordinate::set_beat_num(int beat_num)
-{
-   this->beat_num = beat_num;
+   this->grid_horizontal_coordinate = grid_horizontal_coordinate;
 }
 
 
@@ -43,16 +35,9 @@ int GridCoordinate::get_staff_id()
 
 
 
-int GridCoordinate::get_barline_num()
+GridHorizontalCoordinate GridCoordinate::get_grid_horizontal_coordinate()
 {
-   return barline_num;
-}
-
-
-
-int GridCoordinate::get_beat_num()
-{
-   return beat_num;
+   return grid_horizontal_coordinate;
 }
 
 
@@ -61,8 +46,7 @@ bool GridCoordinate::operator==(const GridCoordinate &other) const
 {
    return (
      staff_id == other.staff_id
-     && barline_num == other.barline_num
-     && beat_num == other.beat_num
+     && grid_horizontal_coordinate == other.grid_horizontal_coordinate
   );
 }
 

--- a/src/models/grid_coordinate.cpp
+++ b/src/models/grid_coordinate.cpp
@@ -7,19 +7,11 @@
 
 
 
-GridCoordinate::GridCoordinate(Grid *grid, int staff_id, int barline_num, int beat_num)
-   : grid(grid)
-   , staff_id(staff_id)
+GridCoordinate::GridCoordinate(int staff_id, int barline_num, int beat_num)
+   : staff_id(staff_id)
    , barline_num(barline_num)
    , beat_num(beat_num)
 {}
-
-
-
-void GridCoordinate::set_grid(Grid *grid)
-{
-   this->grid = grid;
-}
 
 
 
@@ -40,13 +32,6 @@ void GridCoordinate::set_barline_num(int barline_num)
 void GridCoordinate::set_beat_num(int beat_num)
 {
    this->beat_num = beat_num;
-}
-
-
-
-Grid *GridCoordinate::get_grid()
-{
-   return grid;
 }
 
 
@@ -75,8 +60,7 @@ int GridCoordinate::get_beat_num()
 bool GridCoordinate::operator==(const GridCoordinate &other) const
 {
    return (
-     grid == other.grid
-     && staff_id == other.staff_id
+     staff_id == other.staff_id
      && barline_num == other.barline_num
      && beat_num == other.beat_num
   );

--- a/src/models/plotters/basic.cpp
+++ b/src/models/plotters/basic.cpp
@@ -39,7 +39,7 @@ bool Plotter::Basic::plot()
       {
          int staff_id = staff->get_id();
          Measure::Base* plotted_measure = new Measure::Plotted(notes); // < this automatically adds the measure to the base
-         new FloatingMeasure(GridCoordinate(grid, staff_id, barline_num), plotted_measure->get_id());
+         new FloatingMeasure(GridCoordinate(staff_id, barline_num), plotted_measure->get_id());
       }
    }
 

--- a/src/models/plotters/destination.cpp
+++ b/src/models/plotters/destination.cpp
@@ -74,24 +74,7 @@ std::vector<Note> Plotter::Destination::get_notes_for(GridCoordinate destination
 
 bool Plotter::Destination::plot()
 {
-   for (auto &destination : destinations)
-   {
-      Grid *destination_grid = destination.get_grid();
-      int staff_id = destination.get_staff_id();
-
-      if (!destination_grid) throw std::runtime_error("Plotter::Destination cannot plot to a nullptr destination_grid");
-
-      Staff::Base *destination_staff = destination_grid->get_staff(staff_id);
-      if (!destination_staff) throw std::runtime_error("Plotter::Destination cannot plot to a nullptr destination_staff");
-      if (!destination_staff->is_type("instrument"))
-      {
-         std::stringstream error_message;
-         error_message << "Plotter::Destination cannot plot to a \"" << destination_staff->get_type() << "\" staff type";
-         throw std::runtime_error(error_message.str());
-      }
-
-      throw std::runtime_error("Plotter::Destination can not plot to measures because set_measure has been disabled");
-   }
+   throw std::runtime_error("Plotter::Destination has been disabled");
 
    return true;
 }

--- a/src/models/staves/base.cpp
+++ b/src/models/staves/base.cpp
@@ -7,10 +7,10 @@
 
 
 
-Staff::Base::Base(std::string type)
+Staff::Base::Base(std::string type, std::string name)
    : type(type)
    , id(Staff::next_id++)
-   , name()
+   , name(name)
 {
    Staff::push_back(this);
 }

--- a/src/models/staves/instrument.cpp
+++ b/src/models/staves/instrument.cpp
@@ -10,8 +10,8 @@
 
 
 
-Staff::Instrument::Instrument()
-   : Base(Staff::TYPE_IDENTIFIER_INSTRUMENT)
+Staff::Instrument::Instrument(std::string name)
+   : Base(Staff::TYPE_IDENTIFIER_INSTRUMENT, name)
 {
 }
 

--- a/tests/actions/create_floating_measure_action_test.cpp
+++ b/tests/actions/create_floating_measure_action_test.cpp
@@ -40,7 +40,7 @@ TEST(CreateFloatingMeasureActionTest, creates_a_floating_measure_with_the_expect
    std::vector<FloatingMeasure *> floating_measure_elements = FloatingMeasure::get_pool_elements();
 
    ASSERT_EQ(1, floating_measure_elements.size());
-   ASSERT_EQ(grid_coordinate, floating_measure_elements[0]->get_coordinate());
+   ASSERT_EQ(grid_coordinate, floating_measure_elements[0]->get_grid_coordinate());
    ASSERT_EQ(measure_id, floating_measure_elements[0]->get_measure_id());
 }
 

--- a/tests/actions/create_floating_measure_action_test.cpp
+++ b/tests/actions/create_floating_measure_action_test.cpp
@@ -27,7 +27,7 @@ TEST(CreateFloatingMeasureActionTest, has_the_expected_action_name)
 
 TEST(CreateFloatingMeasureActionTest, creates_a_floating_measure_with_the_expected_values)
 {
-   GridCoordinate grid_coordinate = GridCoordinate(nullptr, 2, 7, 13);
+   GridCoordinate grid_coordinate = GridCoordinate(2, GridHorizontalCoordinate{7, 13});
    int measure_id = 11;
    Action::CreateFloatingMeasure create_floating_measure_action(grid_coordinate, measure_id);
 

--- a/tests/models/floating_measure_test.cpp
+++ b/tests/models/floating_measure_test.cpp
@@ -27,7 +27,7 @@ TEST(FloatingMeasureTest, returns_its_measure_id)
 
 TEST(FloatingMeasureTest, returns_its_coordinate)
 {
-   GridCoordinate coordinate(nullptr, 7, 11, 3);
+   GridCoordinate coordinate(7, GridHorizontalCoordinate{11, 3});
    FloatingMeasure floating_measure(coordinate, 0);
 
    ASSERT_EQ(coordinate, floating_measure.get_coordinate());
@@ -56,9 +56,9 @@ TEST(FloatingMeasureTest, can_find_measures_given_a_staff_id_and_a_barline)
    Measure::Basic basic_measure_2;
    Measure::Basic basic_measure_3;
 
-   FloatingMeasure floating_measure_1(GridCoordinate(nullptr, 3, 0), basic_measure_1.get_id());
-   FloatingMeasure floating_measure_2(GridCoordinate(nullptr, 7, 2), basic_measure_2.get_id());
-   FloatingMeasure floating_measure_3(GridCoordinate(nullptr, 7, 0), basic_measure_3.get_id());
+   FloatingMeasure floating_measure_1(GridCoordinate(3, 0), basic_measure_1.get_id());
+   FloatingMeasure floating_measure_2(GridCoordinate(7, 2), basic_measure_2.get_id());
+   FloatingMeasure floating_measure_3(GridCoordinate(7, 0), basic_measure_3.get_id());
 
    std::vector<FloatingMeasure *> expected_measures = { &floating_measure_2 };
 
@@ -73,9 +73,9 @@ TEST(FloatingMeasureTest, can_get_a_list_of_floating_measures)
    Measure::Basic basic_measure_2;
    Measure::Basic basic_measure_3;
 
-   FloatingMeasure floating_measure_1(GridCoordinate(nullptr, 3, 0), basic_measure_1.get_id());
-   FloatingMeasure floating_measure_2(GridCoordinate(nullptr, 7, 2), basic_measure_2.get_id());
-   FloatingMeasure floating_measure_3(GridCoordinate(nullptr, 7, 0), basic_measure_3.get_id());
+   FloatingMeasure floating_measure_1(GridCoordinate(3, 0), basic_measure_1.get_id());
+   FloatingMeasure floating_measure_2(GridCoordinate(7, 2), basic_measure_2.get_id());
+   FloatingMeasure floating_measure_3(GridCoordinate(7, 0), basic_measure_3.get_id());
 
    std::vector<FloatingMeasure *> expected_measures = {
       &floating_measure_1,

--- a/tests/models/floating_measure_test.cpp
+++ b/tests/models/floating_measure_test.cpp
@@ -25,12 +25,12 @@ TEST(FloatingMeasureTest, returns_its_measure_id)
 
 
 
-TEST(FloatingMeasureTest, returns_its_coordinate)
+TEST(FloatingMeasureTest, returns_its_grid_coordinate)
 {
-   GridCoordinate coordinate(7, GridHorizontalCoordinate{11, 3});
-   FloatingMeasure floating_measure(coordinate, 0);
+   GridCoordinate grid_coordinate(7, GridHorizontalCoordinate{11, 3});
+   FloatingMeasure floating_measure(grid_coordinate, 0);
 
-   ASSERT_EQ(coordinate, floating_measure.get_coordinate());
+   ASSERT_EQ(grid_coordinate, floating_measure.get_grid_coordinate());
 }
 
 

--- a/tests/models/grid_coordinate_test.cpp
+++ b/tests/models/grid_coordinate_test.cpp
@@ -12,7 +12,6 @@ TEST(GridCoordinate, can_be_constructed_with_no_arguments)
 {
    GridCoordinate grid_coordinate;
 
-   EXPECT_EQ(nullptr, grid_coordinate.get_grid());
    EXPECT_EQ(0, grid_coordinate.get_staff_id());
    EXPECT_EQ(0, grid_coordinate.get_barline_num());
    EXPECT_EQ(0, grid_coordinate.get_beat_num());
@@ -22,25 +21,11 @@ TEST(GridCoordinate, can_be_constructed_with_no_arguments)
 
 TEST(GridCoordinate, can_be_constructed_with_arguments)
 {
-   Grid grid;
-   GridCoordinate grid_coordinate(&grid, 6, 13, 42);
+   GridHorizontalCoordinate grid_horizontal_coordinate{13, 42};
+   GridCoordinate grid_coordinate(6, grid_horizontal_coordinate);
 
-   EXPECT_EQ(&grid, grid_coordinate.get_grid());
    EXPECT_EQ(6, grid_coordinate.get_staff_id());
-   EXPECT_EQ(13, grid_coordinate.get_barline_num());
-   EXPECT_EQ(42, grid_coordinate.get_beat_num());
-}
-
-
-
-TEST(GridCoordinate, gets_and_sets_the_grid)
-{
-   GridCoordinate grid_coordinate;
-
-   Grid grid;
-
-   grid_coordinate.set_grid(&grid);
-   EXPECT_EQ(&grid, grid_coordinate.get_grid());
+   EXPECT_EQ(grid_horizontal_coordinate, grid_coordinate.get_grid_horizontal_coordinate());
 }
 
 
@@ -55,34 +40,22 @@ TEST(GridCoordinate, gets_and_sets_the_staff_id)
 
 
 
-TEST(GridCoordinate, gets_and_sets_the_barline_num)
+TEST(GridCoordinate, gets_and_sets_the_grid_horizontal_coordinate)
 {
    GridCoordinate grid_coordinate;
 
-   grid_coordinate.set_barline_num(123);
-   EXPECT_EQ(123, grid_coordinate.get_barline_num());
 
-   grid_coordinate.set_barline_num(-86);
-   EXPECT_EQ(-86, grid_coordinate.get_barline_num());
+   GridHorizontalCoordinate grid_horizontal_coordinate_1{123};
+   grid_coordinate.set_grid_horizontal_coordinate(grid_horizontal_coordinate_1);
+   EXPECT_EQ(grid_horizontal_coordinate_1, grid_coordinate.get_grid_horizontal_coordinate());
 
-   grid_coordinate.set_barline_num(720782);
-   EXPECT_EQ(720782, grid_coordinate.get_barline_num());
-}
+   GridHorizontalCoordinate grid_horizontal_coordinate_2{-86};
+   grid_coordinate.set_grid_horizontal_coordinate(grid_horizontal_coordinate_2);
+   EXPECT_EQ(grid_horizontal_coordinate_2, grid_coordinate.get_grid_horizontal_coordinate());
 
-
-
-TEST(GridCoordinate, gets_and_sets_the_beat_num)
-{
-   GridCoordinate grid_coordinate;
-
-   grid_coordinate.set_beat_num(123);
-   EXPECT_EQ(123, grid_coordinate.get_beat_num());
-
-   grid_coordinate.set_beat_num(-86);
-   EXPECT_EQ(-86, grid_coordinate.get_beat_num());
-
-   grid_coordinate.set_beat_num(720782);
-   EXPECT_EQ(720782, grid_coordinate.get_beat_num());
+   GridHorizontalCoordinate grid_horizontal_coordinate_3{720782};
+   grid_coordinate.set_grid_horizontal_coordinate(grid_horizontal_coordinate_3);
+   EXPECT_EQ(grid_horizontal_coordinate_3, grid_coordinate.get_grid_horizontal_coordinate());
 }
 
 
@@ -90,23 +63,18 @@ TEST(GridCoordinate, gets_and_sets_the_beat_num)
 TEST(GridCoordinate, compares_equality_with_another_grid_coordinate)
 {
    EXPECT_EQ(
-      GridCoordinate(nullptr, 67, 195, 84),
-      GridCoordinate(nullptr, 67, 195, 84)
+      GridCoordinate(67, GridHorizontalCoordinate{195, 84}),
+      GridCoordinate(67, GridHorizontalCoordinate{195, 84})
    );
 
    EXPECT_NE(
-      GridCoordinate(nullptr, 67, 195, 84),
-      GridCoordinate(nullptr, 0,  195, 84)
+      GridCoordinate(67, GridHorizontalCoordinate{195, 84}),
+      GridCoordinate(0,  GridHorizontalCoordinate{195, 84})
    );
 
    EXPECT_NE(
-      GridCoordinate(nullptr, 67, 195, 84),
-      GridCoordinate(nullptr, 67, 0,   84)
-   );
-
-   EXPECT_NE(
-      GridCoordinate(nullptr, 67, 195, 84),
-      GridCoordinate(nullptr, 67, 195, 0)
+      GridCoordinate(67, GridHorizontalCoordinate{195, 84}),
+      GridCoordinate(67, GridHorizontalCoordinate{0,   84})
    );
 }
 

--- a/tests/models/grid_coordinate_test.cpp
+++ b/tests/models/grid_coordinate_test.cpp
@@ -13,8 +13,7 @@ TEST(GridCoordinate, can_be_constructed_with_no_arguments)
    GridCoordinate grid_coordinate;
 
    EXPECT_EQ(0, grid_coordinate.get_staff_id());
-   EXPECT_EQ(0, grid_coordinate.get_barline_num());
-   EXPECT_EQ(0, grid_coordinate.get_beat_num());
+   EXPECT_EQ(GridHorizontalCoordinate(), grid_coordinate.get_grid_horizontal_coordinate());
 }
 
 

--- a/tests/models/plotters/destination_test.cpp
+++ b/tests/models/plotters/destination_test.cpp
@@ -27,8 +27,8 @@ TEST(Plotter_DestinationTest, can_be_constructed_with_an_empty_constructor)
 TEST(Plotter_DestinationTest, can_add_and_check_presence_of_destination)
 {
    Plotter::Destination plotter;
-   GridCoordinate grid_coordinate_A(nullptr, 1, 5, 7);
-   GridCoordinate grid_coordinate_B(nullptr, 2, 5, 7);
+   GridCoordinate grid_coordinate_A(1, GridHorizontalCoordinate{5, 7});
+   GridCoordinate grid_coordinate_B(2, GridHorizontalCoordinate{5, 7});
 
    ASSERT_TRUE(plotter.add_destination(grid_coordinate_A));
    ASSERT_TRUE(plotter.has_destination(grid_coordinate_A));
@@ -54,7 +54,7 @@ TEST(Plotter_DestinationTest, can_remove_a_destination)
 TEST(Plotter_DestinationTest, returns_false_when_attempting_to_remove_a_destination_that_is_not_present)
 {
    Plotter::Destination plotter;
-   GridCoordinate grid_coordinate_A(nullptr, 1, 5, 7);
+   GridCoordinate grid_coordinate_A(1, GridHorizontalCoordinate{5, 7});
 
    ASSERT_FALSE(plotter.remove_destination(grid_coordinate_A));
 }
@@ -64,9 +64,9 @@ TEST(Plotter_DestinationTest, returns_false_when_attempting_to_remove_a_destinat
 TEST(Plotter_DestinationTest, returns_a_list_of_destinations)
 {
    Plotter::Destination plotter;
-   GridCoordinate grid_coordinate_A(nullptr, 0, 5, 7);
-   GridCoordinate grid_coordinate_B(nullptr, 1, 5, 7);
-   GridCoordinate grid_coordinate_C(nullptr, 2, 5, 7);
+   GridCoordinate grid_coordinate_A(0, GridHorizontalCoordinate{5, 7});
+   GridCoordinate grid_coordinate_B(1, GridHorizontalCoordinate{5, 7});
+   GridCoordinate grid_coordinate_C(2, GridHorizontalCoordinate{5, 7});
 
    ASSERT_TRUE(plotter.add_destination(grid_coordinate_A));
    ASSERT_TRUE(plotter.add_destination(grid_coordinate_B));
@@ -83,9 +83,9 @@ TEST(Plotter_DestinationTest, returns_a_list_of_destinations)
 TEST(Plotter_DestinationTest, returns_the_number_of_destinations)
 {
    Plotter::Destination plotter;
-   GridCoordinate grid_coordinate_A(nullptr, 0, 5, 7);
-   GridCoordinate grid_coordinate_B(nullptr, 1, 5, 7);
-   GridCoordinate grid_coordinate_C(nullptr, 2, 5, 7);
+   GridCoordinate grid_coordinate_A(0, GridHorizontalCoordinate{5, 7});
+   GridCoordinate grid_coordinate_B(1, GridHorizontalCoordinate{5, 7});
+   GridCoordinate grid_coordinate_C(2, GridHorizontalCoordinate{5, 7});
 
    ASSERT_TRUE(plotter.add_destination(grid_coordinate_A));
    ASSERT_EQ(1, plotter.num_destinations());
@@ -105,7 +105,7 @@ TEST(Plotter_DestinationTest, returns_the_number_of_destinations)
 TEST(Plotter_DestinationTest, cannot_add_a_destination_that_already_exists)
 {
    Plotter::Destination plotter;
-   GridCoordinate grid_coordinate_A(nullptr, 0, 5, 7);
+   GridCoordinate grid_coordinate_A(0, GridHorizontalCoordinate{5, 7});
 
    ASSERT_TRUE(plotter.add_destination(grid_coordinate_A));
    ASSERT_FALSE(plotter.add_destination(grid_coordinate_A));
@@ -121,33 +121,6 @@ TEST(Plotter_DestinationTest, cannot_add_a_destination_that_already_exists)
 TEST(Plotter_DestinationTest, DISABLED_plots_plotted_measure_types_into_the_grid)
 {
    // skip
-}
-
-
-
-TEST(Plotter_DestinationTest, when_plotting_to_a_nullptr_destination_grid_raises_an_error)
-{
-   Plotter::Destination plotter;
-   GridCoordinate grid_coordinate(nullptr, 0, 0, 0);
-
-   ASSERT_TRUE(plotter.add_destination(grid_coordinate));
-
-   ASSERT_THROW(plotter.plot(), std::runtime_error);
-}
-
-
-
-TEST(Plotter_DestinationTest, when_plotting_to_a_destination_staff_that_is_not_an_instrument_type_raises_an_error)
-{
-   Grid grid;
-   grid.append_staff(new Staff::MeasureNumbers);
-
-   Plotter::Destination plotter;
-   GridCoordinate grid_coordinate(&grid, 0, 0, 0);
-
-   ASSERT_TRUE(plotter.add_destination(grid_coordinate));
-
-   ASSERT_THROW(plotter.plot(), std::runtime_error);
 }
 
 


### PR DESCRIPTION
## Coordinates Are a Bit Non-Standard

There are a handfull of classes that are used to represent coordinates in the staves, scores, measures, and beats.  In all cases, the higher coordinates should be composed of the lower coordinates, but what is currently existing in the app is higher coordinates are attempting to re-create lower coordinates and then there is a bit of inconsistency (and thus a lack of features) with the composed elements.

## New Composition of Coordinate Types

There are 3 classes of coordinates: `GridCoordinate`, `GridHorizontalCoordinate`, and `BeatCoordinate`.  Once this PR is merged, they will be composed in the following way:

```
GridCoordinate
  staff_id
  GridHorizontalCoordinate
    barline_num
    BeatCoordinate
      beat_num
      sub_beat_numerator
      sub_beat_denominator
```

Note that `GridCoordinate`'s `grid` property is removed entirely.

## Moving Forward

A good strategy beyond this PR would be to come up with a better naming convention for the classes.  For example, `GridHorizontalCoordinate` doesn't have much to do with a grid (apart from its barlines, perhaps).  There's room for improvement, here. 🙂

### Collateral Features

* `Staff::Base` now allows a construction parameter to set the `name` of the staff.  This can be particularly helpful when creating instruments (lvalues don't need to be created just in order to assign the name property).
* The entirety of `Plotter::Destination`'s `execute()` has been disabled.
* `FloatingMeasure`'s `coordinate` renamed to `grid_coordinate` for consistency.