### PR TITLE
Enable Setting a Focused Floating Measure

### DIFF
--- a/bin/tools/new_action.rb
+++ b/bin/tools/new_action.rb
@@ -33,11 +33,19 @@ source_code = source_template_file.read
 header_code = header_template_file.read
 
 
+# create our strings for replacing
+
+class_name_camel_case = class_name.camel_case
+class_name_snake_case = class_name.underscore
+class_name_constantized = class_name.underscore.upcase
+
+
 # overwrite the template tokens
-source_code.gsub!(/CLASS_NAME/, class_name.camel_case)
-source_code.gsub!(/SNAKECASE_ACTION_NAME/, class_name.underscore)
-header_code.gsub!(/CLASS_NAME/, class_name.camel_case)
-header_code.gsub!(/SNAKECASE_ACTION_NAME/, class_name.underscore)
+source_code.gsub!(/CLASS_NAME/, class_name_camel_case)
+source_code.gsub!(/SNAKECASE_ACTION_NAME/, class_name_snake_case)
+source_code.gsub!(/CONSTANTIZED_ACTION_NAME/, "#{class_name_constantized}_IDENTIFIER")
+header_code.gsub!(/CLASS_NAME/, class_name_camel_case)
+header_code.gsub!(/SNAKECASE_ACTION_NAME/, class_name_snake_case)
 
 
 # save the file with a new filename

--- a/bin/tools/new_action.rb
+++ b/bin/tools/new_action.rb
@@ -53,10 +53,10 @@ puts "generated #{header_filename}"
 
 
 # write `git commit -m "Create source files for CLASS_NAME action"`
-`git reset`
-`git add #{source_filename}`
-`git add #{header_filename}`
-`git commit -m "Create source files for #{class_name.camel_case} action"`
+# `git reset`
+# `git add #{source_filename}`
+# `git add #{header_filename}`
+# `git commit -m "Create source files for #{class_name.camel_case} action"`
 
 
 

--- a/bin/tools/templates/__action_template.cpp
+++ b/bin/tools/templates/__action_template.cpp
@@ -3,10 +3,13 @@
 
 #include <fullscore/actions/SNAKECASE_ACTION_NAME_action.h>
 
+#include <fullscore/action.h>
+
 
 
 Action::CLASS_NAME::CLASS_NAME()
-   : Base("SNAKECASE_ACTION_NAME")
+   : Base(Action::CONSTANTIZED_ACTION_NAME)
+   // std::string const CONSTANTIZED_ACTION_NAME = "SNAKECASE_ACTION_NAME";
 {}
 
 

--- a/include/fullscore/action.h
+++ b/include/fullscore/action.h
@@ -19,6 +19,7 @@ namespace Action
    std::string const MOVE_CURSOR_LEFT_ACTION_IDENTIFIER = "move_cursor_left";
    std::string const MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER = "move_cursor_right";
    std::string const MOVE_CURSOR_UP_ACTION_IDENTIFIER = "move_cursor_up";
+   std::string const MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER = "move_floating_measure_cursor_right";
    std::string const PASTE_MEASURE_FROM_BUFFER_ACTION_IDENTIFIER = "paste_measure_from_buffer";
    std::string const PASTE_MEASURE_FROM_BUFFER_TO_GRID_COORDINATES_ACTION_IDENTIFIER = "paste_measure_from_buffer_to_grid_coordinates";
    std::string const QUEUE_ACTION_IDENTIFIER = "queue";

--- a/include/fullscore/action.h
+++ b/include/fullscore/action.h
@@ -19,6 +19,7 @@ namespace Action
    std::string const MOVE_CURSOR_LEFT_ACTION_IDENTIFIER = "move_cursor_left";
    std::string const MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER = "move_cursor_right";
    std::string const MOVE_CURSOR_UP_ACTION_IDENTIFIER = "move_cursor_up";
+   std::string const MOVE_FLOATING_MEASURE_CURSOR_LEFT_IDENTIFIER = "move_floating_measure_cursor_left";
    std::string const MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER = "move_floating_measure_cursor_right";
    std::string const PASTE_MEASURE_FROM_BUFFER_ACTION_IDENTIFIER = "paste_measure_from_buffer";
    std::string const PASTE_MEASURE_FROM_BUFFER_TO_GRID_COORDINATES_ACTION_IDENTIFIER = "paste_measure_from_buffer_to_grid_coordinates";

--- a/include/fullscore/actions/move_floating_measure_cursor_left_action.h
+++ b/include/fullscore/actions/move_floating_measure_cursor_left_action.h
@@ -1,0 +1,26 @@
+#pragma once
+
+
+
+#include <fullscore/actions/base.h>
+#include <fullscore/models/floating_measure_cursor.h>
+
+
+
+namespace Action
+{
+   class MoveFloatingMeasureCursorLeft : public Base
+   {
+   private:
+      FloatingMeasureCursor *floating_measure_cursor;
+
+   public:
+      MoveFloatingMeasureCursorLeft(FloatingMeasureCursor *floating_measure_cursor);
+      ~MoveFloatingMeasureCursorLeft();
+
+      bool execute() override;
+   };
+};
+
+
+

--- a/include/fullscore/actions/move_floating_measure_cursor_right_action.h
+++ b/include/fullscore/actions/move_floating_measure_cursor_right_action.h
@@ -3,6 +3,7 @@
 
 
 #include <fullscore/actions/base.h>
+#include <fullscore/models/floating_measure_cursor.h>
 
 
 
@@ -10,8 +11,11 @@ namespace Action
 {
    class MoveFloatingMeasureCursorRight : public Base
    {
+   private:
+      FloatingMeasureCursor *floating_measure_cursor;
+
    public:
-      MoveFloatingMeasureCursorRight();
+      MoveFloatingMeasureCursorRight(FloatingMeasureCursor *floating_measure_cursor);
       ~MoveFloatingMeasureCursorRight();
 
       bool execute() override;

--- a/include/fullscore/actions/move_floating_measure_cursor_right_action.h
+++ b/include/fullscore/actions/move_floating_measure_cursor_right_action.h
@@ -1,0 +1,22 @@
+#pragma once
+
+
+
+#include <fullscore/actions/base.h>
+
+
+
+namespace Action
+{
+   class MoveFloatingMeasureCursorRight : public Base
+   {
+   public:
+      MoveFloatingMeasureCursorRight();
+      ~MoveFloatingMeasureCursorRight();
+
+      bool execute() override;
+   };
+};
+
+
+

--- a/include/fullscore/components/grid_render_component.h
+++ b/include/fullscore/components/grid_render_component.h
@@ -13,9 +13,10 @@ private:
    float full_measure_width;
    float staff_height;
    bool showing_debug_data;
+   int focused_floating_measure_id;
 
 public:
-   GridRenderComponent(Grid *grid, MusicEngraver *engraver, float full_measure_width, float staff_height);
+   GridRenderComponent(Grid *grid, MusicEngraver *engraver, float full_measure_width, float staff_height, int focused_floating_measure_id);
    ~GridRenderComponent();
 
    void set_showing_debug_data(bool show);

--- a/include/fullscore/components/measure_render_component.h
+++ b/include/fullscore/components/measure_render_component.h
@@ -19,9 +19,10 @@ private:
    float row_middle_y;
    float staff_height;
    bool showing_debug_data;
+   bool is_focused;
 
 public:
-   MeasureRenderComponent(Measure::Base *context, Measure::Base *measure, MusicEngraver *music_engraver, float full_measure_width, float x_pos, float y_pos, float row_middle_y, float staff_height, bool showing_debug_data);
+   MeasureRenderComponent(Measure::Base *context, Measure::Base *measure, MusicEngraver *music_engraver, float full_measure_width, float x_pos, float y_pos, float row_middle_y, float staff_height, bool showing_debug_data, bool is_focused);
 
    void render();
 };

--- a/include/fullscore/models/floating_measure.h
+++ b/include/fullscore/models/floating_measure.h
@@ -37,6 +37,7 @@ public:
    static int get_next_id();
    static FloatingMeasure *find(int id, find_option_t find_option=FIND_OPTION_NONE);
    static std::vector<FloatingMeasure *> find_at_staff_and_barline(int staff_id, int barline_num);
+   static std::vector<FloatingMeasure *> in_staff(int staff_id);
    static std::vector<FloatingMeasure *> get_pool_elements();
    static bool destroy_all();
    static int get_num_pool_elements();

--- a/include/fullscore/models/floating_measure.h
+++ b/include/fullscore/models/floating_measure.h
@@ -27,7 +27,15 @@ private:
    static std::vector<FloatingMeasure *> pool_elements;
 
 public:
+   enum find_option_t
+   {
+      FIND_OPTION_NONE = 0,
+      FIND_OPTION_INCLUDE_NOT_FOUND,
+      FIND_OPTION_RAISE_NOT_FOUND,
+   };
+
    static int get_next_id();
+   static FloatingMeasure *find(int id, find_option_t find_option=FIND_OPTION_NONE);
    static std::vector<FloatingMeasure *> find_at_staff_and_barline(int staff_id, int barline_num);
    static std::vector<FloatingMeasure *> get_pool_elements();
    static bool destroy_all();

--- a/include/fullscore/models/floating_measure.h
+++ b/include/fullscore/models/floating_measure.h
@@ -37,7 +37,7 @@ public:
    static int get_next_id();
    static FloatingMeasure *find(int id, find_option_t find_option=FIND_OPTION_NONE);
    static std::vector<FloatingMeasure *> find_at_staff_and_barline(int staff_id, int barline_num);
-   static std::vector<FloatingMeasure *> in_staff(int staff_id);
+   static std::vector<FloatingMeasure *> in_staff(int staff_id, bool sort=true);
    static std::vector<FloatingMeasure *> get_pool_elements();
    static bool destroy_all();
    static int get_num_pool_elements();

--- a/include/fullscore/models/floating_measure_cursor.h
+++ b/include/fullscore/models/floating_measure_cursor.h
@@ -1,0 +1,19 @@
+#pragma once
+
+
+
+class FloatingMeasureCursor
+{
+private:
+   int floating_measure_id;
+
+public:
+   FloatingMeasureCursor();
+   ~FloatingMeasureCursor();
+
+   bool set_floating_measure_id(int floating_measure_id);
+   int get_floating_measure_id();
+};
+
+
+

--- a/include/fullscore/widgets/grid_editor.h
+++ b/include/fullscore/widgets/grid_editor.h
@@ -4,6 +4,7 @@
 
 #include <allegro_flare/gui/widget.h>
 #include <allegro_flare/placement2d.h>
+#include <fullscore/models/floating_measure_cursor.h>
 #include <fullscore/models/grid.h>
 #include <fullscore/models/playback_control.h>
 #include <fullscore/services/music_engraver.h>
@@ -42,6 +43,7 @@ public:
    int grid_cursor_x;
    int grid_cursor_y;
    int note_cursor_x;
+   FloatingMeasureCursor floating_measure_cursor;
    edit_mode_target_t edit_mode_target;
    mode_t mode;
    state_t state;

--- a/include/fullscore/widgets/grid_editor.h
+++ b/include/fullscore/widgets/grid_editor.h
@@ -39,8 +39,8 @@ public:
    Grid grid;
    PlaybackControl playback_control;
 
-   int measure_cursor_x; // should be renamed to grid_cursor_x, grid_cursor_y
-   int measure_cursor_y;
+   int grid_cursor_x;
+   int grid_cursor_y;
    int note_cursor_x;
    edit_mode_target_t edit_mode_target;
    mode_t mode;
@@ -59,12 +59,12 @@ public:
    Measure::Base *get_measure_at_cursor();
    Note *get_note_at_cursor();
 
-   int move_measure_cursor_x(int delta);
-   int move_measure_cursor_y(int delta);
+   int move_grid_cursor_x(int delta);
+   int move_grid_cursor_y(int delta);
    int move_note_cursor_x(int delta);
 
-   float get_measure_cursor_real_x();
-   float get_measure_cursor_real_y();
+   float get_grid_cursor_real_x();
+   float get_grid_cursor_real_y();
    float get_measure_length_to_note(Measure::Base *measure, int note_index);
    float get_measure_width(Measure::Base *m);
 

--- a/src/actions/move_cursor_down_action.cpp
+++ b/src/actions/move_cursor_down_action.cpp
@@ -29,7 +29,7 @@ bool Action::MoveCursorDown::execute()
 {
    if (!grid_editor) return false;
 
-   grid_editor->move_measure_cursor_y(1);
+   grid_editor->move_grid_cursor_y(1);
 
    return true;
 }

--- a/src/actions/move_cursor_left_action.cpp
+++ b/src/actions/move_cursor_left_action.cpp
@@ -31,7 +31,7 @@ bool Action::MoveCursorLeft::execute()
 
    if (grid_editor->is_measure_target_mode())
    {
-      grid_editor->move_measure_cursor_x(-1);
+      grid_editor->move_grid_cursor_x(-1);
       grid_editor->note_cursor_x = 0;
    }
    else if (grid_editor->is_note_target_mode()) grid_editor->move_note_cursor_x(-1);

--- a/src/actions/move_cursor_right_action.cpp
+++ b/src/actions/move_cursor_right_action.cpp
@@ -31,7 +31,7 @@ bool Action::MoveCursorRight::execute()
 
    if (grid_editor->is_measure_target_mode())
    {
-      grid_editor->move_measure_cursor_x(1);
+      grid_editor->move_grid_cursor_x(1);
       grid_editor->note_cursor_x = 0;
    }
    else if (grid_editor->is_note_target_mode()) grid_editor->move_note_cursor_x(1);

--- a/src/actions/move_cursor_up_action.cpp
+++ b/src/actions/move_cursor_up_action.cpp
@@ -30,7 +30,7 @@ bool Action::MoveCursorUp::execute()
 {
    if (!grid_editor) return false;
 
-   grid_editor->move_measure_cursor_y(-1);
+   grid_editor->move_grid_cursor_y(-1);
 
    return true;
 }

--- a/src/actions/move_floating_measure_cursor_left_action.cpp
+++ b/src/actions/move_floating_measure_cursor_left_action.cpp
@@ -1,0 +1,57 @@
+
+
+
+#include <fullscore/actions/move_floating_measure_cursor_left_action.h>
+
+#include <fullscore/models/floating_measure.h>
+#include <fullscore/action.h>
+
+
+
+Action::MoveFloatingMeasureCursorLeft::MoveFloatingMeasureCursorLeft(FloatingMeasureCursor *floating_measure_cursor)
+   : Base(Action::MOVE_FLOATING_MEASURE_CURSOR_LEFT_IDENTIFIER)
+   , floating_measure_cursor(floating_measure_cursor)
+{}
+
+
+
+Action::MoveFloatingMeasureCursorLeft::~MoveFloatingMeasureCursorLeft()
+{}
+
+
+
+bool Action::MoveFloatingMeasureCursorLeft::execute()
+{
+   if (!floating_measure_cursor) throw std::runtime_error("Cannot move the floating_measure_cursor left because it does not exist");
+
+   FloatingMeasure *current_floating_measure = FloatingMeasure::find(floating_measure_cursor->get_floating_measure_id());
+   if (!current_floating_measure) throw std::runtime_error("Cannot move the floating_measure_cursor left because it does not have a valid floating_measure_id");
+
+   // store the current_floating_measure's id
+   int current_floating_measure_id = current_floating_measure->get_id();
+
+   // get a (sorted) list of the floating_measures in the current staff
+   std::vector<FloatingMeasure *> staff_floating_measures = FloatingMeasure::in_staff(current_floating_measure->get_grid_coordinate().get_staff_id());
+
+   // get the current_floating_measure's index position in the list
+   int current_floating_measure_position = -1;
+   for (int i=0; i<staff_floating_measures.size(); i++)
+      if (staff_floating_measures[i]->get_id() == current_floating_measure_id) { current_floating_measure_position = i; break; }
+
+   // if the index position was not found, something is wrong
+   if (current_floating_measure_position == -1)
+      throw std::runtime_error("Could not find the current_floating_measure's position in list of measures (this shouldn't happen)");
+
+   // prevent moving the cursor when it is already at the front
+   if (current_floating_measure_position == 0)
+      throw std::runtime_error("Can't move the floating_measure_cursor to the left; it's already at the front.");
+
+   // set the current_floating_measure_id of the cursor to the previous measure
+   FloatingMeasure *previous_floating_measure = staff_floating_measures[current_floating_measure_position - 1];
+   floating_measure_cursor->set_floating_measure_id(previous_floating_measure->get_id());
+
+   return true;
+}
+
+
+

--- a/src/actions/move_floating_measure_cursor_right_action.cpp
+++ b/src/actions/move_floating_measure_cursor_right_action.cpp
@@ -1,0 +1,30 @@
+
+
+
+#include <fullscore/actions/move_floating_measure_cursor_right_action.h>
+
+#include <fullscore/action.h>
+
+
+
+Action::MoveFloatingMeasureCursorRight::MoveFloatingMeasureCursorRight()
+   : Base(Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER)
+{
+}
+
+
+
+Action::MoveFloatingMeasureCursorRight::~MoveFloatingMeasureCursorRight()
+{
+}
+
+
+
+bool Action::MoveFloatingMeasureCursorRight::execute()
+{
+   // unimplemented
+   return false;
+}
+
+
+

--- a/src/actions/move_floating_measure_cursor_right_action.cpp
+++ b/src/actions/move_floating_measure_cursor_right_action.cpp
@@ -3,12 +3,14 @@
 
 #include <fullscore/actions/move_floating_measure_cursor_right_action.h>
 
+#include <fullscore/models/floating_measure.h>
 #include <fullscore/action.h>
 
 
 
-Action::MoveFloatingMeasureCursorRight::MoveFloatingMeasureCursorRight()
+Action::MoveFloatingMeasureCursorRight::MoveFloatingMeasureCursorRight(FloatingMeasureCursor *floating_measure_cursor)
    : Base(Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER)
+   , floating_measure_cursor(floating_measure_cursor)
 {
 }
 
@@ -22,8 +24,35 @@ Action::MoveFloatingMeasureCursorRight::~MoveFloatingMeasureCursorRight()
 
 bool Action::MoveFloatingMeasureCursorRight::execute()
 {
-   // unimplemented
-   return false;
+   if (!floating_measure_cursor) throw std::runtime_error("Cannot move the floating_measure_cursor right because it does not exist");
+
+   FloatingMeasure *current_floating_measure = FloatingMeasure::find(floating_measure_cursor->get_floating_measure_id());
+   if (!current_floating_measure) throw std::runtime_error("Cannot move the floating_measure_cursor right because it does not have a valid floating_measure_id");
+
+   // store the current_floating_measure's id
+   int current_floating_measure_id = current_floating_measure->get_id();
+
+   // get a (sorted) list of the floating_measures in the current staff
+   std::vector<FloatingMeasure *> staff_floating_measures = FloatingMeasure::in_staff(current_floating_measure->get_grid_coordinate().get_staff_id());
+
+   // get the current_floating_measure's index position in the list
+   int current_floating_measure_position = -1;
+   for (int i=0; i<staff_floating_measures.size(); i++)
+      if (staff_floating_measures[i]->get_id() == current_floating_measure_id) { current_floating_measure_position = i; break; }
+
+   // if the index position was not found, something is wrong
+   if (current_floating_measure_position == -1)
+      throw std::runtime_error("Could not find the current_floating_measure's position in list of measures (this shouldn't happen)");
+
+   // prevent moving the cursor when it is already at the end
+   if ((current_floating_measure_position + 1) >= staff_floating_measures.size())
+      throw std::runtime_error("Can't move the floating_measure_cursor to the right; it's already at the end.");
+
+   // set the current_floating_measure_id of the cursor to the next measure
+   FloatingMeasure *next_floating_measure = staff_floating_measures[current_floating_measure_position + 1];
+   floating_measure_cursor->set_floating_measure_id(next_floating_measure->get_id());
+
+   return true;
 }
 
 

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -70,6 +70,7 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_MINUS,     false, false, false, "camera_zoom_out");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_K,         false, false, false, Action::MOVE_CURSOR_UP_ACTION_IDENTIFIER);
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_L,         false, false, false, Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER);
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_W,         false, false, false, Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER);
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         false, false, false, "half_duration");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         false, false, false, "set_time_signature_numerator_3");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    false, false, false, "camera_zoom_in");

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -71,6 +71,7 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_K,         false, false, false, Action::MOVE_CURSOR_UP_ACTION_IDENTIFIER);
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_L,         false, false, false, Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER);
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_W,         false, false, false, Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER);
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_B,         true,  false, false, Action::MOVE_FLOATING_MEASURE_CURSOR_LEFT_IDENTIFIER);
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         false, false, false, "half_duration");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         false, false, false, "set_time_signature_numerator_3");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    false, false, false, "camera_zoom_in");

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -33,6 +33,13 @@ AppController::AppController(Display *display, Config &config)
    std::string init_template_identifier = config.get_or_default_str("FULLSCORE_SETTINGS", "init_template", "string_quartet");
    set_current_grid_editor(create_new_grid_editor(init_template_identifier));
 
+   // TODO: warning! this does not ensure the assigned floating measure cursor is within the current grid
+   if (FloatingMeasure::get_num_pool_elements() != 0)
+   {
+      std::vector<FloatingMeasure *> floating_measures = FloatingMeasure::get_pool_elements();
+      current_grid_editor->floating_measure_cursor.set_floating_measure_id(floating_measures[0]->get_id());
+   }
+
    set_keyboard_input_mappings();
 }
 

--- a/src/components/grid_render_component.cpp
+++ b/src/components/grid_render_component.cpp
@@ -24,12 +24,13 @@
 
 
 
-GridRenderComponent::GridRenderComponent(Grid *grid, MusicEngraver *music_engraver, float full_measure_width, float staff_height)
+GridRenderComponent::GridRenderComponent(Grid *grid, MusicEngraver *music_engraver, float full_measure_width, float staff_height, int focused_floating_measure_id)
    : grid(grid)
    , music_engraver(music_engraver)
    , full_measure_width(full_measure_width)
    , staff_height(staff_height)
    , showing_debug_data(false)
+   , focused_floating_measure_id(focused_floating_measure_id)
 {}
 
 
@@ -151,8 +152,9 @@ void GridRenderComponent::render()
          for (auto &floating_measure : FloatingMeasure::find_at_staff_and_barline(staff->get_id(), x))
          {
             float floating_measure_x_offset = floating_measure->get_grid_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset() * full_measure_width / 4.0;
+            bool is_focused = focused_floating_measure_id == floating_measure->get_id();
             Measure::Base *floating_measure_measure = Measure::find(floating_measure->get_measure_id(), Measure::FIND_OPTION_RAISE_NOT_FOUND);
-            MeasureRenderComponent measure_render_component(context_measure, floating_measure_measure, music_engraver, full_measure_width, x_pos + floating_measure_x_offset, y_counter, row_middle_y, this_staff_height, showing_debug_data);
+            MeasureRenderComponent measure_render_component(context_measure, floating_measure_measure, music_engraver, full_measure_width, x_pos + floating_measure_x_offset, y_counter, row_middle_y, this_staff_height, showing_debug_data, is_focused);
             measure_render_component.render();
          }
       }

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -42,7 +42,7 @@ std::tuple<std::string, std::string> __get_context_pitch_and_extension(Measure::
 
 
 
-MeasureRenderComponent::MeasureRenderComponent(Measure::Base *context, Measure::Base *measure, MusicEngraver *music_engraver, float full_measure_width, float x_pos, float y_pos, float row_middle_y, float staff_height, bool showing_debug_data)
+MeasureRenderComponent::MeasureRenderComponent(Measure::Base *context, Measure::Base *measure, MusicEngraver *music_engraver, float full_measure_width, float x_pos, float y_pos, float row_middle_y, float staff_height, bool showing_debug_data, bool is_focused)
    : context(context)
    , measure(measure)
    , music_engraver(music_engraver)
@@ -52,6 +52,7 @@ MeasureRenderComponent::MeasureRenderComponent(Measure::Base *context, Measure::
    , row_middle_y(row_middle_y)
    , staff_height(staff_height)
    , showing_debug_data(showing_debug_data)
+   , is_focused(is_focused)
 {}
 
 
@@ -89,6 +90,11 @@ void MeasureRenderComponent::render()
       notation_color = color::blue;
       staff_line_color = color::blue;
    }
+
+   if (is_focused)
+      al_draw_rounded_rectangle(x_pos-2, row_middle_y-staff_height/2-2,
+            x_pos+measure_width+2, row_middle_y+staff_height/2+2,
+            5, 5, color::black, 2);
 
    al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,
          x_pos+measure_width, row_middle_y+staff_height/2,

--- a/src/components/ui_grid_editor_render_component.cpp
+++ b/src/components/ui_grid_editor_render_component.cpp
@@ -37,7 +37,7 @@ void UIGridEditorRenderComponent::render()
    UIGridEditor::state_t &state                                = ui_grid_editor.state;
    UISurfaceAreaBase *&surface_area                            = ui_grid_editor.surface_area;
    bool &showing_debug_data                                    = ui_grid_editor.showing_debug_data;
-   int &measure_cursor_y                                       = ui_grid_editor.measure_cursor_y;
+   int &grid_cursor_y                                       = ui_grid_editor.grid_cursor_y;
    int &note_cursor_x                                          = ui_grid_editor.note_cursor_x;
    PlaybackControl &playback_control                           = ui_grid_editor.playback_control;
 
@@ -71,8 +71,8 @@ void UIGridEditorRenderComponent::render()
    Measure::Base *measure = ui_grid_editor.get_measure_at_cursor();
 
    Note *note = ui_grid_editor.get_note_at_cursor();
-   float CACHED_get_measure_cursor_real_x = ui_grid_editor.get_measure_cursor_real_x();
-   float CACHED_get_measure_cursor_real_y = ui_grid_editor.get_measure_cursor_real_y();
+   float CACHED_get_grid_cursor_real_x = ui_grid_editor.get_grid_cursor_real_x();
+   float CACHED_get_grid_cursor_real_y = ui_grid_editor.get_grid_cursor_real_y();
 
    // draw the measure
 
@@ -80,8 +80,8 @@ void UIGridEditorRenderComponent::render()
    if (measure && measure->get_num_notes() == 0) measure_width = 16;
 
    // measure box fill
-   al_draw_filled_rounded_rectangle(CACHED_get_measure_cursor_real_x, GridDimensionsHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
-      CACHED_get_measure_cursor_real_x+measure_width, GridDimensionsHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
+   al_draw_filled_rounded_rectangle(CACHED_get_grid_cursor_real_x, GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT,
+      CACHED_get_grid_cursor_real_x+measure_width, GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT,
       4, 4, color::color(color::aliceblue, 0.2));
 
    // measure box outline
@@ -91,10 +91,10 @@ void UIGridEditorRenderComponent::render()
       float h_thickness = thickness * 0.5;
 
       al_draw_rounded_rectangle(
-            CACHED_get_measure_cursor_real_x - h_thickness*2,
-            GridDimensionsHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT - h_thickness*2,
-            CACHED_get_measure_cursor_real_x+measure_width + h_thickness*2,
-            GridDimensionsHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT + h_thickness*2,
+            CACHED_get_grid_cursor_real_x - h_thickness*2,
+            GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT - h_thickness*2,
+            CACHED_get_grid_cursor_real_x+measure_width + h_thickness*2,
+            GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT + h_thickness*2,
             4,
             4,
             color::color(color::black, 0.3),
@@ -102,10 +102,10 @@ void UIGridEditorRenderComponent::render()
          );
 
       al_draw_rounded_rectangle(
-            CACHED_get_measure_cursor_real_x - h_thickness,
-            GridDimensionsHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT - h_thickness,
-            CACHED_get_measure_cursor_real_x+measure_width + h_thickness,
-            GridDimensionsHelper::get_height_to_staff(grid, measure_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT + h_thickness,
+            CACHED_get_grid_cursor_real_x - h_thickness,
+            GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT - h_thickness,
+            CACHED_get_grid_cursor_real_x+measure_width + h_thickness,
+            GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT + h_thickness,
             4,
             4,
             color::color(color::aliceblue, 0.7),
@@ -116,8 +116,8 @@ void UIGridEditorRenderComponent::render()
    // left bar (blinking)
 
    ALLEGRO_COLOR cursor_color = color::color(color::white, sin(Framework::time_now*5) + 0.5);
-   al_draw_line(CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y,
-         CACHED_get_measure_cursor_real_x, CACHED_get_measure_cursor_real_y+GridDimensionsHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
+   al_draw_line(CACHED_get_grid_cursor_real_x, CACHED_get_grid_cursor_real_y,
+         CACHED_get_grid_cursor_real_x, CACHED_get_grid_cursor_real_y+GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT,
          cursor_color, 3.0);
 
    // draw a hilight box at the focused note
@@ -128,10 +128,10 @@ void UIGridEditorRenderComponent::render()
 
       // note box fill
       al_draw_filled_rounded_rectangle(
-            CACHED_get_measure_cursor_real_x + note_real_offset_x,
-            CACHED_get_measure_cursor_real_y,
-            CACHED_get_measure_cursor_real_x + note_real_offset_x + real_note_width,
-            CACHED_get_measure_cursor_real_y + GridDimensionsHelper::get_height_of_staff(grid, measure_cursor_y)*STAFF_HEIGHT,
+            CACHED_get_grid_cursor_real_x + note_real_offset_x,
+            CACHED_get_grid_cursor_real_y,
+            CACHED_get_grid_cursor_real_x + note_real_offset_x + real_note_width,
+            CACHED_get_grid_cursor_real_y + GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT,
             6,
             6,
             color::color(color::pink, 0.4)

--- a/src/components/ui_grid_editor_render_component.cpp
+++ b/src/components/ui_grid_editor_render_component.cpp
@@ -40,6 +40,7 @@ void UIGridEditorRenderComponent::render()
    int &grid_cursor_y                = ui_grid_editor.grid_cursor_y;
    int &note_cursor_x                = ui_grid_editor.note_cursor_x;
    PlaybackControl &playback_control = ui_grid_editor.playback_control;
+   int focused_floating_measure_id   = ui_grid_editor.floating_measure_cursor.get_floating_measure_id();
 
 
    // get_width_of_score
@@ -61,7 +62,7 @@ void UIGridEditorRenderComponent::render()
    }
 
    // render the measure grid
-   GridRenderComponent grid_render_component(&grid, &music_engraver, FULL_MEASURE_WIDTH, STAFF_HEIGHT);
+   GridRenderComponent grid_render_component(&grid, &music_engraver, FULL_MEASURE_WIDTH, STAFF_HEIGHT, focused_floating_measure_id);
    grid_render_component.set_showing_debug_data(showing_debug_data);
    grid_render_component.render();
 

--- a/src/components/ui_grid_editor_render_component.cpp
+++ b/src/components/ui_grid_editor_render_component.cpp
@@ -30,16 +30,16 @@ UIGridEditorRenderComponent::~UIGridEditorRenderComponent()
 
 void UIGridEditorRenderComponent::render()
 {
-   Grid &grid                                                  = ui_grid_editor.grid;
-   MusicEngraver &music_engraver                               = ui_grid_editor.music_engraver;
-   float &FULL_MEASURE_WIDTH                                   = ui_grid_editor.FULL_MEASURE_WIDTH;
-   float &STAFF_HEIGHT                                         = ui_grid_editor.STAFF_HEIGHT;
-   UIGridEditor::state_t &state                                = ui_grid_editor.state;
-   UISurfaceAreaBase *&surface_area                            = ui_grid_editor.surface_area;
-   bool &showing_debug_data                                    = ui_grid_editor.showing_debug_data;
-   int &grid_cursor_y                                       = ui_grid_editor.grid_cursor_y;
-   int &note_cursor_x                                          = ui_grid_editor.note_cursor_x;
-   PlaybackControl &playback_control                           = ui_grid_editor.playback_control;
+   Grid &grid                        = ui_grid_editor.grid;
+   MusicEngraver &music_engraver     = ui_grid_editor.music_engraver;
+   float &FULL_MEASURE_WIDTH         = ui_grid_editor.FULL_MEASURE_WIDTH;
+   float &STAFF_HEIGHT               = ui_grid_editor.STAFF_HEIGHT;
+   UIGridEditor::state_t &state      = ui_grid_editor.state;
+   UISurfaceAreaBase *&surface_area  = ui_grid_editor.surface_area;
+   bool &showing_debug_data          = ui_grid_editor.showing_debug_data;
+   int &grid_cursor_y                = ui_grid_editor.grid_cursor_y;
+   int &note_cursor_x                = ui_grid_editor.note_cursor_x;
+   PlaybackControl &playback_control = ui_grid_editor.playback_control;
 
 
    // get_width_of_score

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -237,16 +237,16 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
    else if (action_identifier == Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER)
       action = new Action::MoveCursorRight(current_grid_editor);
    else if (action_identifier == Action::INSERT_STAFF_ACTION_IDENTIFIER)
-      action = new Action::InsertStaff(&current_grid_editor->grid, current_grid_editor->measure_cursor_y);
+      action = new Action::InsertStaff(&current_grid_editor->grid, current_grid_editor->grid_cursor_y);
    else if (action_identifier == Action::DELETE_STAFF_ACTION_IDENTIFIER)
-      action = new Action::DeleteStaff(&current_grid_editor->grid, current_grid_editor->measure_cursor_y);
+      action = new Action::DeleteStaff(&current_grid_editor->grid, current_grid_editor->grid_cursor_y);
    else if (action_identifier == Action::APPEND_STAFF_ACTION_IDENTIFIER)
       action = new Action::AppendStaff(&current_grid_editor->grid);
    else if (action_identifier == Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER)
    {
-      Staff::Base *current_cursor_staff = current_grid_editor->grid.get_staff(current_grid_editor->measure_cursor_y);
+      Staff::Base *current_cursor_staff = current_grid_editor->grid.get_staff(current_grid_editor->grid_cursor_y);
       int current_staff_id = current_cursor_staff->get_id();
-      int current_barline_num = current_grid_editor->measure_cursor_x;
+      int current_barline_num = current_grid_editor->grid_cursor_x;
       GridCoordinate grid_coordinate(current_staff_id, GridHorizontalCoordinate(current_barline_num, 0));
       Measure::Base *static_measure = new Measure::Basic({0, 0, 0, 0});
 
@@ -255,13 +255,13 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
    else if (action_identifier == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(current_grid_editor);
    else if (action_identifier == "set_time_signature_numerator_2")
-      action = new Action::SetTimeSignatureNumerator(current_grid_editor->grid.get_time_signature_ptr(current_grid_editor->measure_cursor_x), 2);
+      action = new Action::SetTimeSignatureNumerator(current_grid_editor->grid.get_time_signature_ptr(current_grid_editor->grid_cursor_x), 2);
    else if (action_identifier == "set_time_signature_numerator_3")
-      action = new Action::SetTimeSignatureNumerator(current_grid_editor->grid.get_time_signature_ptr(current_grid_editor->measure_cursor_x), 3);
+      action = new Action::SetTimeSignatureNumerator(current_grid_editor->grid.get_time_signature_ptr(current_grid_editor->grid_cursor_x), 3);
    else if (action_identifier == "set_time_signature_numerator_4")
-      action = new Action::SetTimeSignatureNumerator(current_grid_editor->grid.get_time_signature_ptr(current_grid_editor->measure_cursor_x), 4);
+      action = new Action::SetTimeSignatureNumerator(current_grid_editor->grid.get_time_signature_ptr(current_grid_editor->grid_cursor_x), 4);
    else if (action_identifier == "set_time_signature_numerator_5")
-      action = new Action::SetTimeSignatureNumerator(current_grid_editor->grid.get_time_signature_ptr(current_grid_editor->measure_cursor_x), 5);
+      action = new Action::SetTimeSignatureNumerator(current_grid_editor->grid.get_time_signature_ptr(current_grid_editor->grid_cursor_x), 5);
    else if (action_identifier == Action::YANK_GRID_MEASURE_TO_BUFFER_ACTION_IDENTIFIER)
       action = new Action::YankGridMeasureToBuffer(&app_controller->yank_measure_buffer, focused_measure);
    else if (action_identifier == "paste_measure_from_buffer")

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -32,6 +32,7 @@
 #include <fullscore/actions/move_cursor_right_action.h>
 #include <fullscore/actions/move_cursor_up_action.h>
 #include <fullscore/actions/move_floating_measure_cursor_right_action.h>
+#include <fullscore/actions/move_floating_measure_cursor_left_action.h>
 #include <fullscore/actions/paste_measure_from_buffer_action.h>
 #include <fullscore/actions/queue_action.h>
 #include <fullscore/actions/reset_playback_action.h>
@@ -239,6 +240,8 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
       action = new Action::MoveCursorRight(current_grid_editor);
    else if (action_identifier == Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER)
       action = new Action::MoveFloatingMeasureCursorRight(&current_grid_editor->floating_measure_cursor);
+   else if (action_identifier == Action::MOVE_FLOATING_MEASURE_CURSOR_LEFT_IDENTIFIER)
+      action = new Action::MoveFloatingMeasureCursorLeft(&current_grid_editor->floating_measure_cursor);
    else if (action_identifier == Action::INSERT_STAFF_ACTION_IDENTIFIER)
       action = new Action::InsertStaff(&current_grid_editor->grid, current_grid_editor->grid_cursor_y);
    else if (action_identifier == Action::DELETE_STAFF_ACTION_IDENTIFIER)

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -31,6 +31,7 @@
 #include <fullscore/actions/move_cursor_left_action.h>
 #include <fullscore/actions/move_cursor_right_action.h>
 #include <fullscore/actions/move_cursor_up_action.h>
+#include <fullscore/actions/move_floating_measure_cursor_right_action.h>
 #include <fullscore/actions/paste_measure_from_buffer_action.h>
 #include <fullscore/actions/queue_action.h>
 #include <fullscore/actions/reset_playback_action.h>
@@ -236,6 +237,8 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
       action = new Action::MoveCursorUp(current_grid_editor);
    else if (action_identifier == Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER)
       action = new Action::MoveCursorRight(current_grid_editor);
+   else if (action_identifier == Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER)
+      action = new Action::MoveFloatingMeasureCursorRight(&current_grid_editor->floating_measure_cursor);
    else if (action_identifier == Action::INSERT_STAFF_ACTION_IDENTIFIER)
       action = new Action::InsertStaff(&current_grid_editor->grid, current_grid_editor->grid_cursor_y);
    else if (action_identifier == Action::DELETE_STAFF_ACTION_IDENTIFIER)

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -186,13 +186,17 @@ Grid GridFactory::development()
       Note(2, Duration(Duration::EIGHTH)),
    };
 
+   /*
    Plotter::Basic basic_plotter_1 = Plotter::Basic(&grid, 3, notes_to_plot);
    basic_plotter_1.plot();
+   */
 
    auto notes_retrograde = Transform::Retrograde().transform(notes_to_plot);
 
+   /*
    Plotter::Basic basic_plotter_2 = Plotter::Basic(&grid, 5, notes_retrograde);
    basic_plotter_2.plot();
+   */
 
 
    return grid;

--- a/src/factories/grid_factory.cpp
+++ b/src/factories/grid_factory.cpp
@@ -152,7 +152,7 @@ Grid GridFactory::development()
    FloatingMeasure *floating_measure = new FloatingMeasure(GridCoordinate(&current_grid_editor->grid, staff_to_put_measure->get_id(), 2), basic_measure->get_id());
 */
 
-   Grid grid;
+   Grid grid(10);
 
 
    grid.append_staff(new Staff::MeasureNumbers);
@@ -186,17 +186,16 @@ Grid GridFactory::development()
       Note(2, Duration(Duration::EIGHTH)),
    };
 
-   /*
-   Plotter::Basic basic_plotter_1 = Plotter::Basic(&grid, 3, notes_to_plot);
-   basic_plotter_1.plot();
-   */
+   for (unsigned i=0; i<grid.get_num_barlines(); i++)
+   {
+      Plotter::Basic basic_plotter_1 = Plotter::Basic(&grid, i, notes_to_plot);
+      basic_plotter_1.plot();
+   }
 
    auto notes_retrograde = Transform::Retrograde().transform(notes_to_plot);
 
-   /*
    Plotter::Basic basic_plotter_2 = Plotter::Basic(&grid, 5, notes_retrograde);
    basic_plotter_2.plot();
-   */
 
 
    return grid;

--- a/src/models/floating_measure.cpp
+++ b/src/models/floating_measure.cpp
@@ -99,6 +99,29 @@ std::vector<FloatingMeasure *> FloatingMeasure::find_at_staff_and_barline(int st
 
 
 
+static bool __compare_floating_measure_x_location(FloatingMeasure *m1, FloatingMeasure *m2)
+{
+   if (m1->get_grid_coordinate().get_grid_horizontal_coordinate().get_barline_num() == m2->get_grid_coordinate().get_grid_horizontal_coordinate().get_barline_num())
+      return (m1->get_grid_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset() < m2->get_grid_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset());
+   return (m1->get_grid_coordinate().get_grid_horizontal_coordinate().get_barline_num() < m2->get_grid_coordinate().get_grid_horizontal_coordinate().get_barline_num());
+}
+
+
+
+std::vector<FloatingMeasure *> FloatingMeasure::in_staff(int staff_id)
+{
+   std::vector<FloatingMeasure *> results;
+
+   for (auto &element : pool_elements)
+      if (element->grid_coordinate.get_staff_id() == staff_id) results.push_back(element);
+
+   std::sort(results.begin(), results.end(), __compare_floating_measure_x_location);
+
+   return results;
+}
+
+
+
 std::vector<FloatingMeasure *> FloatingMeasure::get_pool_elements()
 {
    return pool_elements;

--- a/src/models/floating_measure.cpp
+++ b/src/models/floating_measure.cpp
@@ -2,6 +2,14 @@
 
 
 #include <fullscore/models/floating_measure.h>
+#include <cmath>
+
+
+
+bool ___basically_equal(float f1, float f2, float threshold=0.00001f)
+{
+   return (std::abs(f1 - f2) > threshold);
+}
 
 
 
@@ -102,20 +110,26 @@ std::vector<FloatingMeasure *> FloatingMeasure::find_at_staff_and_barline(int st
 static bool __compare_floating_measure_x_location(FloatingMeasure *m1, FloatingMeasure *m2)
 {
    if (m1->get_grid_coordinate().get_grid_horizontal_coordinate().get_barline_num() == m2->get_grid_coordinate().get_grid_horizontal_coordinate().get_barline_num())
+   {
+      float m1_x_offset = m1->get_grid_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset();
+      float m2_x_offset = m2->get_grid_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset();
+
+      if (___basically_equal(m1_x_offset, m2_x_offset)) return (m1->get_id() < m2->get_id());
       return (m1->get_grid_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset() < m2->get_grid_coordinate().get_grid_horizontal_coordinate().get_beat_coordinate().get_x_offset());
+   }
    return (m1->get_grid_coordinate().get_grid_horizontal_coordinate().get_barline_num() < m2->get_grid_coordinate().get_grid_horizontal_coordinate().get_barline_num());
 }
 
 
 
-std::vector<FloatingMeasure *> FloatingMeasure::in_staff(int staff_id)
+std::vector<FloatingMeasure *> FloatingMeasure::in_staff(int staff_id, bool sort)
 {
    std::vector<FloatingMeasure *> results;
 
    for (auto &element : pool_elements)
       if (element->grid_coordinate.get_staff_id() == staff_id) results.push_back(element);
 
-   std::sort(results.begin(), results.end(), __compare_floating_measure_x_location);
+   if (sort) std::sort(results.begin(), results.end(), __compare_floating_measure_x_location);
 
    return results;
 }

--- a/src/models/floating_measure.cpp
+++ b/src/models/floating_measure.cpp
@@ -65,6 +65,25 @@ int FloatingMeasure::get_next_id()
 
 
 
+FloatingMeasure *FloatingMeasure::find(int id, find_option_t find_option)
+{
+   FloatingMeasure *found_element = nullptr;
+
+   for (auto &element : pool_elements)
+      if (element->get_id() == id) { found_element = element; break; }
+
+   if (find_option == FIND_OPTION_RAISE_NOT_FOUND && found_element == nullptr)
+   {
+      std::stringstream error_message;
+      error_message << "Looking for FloatingMeasure with id = " << id << " but does not exist";
+      throw std::runtime_error(error_message.str());
+   }
+
+   return found_element;
+}
+
+
+
 std::vector<FloatingMeasure *> FloatingMeasure::find_at_staff_and_barline(int staff_id, int barline_num)
 {
    std::vector<FloatingMeasure *> results;

--- a/src/models/floating_measure_cursor.cpp
+++ b/src/models/floating_measure_cursor.cpp
@@ -1,0 +1,35 @@
+
+
+
+#include <fullscore/models/floating_measure_cursor.h>
+
+
+
+FloatingMeasureCursor::FloatingMeasureCursor()
+   : floating_measure_id(-1)
+{
+}
+
+
+
+FloatingMeasureCursor::~FloatingMeasureCursor()
+{
+}
+
+
+
+bool FloatingMeasureCursor::set_floating_measure_id(int floating_measure_id)
+{
+   this->floating_measure_id = floating_measure_id;
+   return true;
+}
+
+
+
+int FloatingMeasureCursor::get_floating_measure_id()
+{
+   return floating_measure_id;
+}
+
+
+

--- a/src/models/plotters/basic.cpp
+++ b/src/models/plotters/basic.cpp
@@ -3,7 +3,8 @@
 
 #include <fullscore/models/plotters/basic.h>
 
-#include <fullscore/models/measures/plotted.h>
+#include <allegro_flare/useful.h>
+#include <fullscore/models/measures/basic.h>
 #include <fullscore/models/staves/base.h>
 #include <fullscore/models/plotter.h>
 #include <fullscore/models/grid.h>
@@ -38,8 +39,8 @@ bool Plotter::Basic::plot()
       if (staff->is_type("instrument"))
       {
          int staff_id = staff->get_id();
-         Measure::Base* plotted_measure = new Measure::Plotted(notes); // < this automatically adds the measure to the base
-         new FloatingMeasure(GridCoordinate(staff_id, barline_num), plotted_measure->get_id());
+         Measure::Base* plotted_measure = new Measure::Basic(notes); // < this automatically adds the measure to the base
+         new FloatingMeasure(GridCoordinate(staff_id, {barline_num, {random_int(0, 4)}}), plotted_measure->get_id());
       }
    }
 

--- a/src/widgets/grid_editor.cpp
+++ b/src/widgets/grid_editor.cpp
@@ -21,8 +21,8 @@ UIGridEditor::UIGridEditor(UIWidget *parent)
    : UIWidget(parent, "UIGridEditor", new UISurfaceAreaBoxPadded(0, 0, 300, 200, 30, 30, 30, 30))
    , grid()
    , playback_control()
-   , measure_cursor_x(0)
-   , measure_cursor_y(0)
+   , grid_cursor_x(0)
+   , grid_cursor_y(0)
    , note_cursor_x(0)
    , edit_mode_target(MEASURE_TARGET)
    , mode(NORMAL_MODE)
@@ -84,17 +84,17 @@ Note *UIGridEditor::get_note_at_cursor()
 
 
 
-float UIGridEditor::get_measure_cursor_real_x()
+float UIGridEditor::get_grid_cursor_real_x()
 {
-   return GridDimensionsHelper::get_length_to_measure(grid, measure_cursor_x) * FULL_MEASURE_WIDTH;
+   return GridDimensionsHelper::get_length_to_measure(grid, grid_cursor_x) * FULL_MEASURE_WIDTH;
 }
 
 
 
 
-float UIGridEditor::get_measure_cursor_real_y()
+float UIGridEditor::get_grid_cursor_real_y()
 {
-   return GridDimensionsHelper::get_height_to_staff(grid, measure_cursor_y) * STAFF_HEIGHT;
+   return GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y) * STAFF_HEIGHT;
 }
 
 
@@ -128,21 +128,21 @@ float UIGridEditor::get_measure_width(Measure::Base *m)  // TODO: should probabl
 
 
 
-int UIGridEditor::move_measure_cursor_x(int delta)
+int UIGridEditor::move_grid_cursor_x(int delta)
 {
    int num_barlines = grid.get_num_barlines();
-   measure_cursor_x = limit<int>(0, num_barlines-1, measure_cursor_x + delta);
-   return measure_cursor_x;
+   grid_cursor_x = limit<int>(0, num_barlines-1, grid_cursor_x + delta);
+   return grid_cursor_x;
 }
 
 
 
 
-int UIGridEditor::move_measure_cursor_y(int delta)
+int UIGridEditor::move_grid_cursor_y(int delta)
 {
    int num_staves = grid.get_num_staves();
-   measure_cursor_y = limit<int>(0, num_staves-1, measure_cursor_y + delta);
-   return measure_cursor_y;
+   grid_cursor_y = limit<int>(0, num_staves-1, grid_cursor_y + delta);
+   return grid_cursor_y;
 }
 
 

--- a/src/widgets/grid_editor.cpp
+++ b/src/widgets/grid_editor.cpp
@@ -24,6 +24,7 @@ UIGridEditor::UIGridEditor(UIWidget *parent)
    , grid_cursor_x(0)
    , grid_cursor_y(0)
    , note_cursor_x(0)
+   , floating_measure_cursor()
    , edit_mode_target(MEASURE_TARGET)
    , mode(NORMAL_MODE)
    , state(STATE_INACTIVE) //TODO insure STATE_INACTIVE is a good initizliation value

--- a/tests/models/floating_measure_cursor_test.cpp
+++ b/tests/models/floating_measure_cursor_test.cpp
@@ -1,0 +1,38 @@
+
+
+
+#include <gtest/gtest.h>
+
+#include <fullscore/models/floating_measure_cursor.h>
+
+
+
+TEST(FloatingMeasureCursorTest, can_be_created)
+{
+   FloatingMeasureCursor floating_measure_cursor;
+}
+
+
+
+TEST(FloatingMeasureCursorTest, initializes_with_a_measure_id_of_negative_1)
+{
+   FloatingMeasureCursor floating_measure_cursor;
+
+   EXPECT_EQ(-1, floating_measure_cursor.get_floating_measure_id());
+}
+
+
+
+TEST(FloatingMeasureCursorTest, can_set_and_get_a_floating_measure_id)
+{
+   FloatingMeasureCursor floating_measure_cursor;
+
+   EXPECT_EQ(-1, floating_measure_cursor.get_floating_measure_id());
+   EXPECT_EQ(true, floating_measure_cursor.set_floating_measure_id(123));
+   EXPECT_EQ(123, floating_measure_cursor.get_floating_measure_id());
+   EXPECT_EQ(true, floating_measure_cursor.set_floating_measure_id(6));
+   EXPECT_EQ(6, floating_measure_cursor.get_floating_measure_id());
+}
+
+
+

--- a/tests/models/floating_measure_test.cpp
+++ b/tests/models/floating_measure_test.cpp
@@ -50,6 +50,19 @@ TEST(FloatingMeasureTest, is_assigned_an_incremented_id_when_created)
 
 
 
+TEST(FloatingMeasureTest, can_find_a_floating_measure_by_id)
+{
+   FloatingMeasure floating_measure_1(GridCoordinate(), 0);
+   FloatingMeasure floating_measure_2(GridCoordinate(), 0);
+   FloatingMeasure floating_measure_3(GridCoordinate(), 0);
+
+   ASSERT_EQ(&floating_measure_1, FloatingMeasure::find(floating_measure_1.get_id()));
+   ASSERT_EQ(&floating_measure_2, FloatingMeasure::find(floating_measure_2.get_id()));
+   ASSERT_EQ(&floating_measure_3, FloatingMeasure::find(floating_measure_3.get_id()));
+}
+
+
+
 TEST(FloatingMeasureTest, can_find_measures_given_a_staff_id_and_a_barline)
 {
    Measure::Basic basic_measure_1;

--- a/tests/models/floating_measure_test.cpp
+++ b/tests/models/floating_measure_test.cpp
@@ -103,6 +103,37 @@ TEST(FloatingMeasureTest, can_get_a_list_of_floating_measures)
 
 
 
+TEST(FloatingMeasureTest, can_get_a_list_of_floating_measures_for_a_staff)
+{
+   FloatingMeasure::destroy_all();
+
+   Measure::Basic basic_measure_1;
+   Measure::Basic basic_measure_2;
+   Measure::Basic basic_measure_3;
+
+   FloatingMeasure floating_measure_1(GridCoordinate(3, 1), basic_measure_1.get_id());
+   FloatingMeasure floating_measure_2(GridCoordinate(7, 2), basic_measure_2.get_id());
+   FloatingMeasure floating_measure_3(GridCoordinate(3, 0), basic_measure_1.get_id());
+   FloatingMeasure floating_measure_4(GridCoordinate(7, 0), basic_measure_3.get_id());
+   FloatingMeasure floating_measure_5(GridCoordinate(7, 9), basic_measure_3.get_id());
+
+   std::vector<FloatingMeasure *> expected_measures_in_staff_3 = {
+      &floating_measure_3,
+      &floating_measure_1
+   };
+
+   std::vector<FloatingMeasure *> expected_measures_in_staff_7 = {
+      &floating_measure_4,
+      &floating_measure_2,
+      &floating_measure_5 // note the sorting order
+   };
+
+   ASSERT_EQ(expected_measures_in_staff_3, FloatingMeasure::in_staff(3));
+   ASSERT_EQ(expected_measures_in_staff_7, FloatingMeasure::in_staff(7));
+}
+
+
+
 TEST(FloatingMeasureTest, can_get_the_number_of_floating_measures_in_the_pool)
 {
    Measure::Basic basic_measure;

--- a/tests/models/floating_measure_test.cpp
+++ b/tests/models/floating_measure_test.cpp
@@ -134,6 +134,38 @@ TEST(FloatingMeasureTest, can_get_a_list_of_floating_measures_for_a_staff)
 
 
 
+TEST(FloatingMeasureTest, returns_a_staffs_floating_measures_horizontally_sorted_by_default)
+{
+   FloatingMeasure::destroy_all();
+
+   FloatingMeasure floating_measure_1(GridCoordinate(0, 3), 0);
+   FloatingMeasure floating_measure_2(GridCoordinate(0, 1), 0);
+   FloatingMeasure floating_measure_3(GridCoordinate(0, {2, {3, 8}}), 0);
+   FloatingMeasure floating_measure_4(GridCoordinate(0, {2, {3, 8}}), 0);
+   FloatingMeasure floating_measure_5(GridCoordinate(0, {3, {2, 4}}), 0);
+   FloatingMeasure floating_measure_6(GridCoordinate(0, {1, {3, 8}}), 0);
+
+   std::vector<FloatingMeasure *> expected_measures_order = {
+      &floating_measure_2,
+      &floating_measure_6,
+      &floating_measure_3,
+      &floating_measure_4,
+      &floating_measure_1,
+      &floating_measure_5
+   };
+
+   ASSERT_EQ(expected_measures_order, FloatingMeasure::in_staff(0));
+}
+
+
+
+TEST(FloatingMeasureTest, DISABLED_returns_a_staffs_floating_measures_with_undefined_sorting)
+{
+   // test not necessary
+}
+
+
+
 TEST(FloatingMeasureTest, can_get_the_number_of_floating_measures_in_the_pool)
 {
    Measure::Basic basic_measure;


### PR DESCRIPTION
## Floating Measures are Inaccessible

After the last [PR that removed Per-Barline Measures](https://github.com/MarkOates/fullscore/pull/94), it's not possible to access, focus, or modify a measure.  That is, floating measures cannot be highlighted or singled out for actions in any way.  Only plotting can put measures onto the score.

This PR adds an initial piping to help out with this.  It adds a `FloatingMeasureCursor` in the `UIGridEditor` that (for now) initializes at the first measure and sets the cursor on it.  It also adds 2 actions `Action::MoveFloatingMeasureCursorLeft` and `Action:: MoveFloatingMeasureCursorRight` that, obviously, moves the cursor left or right.  These actions have been mapped to <kbd>W</kbd> and <kbd>Shift</kbd>+<kbd>B</kbd>, respectively, mimicking the key mappings on VIM.

There's currently no way to move the cursor up or down a staff.  A simple method could be probably be implemented, moving the cursor down to the next `instrument` staff type, and placing the cursor on the first floating measure nearest that measure.  The exact technique may take some exploring so I'll leave that for another PR.

## Is This Something That Should be Added?

~Even though I put a bunch of work into this PR, I'm reconsidering if this feature should actually be added.  That is, the composer should _primarily_ be conceptualizing the music through plotting - maybe not modifying individual measures. 🤔~

edit: Even though plotting is the primary way to conceptualize scores, individual measures are an important part of creating the necessary atomic units that are fed into a plotter.  There is a precedent for maintaining the feature of composing measures atomically.

## In the Mean Time

Here's a fancy screenshot of the plotter gone wild for testing:

![fun](https://user-images.githubusercontent.com/772949/32998064-be8e9ff6-cd65-11e7-9514-b80719462be0.png)