### PR TITLE
Add More Instruments

### DIFF
--- a/include/fullscore/factories/instrument_factory.h
+++ b/include/fullscore/factories/instrument_factory.h
@@ -9,6 +9,13 @@
 class InstrumentFactory
 {
 public:
+   Staff::Instrument *create_flute();
+   Staff::Instrument *create_clarinet();
+   Staff::Instrument *create_oboe();
+   Staff::Instrument *create_bassoon();
+
+   Staff::Instrument *create_trumpet();
+   Staff::Instrument *create_french_horn();
    Staff::Instrument *create_trombone();
    Staff::Instrument *create_bass_trombone();
    Staff::Instrument *create_euphonium();

--- a/include/fullscore/instrument_attributes.h
+++ b/include/fullscore/instrument_attributes.h
@@ -31,6 +31,16 @@ namespace InstrumentAttribute
    }
 
 
+   // Transposition & Clef
+
+   std::string const DEFAULT_CLEF  = "default_celf";
+   std::string const TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH = "transposition_concert_to_written_pitch";
+   std::string const TREBLE_CLEF = "treble_clef;
+   std::string const ALTO_CLEF = "alto_clef;
+   std::string const TENOR_CLEF = "tenor_clef;
+   std::string const BASS_CLEF = "bass_clef;
+
+
    // Range
 
    std::string const COMFORTABLE_RANGE_MIN    = "comfortable_range_min";

--- a/src/factories/instrument_factory.cpp
+++ b/src/factories/instrument_factory.cpp
@@ -8,6 +8,96 @@
 
 
 
+Staff::Instrument *InstrumentFactory::create_flute()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Flute");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::WOODWIND);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::SOPRANO);
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_clarinet()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Clarinet");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::WOODWIND
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::ALTO);
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_oboe()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Oboe");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::WOODWIND);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::SOPRANO);
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_bassoon()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Bassoon");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::WOODWIND);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::TENOR);
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_trumpet()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("Trumpet");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::BRASS);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::SOPRANO);
+
+   return instrument;
+}
+
+
+
+Staff::Instrument *InstrumentFactory::create_french_horn()
+{
+   Staff::Instrument *instrument = new Staff::Instrument("French Horn");
+
+   // lineage
+   instrument->attributes.set(InstrumentAttribute::FAMILY, InstrumentAttribute::Family::BRASS);
+
+   // roles
+   instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::ALTO);
+
+   return instrument;
+}
+
+
+
 Staff::Instrument *InstrumentFactory::create_trombone()
 {
    Staff::Instrument *instrument = new Staff::Instrument("Trombone");

--- a/src/factories/instrument_factory.cpp
+++ b/src/factories/instrument_factory.cpp
@@ -18,6 +18,10 @@ Staff::Instrument *InstrumentFactory::create_flute()
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::SOPRANO);
 
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::TREBLE_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
+
    return instrument;
 }
 
@@ -32,6 +36,10 @@ Staff::Instrument *InstrumentFactory::create_clarinet()
 
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::ALTO);
+
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::TREBLE_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 2);
 
    return instrument;
 }
@@ -48,6 +56,10 @@ Staff::Instrument *InstrumentFactory::create_oboe()
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::SOPRANO);
 
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::TREBLE_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
+
    return instrument;
 }
 
@@ -62,6 +74,10 @@ Staff::Instrument *InstrumentFactory::create_bassoon()
 
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::TENOR);
+
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::BASS_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
 
    return instrument;
 }
@@ -78,6 +94,10 @@ Staff::Instrument *InstrumentFactory::create_trumpet()
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::SOPRANO);
 
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::TREBLE_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 2);
+
    return instrument;
 }
 
@@ -93,6 +113,10 @@ Staff::Instrument *InstrumentFactory::create_french_horn()
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::ALTO);
 
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::TREBLE_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 7);
+
    return instrument;
 }
 
@@ -107,6 +131,10 @@ Staff::Instrument *InstrumentFactory::create_trombone()
 
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::TENOR);
+
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::BASS_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
 
    // range
    instrument->attributes.set(InstrumentAttribute::COMFORTABLE_RANGE_MIN, SPNToPitchConverter('F', 2).convert());
@@ -144,6 +172,10 @@ Staff::Instrument *InstrumentFactory::create_bass_trombone()
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::BASS);
 
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::BASS_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
+
    // SmartMusic ranges
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('G', 2, 0).convert());
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('D', 4, 0).convert());
@@ -171,6 +203,10 @@ Staff::Instrument *InstrumentFactory::create_euphonium()
 
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::TENOR);
+
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::BASS_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
 
    // range
    instrument->attributes.set(InstrumentAttribute::COMFORTABLE_RANGE_MIN, SPNToPitchConverter('G', 2).convert());
@@ -208,6 +244,10 @@ Staff::Instrument *InstrumentFactory::create_tuba()
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::BASS);
 
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::BASS_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
+
    // SmartMusic ranges
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('G', 1, 0).convert());
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('D', 3, 0).convert());
@@ -235,6 +275,10 @@ Staff::Instrument *InstrumentFactory::create_violin()
 
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::SOPRANO);
+
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::TREBLE_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
 
    // SmartMusic ranges
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('G', 3, 0).convert());
@@ -264,6 +308,10 @@ Staff::Instrument *InstrumentFactory::create_viola()
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::ALTO);
 
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::ALTO_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
+
    // SmartMusic ranges
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('C', 3, 0).convert());
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('E', 5, 0).convert());
@@ -292,6 +340,10 @@ Staff::Instrument *InstrumentFactory::create_cello()
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::BARITONE);
 
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::BASS_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 0);
+
    // SmartMusic ranges
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('C', 2, 0).convert());
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MAX, SPNToPitchConverter('D', 4, 0).convert());
@@ -319,6 +371,10 @@ Staff::Instrument *InstrumentFactory::create_bass()
 
    // roles
    instrument->attributes.set(InstrumentAttribute::VOICE_ROLE, InstrumentAttribute::VoiceRole::BASS);
+
+   // transposition & clef
+   instrument->attributes.set(InstrumentAttribute::DEFAULT_CLEF, InstrumentAttribute::BASS_CLEF);
+   instrument->attributes.set(InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH, 12);
 
    // SmartMusic ranges
    instrument->attributes.set(InstrumentAttribute::SMARTMUSIC_BASIC_RANGE_MIN, SPNToPitchConverter('E', 2, 0).convert());


### PR DESCRIPTION
## Modest Instrument Additions

This PR adds the following instruments:

- Flute
- Clarinet
- Oboe
- Bassoon
- Trumpet
- F Horn

Each instrument is added with only the attributes below.  Note that instrument ranges are not included:

- `InstrumentAttribute::FAMILY`
- `InstrumentAttribute::VOICE_ROLE`

## New Instrument Attributes!

Instruments now have new attributes:

- `InstrumentAttribute::TRANSPOSITION_CONCERT_TO_WRITTEN_PITCH` - a transposition value that would convert concert pitch notes to written notes for the instrument.
- `InstrumentAttribute::DEFAULT_CLEF` - value that can (should, it's not enforced) be any of the following values:
   - `InstrumentAttribute::DEFAULT_CLEF`
   - `InstrumentAttribute::TREBLE_CLEF`
   - `InstrumentAttribute::ALTO_CLEF`
   - `InstrumentAttribute::TENOR_CLEF`
   - `InstrumentAttribute::BASS_CLEF`

Other clefs might be added in the future.