### PR TITLE
Add InstrumentFactory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ obj/%.o: src/%.cpp
 obj/tests/%.o: tests/%.cpp $(OBJECTS)
 	@mkdir -p $(@D)
 	@printf "compiling test obj file \e[1m\e[36m$<\033[0m..."
-	@g++ -c -std=gnu++11 -Wall -Wuninitialized -Weffc++ $< -o $@ -I$(ALLEGRO_DIR)/include -I./include -I$(GOOGLE_TEST_INCLUDE_DIR)
+	@g++ -c -std=gnu++11 -Wall -Wuninitialized -Weffc++ $< -o $@ -I$(ALLEGRO_FLARE_DIR)/include -I$(ALLEGRO_DIR)/include -I./include -I$(GOOGLE_TEST_INCLUDE_DIR)
 	@echo "done. Object at \033[1m\033[32m$@\033[0m"
 
 

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ clean:
 fresh:
 	make clean
 	make -j8
-	make tests
+	make tests -j8
 	make bin/test_runner -j8
 	bin/test_runner
 

--- a/include/fullscore/converters/scientific_pitch_notation_to_pitch_converter.h
+++ b/include/fullscore/converters/scientific_pitch_notation_to_pitch_converter.h
@@ -18,3 +18,7 @@ public:
 
 
 
+using SPNToPitchConverter = ScientificPitchNotationToPitchConverter;
+
+
+

--- a/include/fullscore/converters/scientific_pitch_notation_to_pitch_converter.h
+++ b/include/fullscore/converters/scientific_pitch_notation_to_pitch_converter.h
@@ -1,0 +1,20 @@
+#pragma once
+
+
+
+class ScientificPitchNotationToPitchConverter
+{
+private:
+   char note_name;
+   int octave;
+   int accidental;
+
+public:
+   ScientificPitchNotationToPitchConverter(char note_name, int octave, int accidental=0);
+   ~ScientificPitchNotationToPitchConverter();
+
+   int convert();
+};
+
+
+

--- a/include/fullscore/factories/instrument_factory.h
+++ b/include/fullscore/factories/instrument_factory.h
@@ -11,6 +11,11 @@ class InstrumentFactory
 public:
    Staff::Instrument *create_trombone();
    Staff::Instrument *create_euphonium();
+
+   Staff::Instrument *create_violin();
+   Staff::Instrument *create_viola();
+   Staff::Instrument *create_cello();
+   Staff::Instrument *create_bass();
 };
 
 

--- a/include/fullscore/factories/instrument_factory.h
+++ b/include/fullscore/factories/instrument_factory.h
@@ -10,7 +10,9 @@ class InstrumentFactory
 {
 public:
    Staff::Instrument *create_trombone();
+   Staff::Instrument *create_bass_trombone();
    Staff::Instrument *create_euphonium();
+   Staff::Instrument *create_tuba();
 
    Staff::Instrument *create_violin();
    Staff::Instrument *create_viola();

--- a/include/fullscore/factories/instrument_factory.h
+++ b/include/fullscore/factories/instrument_factory.h
@@ -10,6 +10,7 @@ class InstrumentFactory
 {
 public:
    Staff::Instrument *create_trombone();
+   Staff::Instrument *create_euphonium();
 };
 
 

--- a/include/fullscore/factories/instrument_factory.h
+++ b/include/fullscore/factories/instrument_factory.h
@@ -1,0 +1,16 @@
+#pragma once
+
+
+
+#include <fullscore/models/staves/instrument.h>
+
+
+
+class InstrumentFactory
+{
+public:
+   Staff::Instrument *create_trombone();
+};
+
+
+

--- a/include/fullscore/instrument_attributes.h
+++ b/include/fullscore/instrument_attributes.h
@@ -39,6 +39,18 @@ namespace InstrumentAttribute
    std::string const EXTENDED_RANGE_MAX       = "extended_range_max";
    std::string const HYPER_EXTENDED_RANGE_MIN = "hyper_extended_range_min";
    std::string const HYPER_EXTENDED_RANGE_MAX = "hyper_extended_range_max";
+
+
+   // Range
+
+   std::string const SMARTMUSIC_BASIC_RANGE_MIN        = "smartmusic_basic_range_min";
+   std::string const SMARTMUSIC_BASIC_RANGE_MAX        = "smartmusic_basic_range_max";
+   std::string const SMARTMUSIC_INTERMEDIATE_RANGE_MIN = "smartmusic_intermediate_range_min";
+   std::string const SMARTMUSIC_INTERMEDIATE_RANGE_MAX = "smartmusic_intermediate_range_max";
+   std::string const SMARTMUSIC_ADVANCED_RANGE_MIN     = "smartmusic_advanced_range_min";
+   std::string const SMARTMUSIC_ADVANCED_RANGE_MAX     = "smartmusic_advanced_range_max";
+   std::string const SMARTMUSIC_EXTENDED_RANGE_MIN     = "smartmusic_extended_range_min";
+   std::string const SMARTMUSIC_EXTENDED_RANGE_MAX     = "smartmusic_extended_range_max";
 }
 
 

--- a/include/fullscore/instrument_attributes.h
+++ b/include/fullscore/instrument_attributes.h
@@ -1,0 +1,45 @@
+#pragma once
+
+
+
+namespace InstrumentAttribute
+{
+   // Families
+
+   std::string const FAMILY = "family";
+
+   namespace Family
+   {
+      std::string const WOODWIND   = "woodwind";
+      std::string const BRASS      = "brass";
+      std::string const PERCUSSION = "percussion";
+      std::string const STRING     = "string";
+   }
+
+
+   // Roles
+
+   std::string const VOICE_ROLE   = "voice_role";
+
+   namespace VoiceRole
+   {
+      std::string const SOPRANO  = "soprano";
+      std::string const ALTO     = "alto";
+      std::string const TENOR    = "tenor";
+      std::string const BARITONE = "baritone";
+      std::string const BASS     = "bass";
+   }
+
+
+   // Range
+
+   std::string const COMFORTABLE_RANGE_MIN    = "comfortable_range_min";
+   std::string const COMFORTABLE_RANGE_MAX    = "comfortable_range_max";
+   std::string const EXTENDED_RANGE_MIN       = "extended_range_min";
+   std::string const EXTENDED_RANGE_MAX       = "extended_range_max";
+   std::string const HYPER_EXTENDED_RANGE_MIN = "hyper_extended_range_min";
+   std::string const HYPER_EXTENDED_RANGE_MAX = "hyper_extended_range_max";
+}
+
+
+

--- a/include/fullscore/models/pitch.h
+++ b/include/fullscore/models/pitch.h
@@ -11,6 +11,8 @@ public:
    Pitch(int scale_degree, int accidental=0);
 
    bool operator==(const Pitch &other) const;
+   bool operator>(const Pitch &other) const;
+   bool operator<(const Pitch &other) const;
 };
 
 

--- a/include/fullscore/models/pitch_range.h
+++ b/include/fullscore/models/pitch_range.h
@@ -1,0 +1,22 @@
+#pragma once
+
+
+
+#include <fullscore/models/pitch.h>
+
+
+
+class PitchRange
+{
+public:
+   Pitch min, max;
+
+   PitchRange(Pitch min, Pitch max);
+   ~PitchRange();
+
+   bool within(Pitch pitch);
+   bool outside(Pitch pitch);
+};
+
+
+

--- a/include/fullscore/models/staves/instrument.h
+++ b/include/fullscore/models/staves/instrument.h
@@ -3,6 +3,7 @@
 
 
 #include <fullscore/models/staves/base.h>
+#include <allegro_flare/attributes.h>
 
 
 
@@ -11,6 +12,8 @@ namespace Staff
    class Instrument : public Base
    {
    public:
+      Attributes attributes;
+
       Instrument(std::string name = std::string());
       ~Instrument();
 

--- a/src/converters/scientific_pitch_notation_to_pitch_converter.cpp
+++ b/src/converters/scientific_pitch_notation_to_pitch_converter.cpp
@@ -1,0 +1,54 @@
+
+
+
+#include <fullscore/converters/scientific_pitch_notation_to_pitch_converter.h>
+
+#include <sstream>
+
+
+
+ScientificPitchNotationToPitchConverter::ScientificPitchNotationToPitchConverter(char note_name, int octave, int accidental)
+   : note_name(note_name)
+   , octave(octave)
+   , accidental(accidental)
+{
+}
+
+
+
+ScientificPitchNotationToPitchConverter::~ScientificPitchNotationToPitchConverter()
+{
+}
+
+
+
+int ScientificPitchNotationToPitchConverter::convert()
+{
+   int result_pitch = 0;
+
+   switch (note_name)
+   {
+   case 'C': result_pitch = 0; break;
+   case 'D': result_pitch = 2; break;
+   case 'E': result_pitch = 4; break;
+   case 'F': result_pitch = 5; break;
+   case 'G': result_pitch = 7; break;
+   case 'A': result_pitch = 9; break;
+   case 'B': result_pitch = 11; break;
+   default:
+      {
+         std::stringstream error_message;
+         error_message
+            << "Cannot convert from scientific pitch notation to pitch with an invalid note_name \""
+            << note_name
+            << "\"";
+         throw std::runtime_error(error_message.str());
+      }
+      break;
+   };
+
+   return result_pitch + (octave - 4) * 12 + accidental;
+}
+
+
+

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -157,16 +157,26 @@ Grid GridFactory::development()
 
    grid.append_staff(new Staff::MeasureNumbers);
    grid.append_staff(new Staff::Tempo);
-   grid.append_staff(new Staff::Instrument);
-   grid.append_staff(new Staff::Instrument);
-   grid.append_staff(new Staff::Instrument);
-
-
-   grid.get_staff(0)->set_name("measure numbers");
-   grid.get_staff(1)->set_name("tempo");
-   grid.get_staff(2)->set_name("Trumpet I");
-   grid.get_staff(3)->set_name("Trumpet II");
-   grid.get_staff(4)->set_name("Trombone");
+   grid.append_staff(new Staff::Instrument("Flute I"));
+   grid.append_staff(new Staff::Instrument("Flute II"));
+   grid.append_staff(new Staff::Instrument("Oboe"));
+   grid.append_staff(new Staff::Instrument("Bassoon"));
+   grid.append_staff(new Staff::Instrument("Clarinet I"));
+   grid.append_staff(new Staff::Instrument("Clarinet II"));
+   grid.append_staff(new Staff::Spacer());
+   grid.append_staff(new Staff::Instrument("Trumpet I"));
+   grid.append_staff(new Staff::Instrument("Trumpet II"));
+   grid.append_staff(new Staff::Instrument("F Horn I"));
+   grid.append_staff(new Staff::Instrument("F Horn II"));
+   grid.append_staff(new Staff::Instrument("Trombone I"));
+   grid.append_staff(new Staff::Instrument("Trombone II"));
+   grid.append_staff(new Staff::Instrument("Tuba"));
+   grid.append_staff(new Staff::Spacer());
+   grid.append_staff(new Staff::Instrument("Violin I"));
+   grid.append_staff(new Staff::Instrument("Violin II"));
+   grid.append_staff(new Staff::Instrument("Viola"));
+   grid.append_staff(new Staff::Instrument("Cello"));
+   grid.append_staff(new Staff::Instrument("Bass"));
 
 
    std::vector<Note> notes_to_plot = {

--- a/src/factories/instrument_factory.cpp
+++ b/src/factories/instrument_factory.cpp
@@ -31,3 +31,26 @@ Staff::Instrument *InstrumentFactory::create_trombone()
 
 
 
+Staff::Instrument *InstrumentFactory::create_euphonium()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Euphonium");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::BRASS);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::TENOR);
+
+   // range
+   instrument->attributes.set(InstrumentAttribute::COMFORTABLE_RANGE_MIN, SPNToPitchConverter('G', 2).convert());
+   instrument->attributes.set(InstrumentAttribute::COMFORTABLE_RANGE_MAX, SPNToPitchConverter('F', 4).convert());
+   instrument->attributes.set(InstrumentAttribute::EXTENDED_RANGE_MIN, SPNToPitchConverter('E', 2, -1).convert());
+   instrument->attributes.set(InstrumentAttribute::EXTENDED_RANGE_MAX, SPNToPitchConverter('A', 4, -1).convert());
+   instrument->attributes.set(InstrumentAttribute::HYPER_EXTENDED_RANGE_MIN, SPNToPitchConverter('G', 1, -1).convert());
+   instrument->attributes.set(InstrumentAttribute::HYPER_EXTENDED_RANGE_MAX, SPNToPitchConverter('C', 5).convert());
+
+   return instrument;
+}
+
+
+

--- a/src/factories/instrument_factory.cpp
+++ b/src/factories/instrument_factory.cpp
@@ -54,3 +54,115 @@ Staff::Instrument *InstrumentFactory::create_euphonium()
 
 
 
+Staff::Instrument *InstrumentFactory::create_violin()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Violin");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::STRING);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::SOPRANO);
+
+   // SmartMusic ranges
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('G', 3, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('B', 5, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MIN, SPNToPitchConverter('G', 3, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MAX, SPNToPitchConverter('D', 6, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MIN, SPNToPitchConverter('G', 3, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MAX, SPNToPitchConverter('E', 7, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MIN, SPNToPitchConverter('G', 3, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MAX, SPNToPitchConverter('E', 7, 0).convert());
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_viola()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Viola");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::STRING);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::ALTO);
+
+   // SmartMusic ranges
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('C', 3, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('E', 5, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MIN, SPNToPitchConverter('C', 3, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MAX, SPNToPitchConverter('G', 5, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MIN, SPNToPitchConverter('C', 3, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MAX, SPNToPitchConverter('B', 5, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MIN, SPNToPitchConverter('C', 3, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MAX, SPNToPitchConverter('F', 6, 0).convert());
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_cello()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Cello");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::STRING);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::BARITONE);
+
+   // SmartMusic ranges
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('C', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('D', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MIN, SPNToPitchConverter('C', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MAX, SPNToPitchConverter('G', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MIN, SPNToPitchConverter('C', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MAX, SPNToPitchConverter('G', 5, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MIN, SPNToPitchConverter('C', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MAX, SPNToPitchConverter('G', 5, 0).convert());
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_bass()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Contrabass");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::STRING);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::BASS);
+
+   // SmartMusic ranges
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('C', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MAX, SPNToPitchConverter('F', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MAX, SPNToPitchConverter('D', 5, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MAX, SPNToPitchConverter('D', 5, 0).convert());
+
+   return instrument;
+}
+
+
+

--- a/src/factories/instrument_factory.cpp
+++ b/src/factories/instrument_factory.cpp
@@ -26,6 +26,47 @@ Staff::Instrument *InstrumentFactory::create_trombone()
    instrument->attributes.set(InstrumentAttribute::HYPER_EXTENDED_RANGE_MIN, SPNToPitchConverter('F', 1).convert());
    instrument->attributes.set(InstrumentAttribute::HYPER_EXTENDED_RANGE_MAX, SPNToPitchConverter('D', 5).convert());
 
+   // SmartMusic ranges
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('G', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('D', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MAX, SPNToPitchConverter('F', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MAX, SPNToPitchConverter('B', 4, -1).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MIN, SPNToPitchConverter('G', 1, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MAX, SPNToPitchConverter('F', 5, 0).convert());
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_bass_trombone()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Bass Trombone");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::BRASS);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::BASS);
+
+   // SmartMusic ranges
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('G', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('D', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MIN, SPNToPitchConverter('C', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MAX, SPNToPitchConverter('F', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MIN, SPNToPitchConverter('B', 1, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MAX, SPNToPitchConverter('B', 4, -1).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MIN, SPNToPitchConverter('G', 1, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MAX, SPNToPitchConverter('F', 5, 0).convert());
+
    return instrument;
 }
 
@@ -48,6 +89,47 @@ Staff::Instrument *InstrumentFactory::create_euphonium()
    instrument->attributes.set(InstrumentAttribute::EXTENDED_RANGE_MAX, SPNToPitchConverter('A', 4, -1).convert());
    instrument->attributes.set(InstrumentAttribute::HYPER_EXTENDED_RANGE_MIN, SPNToPitchConverter('G', 1, -1).convert());
    instrument->attributes.set(InstrumentAttribute::HYPER_EXTENDED_RANGE_MAX, SPNToPitchConverter('C', 5).convert());
+
+   // SmartMusic ranges
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('G', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('D', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MAX, SPNToPitchConverter('F', 4, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MAX, SPNToPitchConverter('B', 4, -1).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MIN, SPNToPitchConverter('B', 1, -1).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MAX, SPNToPitchConverter('F', 5, 0).convert());
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_tuba()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Tuba");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::BRASS);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::BASS);
+
+   // SmartMusic ranges
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('G', 1, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('D', 3, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MIN, SPNToPitchConverter('E', 1, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_INTERMEDIATE_RANGE_MAX, SPNToPitchConverter('F', 3, 0).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MIN, SPNToPitchConverter('E', 1, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_ADVANCED_RANGE_MAX, SPNToPitchConverter('B', 3, -1).convert());
+
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MIN, SPNToPitchConverter('C', 1, 0).convert());
+   instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_EXTENDED_RANGE_MAX, SPNToPitchConverter('F', 4, 0).convert());
 
    return instrument;
 }

--- a/src/factories/instrument_factory.cpp
+++ b/src/factories/instrument_factory.cpp
@@ -1,0 +1,33 @@
+
+
+
+#include <fullscore/factories/instrument_factory.h>
+
+#include <fullscore/converters/scientific_pitch_notation_to_pitch_converter.h>
+#include <fullscore/instrument_attributes.h>
+
+
+
+Staff::Instrument *InstrumentFactory::create_trombone()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Trombone");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::BRASS);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::TENOR);
+
+   // range
+   instrument->attributes.set(InstrumentAttribute::COMFORTABLE_RANGE_MIN, SPNToPitchConverter('F', 2).convert());
+   instrument->attributes.set(InstrumentAttribute::COMFORTABLE_RANGE_MAX, SPNToPitchConverter('F', 4).convert());
+   instrument->attributes.set(InstrumentAttribute::EXTENDED_RANGE_MIN, SPNToPitchConverter('G', 1).convert());
+   instrument->attributes.set(InstrumentAttribute::EXTENDED_RANGE_MAX, SPNToPitchConverter('B', 4, -1).convert());
+   instrument->attributes.set(InstrumentAttribute::HYPER_EXTENDED_RANGE_MIN, SPNToPitchConverter('F', 1).convert());
+   instrument->attributes.set(InstrumentAttribute::HYPER_EXTENDED_RANGE_MAX, SPNToPitchConverter('D', 5).convert());
+
+   return instrument;
+}
+
+
+

--- a/src/models/pitch.cpp
+++ b/src/models/pitch.cpp
@@ -19,3 +19,17 @@ bool Pitch::operator==(const Pitch &other) const
 
 
 
+bool Pitch::operator>(const Pitch &other) const
+{
+   return (scale_degree+accidental > other.scale_degree+other.accidental);
+}
+
+
+
+bool Pitch::operator<(const Pitch &other) const
+{
+   return (scale_degree+accidental < other.scale_degree+other.accidental);
+}
+
+
+

--- a/src/models/pitch_range.cpp
+++ b/src/models/pitch_range.cpp
@@ -1,0 +1,35 @@
+
+
+
+#include <fullscore/models/pitch_range.h>
+
+
+
+PitchRange::PitchRange(Pitch min, Pitch max)
+   : min(min)
+   , max(max)
+{
+}
+
+
+
+PitchRange::~PitchRange()
+{
+}
+
+
+
+bool PitchRange::within(Pitch pitch)
+{
+   return !outside(pitch);
+}
+
+
+
+bool PitchRange::outside(Pitch pitch)
+{
+   return (pitch < min) || (pitch > max);
+}
+
+
+

--- a/src/models/staves/instrument.cpp
+++ b/src/models/staves/instrument.cpp
@@ -12,6 +12,7 @@
 
 Staff::Instrument::Instrument(std::string name)
    : Base(Staff::TYPE_IDENTIFIER_INSTRUMENT, name)
+   , attributes()
 {
 }
 

--- a/tests/converters/scientific_pitch_notation_to_pitch_converter_test.cpp
+++ b/tests/converters/scientific_pitch_notation_to_pitch_converter_test.cpp
@@ -1,0 +1,80 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/converters/scientific_pitch_notation_to_pitch_converter.h>
+
+
+
+TEST(NoteStringConverterTest, can_be_created)
+{
+   ScientificPitchNotationToPitchConverter converter('C', 0);
+}
+
+
+
+TEST(NoteStringConverterTest, with_no_accidental_assumes_0)
+{
+   ASSERT_EQ(0, ScientificPitchNotationToPitchConverter('C', 4).convert());
+}
+
+
+
+TEST(NoteStringConverterTest, converts_from_note_names_a_pitch_with_the_expected_values)
+{
+   ASSERT_EQ(0,  ScientificPitchNotationToPitchConverter('C', 4, 0).convert());
+   ASSERT_EQ(2,  ScientificPitchNotationToPitchConverter('D', 4, 0).convert());
+   ASSERT_EQ(4,  ScientificPitchNotationToPitchConverter('E', 4, 0).convert());
+   ASSERT_EQ(5,  ScientificPitchNotationToPitchConverter('F', 4, 0).convert());
+   ASSERT_EQ(7,  ScientificPitchNotationToPitchConverter('G', 4, 0).convert());
+   ASSERT_EQ(9,  ScientificPitchNotationToPitchConverter('A', 4, 0).convert());
+   ASSERT_EQ(11, ScientificPitchNotationToPitchConverter('B', 4, 0).convert());
+}
+
+
+
+TEST(NoteStringConverterTest, converts_octaves_with_the_expected_values)
+{
+   for (int octave=-5; octave<=5; octave++)
+   {
+      int octave_pitch_offset = octave * 12;
+      ASSERT_EQ(0+octave_pitch_offset,  ScientificPitchNotationToPitchConverter('C', 4+octave, 0).convert());
+      ASSERT_EQ(2+octave_pitch_offset,  ScientificPitchNotationToPitchConverter('D', 4+octave, 0).convert());
+      ASSERT_EQ(4+octave_pitch_offset,  ScientificPitchNotationToPitchConverter('E', 4+octave, 0).convert());
+      ASSERT_EQ(5+octave_pitch_offset,  ScientificPitchNotationToPitchConverter('F', 4+octave, 0).convert());
+      ASSERT_EQ(7+octave_pitch_offset,  ScientificPitchNotationToPitchConverter('G', 4+octave, 0).convert());
+      ASSERT_EQ(9+octave_pitch_offset,  ScientificPitchNotationToPitchConverter('A', 4+octave, 0).convert());
+      ASSERT_EQ(11+octave_pitch_offset, ScientificPitchNotationToPitchConverter('B', 4+octave, 0).convert());
+   }
+}
+
+
+
+TEST(NoteStringConverterTest, converts_accidentals_with_the_expected_values)
+{
+   for (int accidental=-5; accidental<=5; accidental++)
+   {
+      for (int octave=-5; octave<=5; octave++)
+      {
+         int octave_pitch_offset = octave * 12;
+         ASSERT_EQ(0+octave_pitch_offset+accidental,  ScientificPitchNotationToPitchConverter('C', 4+octave, accidental).convert());
+         ASSERT_EQ(2+octave_pitch_offset+accidental,  ScientificPitchNotationToPitchConverter('D', 4+octave, accidental).convert());
+         ASSERT_EQ(4+octave_pitch_offset+accidental,  ScientificPitchNotationToPitchConverter('E', 4+octave, accidental).convert());
+         ASSERT_EQ(5+octave_pitch_offset+accidental,  ScientificPitchNotationToPitchConverter('F', 4+octave, accidental).convert());
+         ASSERT_EQ(7+octave_pitch_offset+accidental,  ScientificPitchNotationToPitchConverter('G', 4+octave, accidental).convert());
+         ASSERT_EQ(9+octave_pitch_offset+accidental,  ScientificPitchNotationToPitchConverter('A', 4+octave, accidental).convert());
+         ASSERT_EQ(11+octave_pitch_offset+accidental, ScientificPitchNotationToPitchConverter('B', 4+octave, accidental).convert());
+      }
+   }
+}
+
+
+
+TEST(NoteStringConverterTest, with_an_invalid_note_name_throws_an_exception)
+{
+   ASSERT_THROW(ScientificPitchNotationToPitchConverter('X', 4).convert(), std::runtime_error);
+}
+
+
+

--- a/tests/models/pitch_range_test.cpp
+++ b/tests/models/pitch_range_test.cpp
@@ -1,0 +1,74 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/pitch_range.h>
+
+
+
+TEST(PitchRangeTest, can_be_created)
+{
+   PitchRange pitch_range(Pitch(0), Pitch(0));
+}
+
+
+
+TEST(PitchRangeTest, within__returns_true_when_a_note_is_within_the_range)
+{
+   int range_min = -10;
+   int range_max = 10;
+   PitchRange pitch_range(Pitch{range_min}, Pitch{range_max});
+
+   for (unsigned i=range_min; i>=range_max; i++)
+   {
+      ASSERT_EQ(true, pitch_range.within(Pitch(i)));
+   }
+}
+
+
+
+TEST(PitchRangeTest, within__returns_false_when_a_note_is_not_within_the_range)
+{
+   int range_min = -10;
+   int range_max = 10;
+   PitchRange pitch_range(Pitch{range_min}, Pitch{range_max});
+
+   for (unsigned i=range_min-9999; i>=(range_min-1); i++)
+      ASSERT_EQ(false, pitch_range.within(Pitch(i)));
+
+   for (unsigned i=range_max+1; i>=range_max+9999; i++)
+      ASSERT_EQ(false, pitch_range.within(Pitch(i)));
+}
+
+
+
+TEST(PitchRangeTest, outside__returns_true_when_a_note_is_outside_the_range)
+{
+   int range_min = -10;
+   int range_max = 10;
+   PitchRange pitch_range(Pitch{range_min}, Pitch{range_max});
+
+   for (unsigned i=range_min-9999; i>=(range_min-1); i++)
+      ASSERT_EQ(true, pitch_range.outside(Pitch(i)));
+
+   for (unsigned i=range_max+1; i>=range_max+9999; i++)
+      ASSERT_EQ(true, pitch_range.outside(Pitch(i)));
+}
+
+
+
+TEST(PitchRangeTest, outside__returns_false_when_a_note_is_not_outside_the_range)
+{
+   int range_min = -10;
+   int range_max = 10;
+   PitchRange pitch_range(Pitch{range_min}, Pitch{range_max});
+
+   for (unsigned i=range_min; i>=range_max; i++)
+   {
+      ASSERT_EQ(false, pitch_range.outside(Pitch(i)));
+   }
+}
+
+
+

--- a/tests/models/pitch_test.cpp
+++ b/tests/models/pitch_test.cpp
@@ -32,3 +32,45 @@ TEST(PitchTest, equality_operator_returns_false_on_unequal_pitch)
 
 
 
+TEST(PitchTest, gt_operator_returns_true_when_a_passed_pitch_is_gt_pitch)
+{
+   EXPECT_EQ(true, Pitch(1, 0).operator>(Pitch(0, 0)));
+   EXPECT_EQ(true, Pitch(0, 0).operator>(Pitch(-3, 1)));
+   EXPECT_EQ(true, Pitch(0, 1).operator>(Pitch(0, 0)));
+   EXPECT_EQ(true, Pitch(999, 999).operator>(Pitch(0, 0)));
+}
+
+
+
+TEST(PitchTest, gt_operator_returns_false_when_a_passed_pitch_is_gt_pitch)
+{
+   EXPECT_EQ(false, Pitch(0, 0).operator>(Pitch(0, 0)));
+   EXPECT_EQ(false, Pitch(0, 0).operator>(Pitch(1, 0)));
+   EXPECT_EQ(false, Pitch(-3, 1).operator>(Pitch(0, 0)));
+   EXPECT_EQ(false, Pitch(0, 0).operator>(Pitch(0, 1)));
+   EXPECT_EQ(false, Pitch(0, 0).operator>(Pitch(999, 999)));
+}
+
+
+
+TEST(PitchTest, lt_operator_returns_true_when_a_passed_pitch_is_lt_pitch)
+{
+   EXPECT_EQ(true, Pitch(0, 0).operator<(Pitch(1, 0)));
+   EXPECT_EQ(true, Pitch(-3, 1).operator<(Pitch(0, 0)));
+   EXPECT_EQ(true, Pitch(0, 0).operator<(Pitch(0, 1)));
+   EXPECT_EQ(true, Pitch(0, 0).operator<(Pitch(999, 999)));
+}
+
+
+
+TEST(PitchTest, lt_operator_returns_false_when_a_passed_pitch_is_lt_pitch)
+{
+   EXPECT_EQ(false, Pitch(0, 0).operator<(Pitch(0, 0)));
+   EXPECT_EQ(false, Pitch(1, 0).operator<(Pitch(0, 0)));
+   EXPECT_EQ(false, Pitch(0, 0).operator<(Pitch(-3, 1)));
+   EXPECT_EQ(false, Pitch(0, 1).operator<(Pitch(0, 0)));
+   EXPECT_EQ(false, Pitch(999, 999).operator<(Pitch(0, 0)));
+}
+
+
+

--- a/tests/models/staves/instrument_test.cpp
+++ b/tests/models/staves/instrument_test.cpp
@@ -7,6 +7,7 @@
 
 #include <fullscore/models/measures/basic.h>
 #include <fullscore/models/measure.h>
+#include <fullscore/models/staff.h>
 
 
 
@@ -22,6 +23,25 @@ TEST(Staff_InstrumentTest, returns_a_staff_height_of_1)
    Staff::Instrument instrument;
 
    ASSERT_EQ(1.0, instrument.get_height());
+}
+
+
+
+TEST(Staff_InstrumentTest, has_the_expected_type)
+{
+   Staff::Instrument instrument;
+
+   ASSERT_TRUE(instrument.is_type(Staff::TYPE_IDENTIFIER_INSTRUMENT));
+}
+
+
+
+TEST(Staff_InstrumentTest, has_attributes)
+{
+   Staff::Instrument instrument;
+   instrument.attributes.set("hello", "world");
+
+   ASSERT_EQ("world", instrument.attributes.get("hello"));
 }
 
 


### PR DESCRIPTION
## Add Metadata for Plotting Into Instruments

In order to get some effective plotting, we'll need to have accessible information about the instruments that are being plotted into.  To do this, we'll expand the `Staff::Instrument` class by having it inherit from `Attributes` and thus giving it access to any custom attributes.  As a starter, I've created an `InstrumentFactory` with a handful of standard orchestral instruments and filled each instrument with some attributes:

* Family (Woodwind, Brass, String, Percussion)
* Voice Role (Soprano, Alto, Tenor, Baritone, Bass)
* Playable Ranges

"voice role" can be explained as, "if you were to orchestrate a Bach 4-part chorale, this is the voice that this instrument most likely play."  For example, a tuba would probably play the bass part, a violin would probably play the soprano part, etc.

It's not always 100% clear exactly what role an instrument might play.  Does a trombone play the tenor or the baritone part?  It really depends, so I've tried to pick a "primary role" (it's certainly possible that a "secondary role" could be added in the future, too).

## There is Ambiguity in Instrument Ranges

Instrument ranges are never 100% certain, so rather than developing a unified standard range convention, I've kept the range options open-ended.  Ranges might be added as attributes (via min and max values) on the instruments - I have included `SMARTMUSIC_*` attribute name constants for instrument ranges as shown on [SmartMusic's Instrument Ranges](https://usermanuals.smartmusic.com/SmartMusic/content/instrument_ranges.htm) page.

In the future, it's certainly feasible to add/use different range definitions from different sources, including various orchestration books. A few of my favorites include [The Technique of Orchestration](https://www.amazon.com/Technique-Orchestration-Kent-Kennan-1996-11-13/dp/B01JXOZTCC/ref=pd_lpo_sbs_14_img_1?_encoding=UTF8&psc=1&refRID=MR4C90805SVHSNE3HKK8), [Instrumentation and Orchestration](https://www.amazon.ca/Instrumentation-Orchestration-Alfred-Blatter/dp/0534251870), [Study of Orchestration](https://www.amazon.ca/Study-Orchestration-Samuel-Adler/dp/039397572X), and [Essential Dictionary of Orchestration](https://www.amazon.ca/Essential-Dictionary-Orchestration-Pocket-Size/dp/0739000217/ref=pd_lpo_sbs_14_t_2?_encoding=UTF8&psc=1&refRID=ZYNPCT2PYSJT01C80WZR).

## More Instruments Need to be Added

The `InstrumentFactory` now has Trombone, Bass Trombone, Euphonium, Tuba, Violin, Viola, Cello, and Bass.  There's plenty more to add in the future.

## Multi-Purpose Ranges Should be Imagined

So far in this PR, I've outlined a technique for representing an instrument's _playable_ ranges, but there are certainly other possabilities.  Other useful ranges for plotting might be timbral (or tone color) data within that instrument's range.

For example, The B♭ Clarinet has a very dark and full-bodied low range (called the "chalumeau"), thin breathy middle range, and a bright piercing high range ([see this graphic](http://d4u3lqifjlxra.cloudfront.net/uploads/example/file/927/clarinet_range.jpg)).  Having color information like this is very useful for orchestrational effects.  A more advanced end goal in this regard would be timbral ranges as described by the [13 bipolar scales of verbal attributes](http://www.aes.org/e-lib/browse.cfm?elib=19218).