### PR TITLE
Add MeasureSelectionBoxRenderer and Multi-Action Mapping

### DIFF
--- a/include/fullscore/app_controller.h
+++ b/include/fullscore/app_controller.h
@@ -11,7 +11,7 @@
 //#include <fullscore/widgets/command_bar.h>
 #include <fullscore/widgets/follow_camera.h>
 #include <fullscore/widgets/grid_editor.h>
-#include <fullscore/widgets/measure_inspector.h>
+//#include <fullscore/widgets/measure_inspector.h>
 
 
 
@@ -25,7 +25,7 @@ public:
    UIGridEditor *current_grid_editor;
    std::vector<UIGridEditor *> grid_editors;
    //UICommandBar *command_bar;
-   UIMeasureInspector *ui_measure_inspector;
+   //UIMeasureInspector *ui_measure_inspector;
    Measure::Basic yank_measure_buffer;
    bool showing_help_menu;
    KeyboardCommandMapper normal_mode_keyboard_mappings;

--- a/include/fullscore/app_controller.h
+++ b/include/fullscore/app_controller.h
@@ -37,7 +37,7 @@ public:
    void key_char_func() override;
    void on_message(UIWidget *sender, std::string message) override;
 
-   std::string find_action_identifier(UIGridEditor::mode_t mode, UIGridEditor::edit_mode_target_t edit_mode_target, int al_keycode, bool shift=false, bool ctrl=false, bool alt=false);
+   std::vector<std::string> find_action_mapping(UIGridEditor::mode_t mode, UIGridEditor::edit_mode_target_t edit_mode_target, int al_keycode, bool shift=false, bool ctrl=false, bool alt=false);
 
    UIGridEditor *create_new_grid_editor(std::string identifier);
    bool set_current_grid_editor(UIGridEditor *editor);

--- a/include/fullscore/app_controller.h
+++ b/include/fullscore/app_controller.h
@@ -33,7 +33,6 @@ public:
    KeyboardCommandMapper normal_mode_measure_keyboard_mappings;
 
    AppController(Display *display, Config &config);
-   void primary_timer_func() override;
    void key_char_func() override;
    void on_message(UIWidget *sender, std::string message) override;
 

--- a/include/fullscore/app_controller.h
+++ b/include/fullscore/app_controller.h
@@ -34,7 +34,6 @@ public:
 
    AppController(Display *display, Config &config);
    void key_char_func() override;
-   void on_message(UIWidget *sender, std::string message) override;
 
    std::vector<std::string> find_action_mapping(UIGridEditor::mode_t mode, UIGridEditor::edit_mode_target_t edit_mode_target, int al_keycode, bool shift=false, bool ctrl=false, bool alt=false);
 

--- a/include/fullscore/models/floating_measure_cursor.h
+++ b/include/fullscore/models/floating_measure_cursor.h
@@ -12,6 +12,7 @@ public:
    ~FloatingMeasureCursor();
 
    bool set_floating_measure_id(int floating_measure_id);
+   void clear_floating_measure_id();
    int get_floating_measure_id();
 };
 

--- a/include/fullscore/renderers/measure_selection_box_renderer.h
+++ b/include/fullscore/renderers/measure_selection_box_renderer.h
@@ -1,0 +1,32 @@
+#pragma once
+
+
+
+#include <allegro_flare/placement2d.h>
+
+
+
+class MeasureSelectionBoxRenderer
+{
+public:
+  enum state_t
+  {
+     STATE_UNDEF = 0,
+     STATE_NOTE_FOCUS,
+     STATE_MEASURE_FOCUS
+  };
+
+private:
+  state_t state;
+  placement2d placement;
+  float selected_note_x, selected_note_w;
+
+public:
+   MeasureSelectionBoxRenderer(state_t state, float x, float y, float w, float h, float selected_note_x, float selected_note_w);
+   ~MeasureSelectionBoxRenderer();
+
+   void render();
+};
+
+
+

--- a/src/actions/paste_measure_from_buffer_action.cpp
+++ b/src/actions/paste_measure_from_buffer_action.cpp
@@ -6,12 +6,13 @@
 
 #include <fullscore/models/measures/basic.h>
 #include <fullscore/models/Note.h>
+#include <fullscore/action.h>
 
 
 
 
 Action::PasteMeasureFromBuffer::PasteMeasureFromBuffer(Measure::Base *destination_measure, Measure::Basic *yank_measure_buffer)
-   : Base("paste_measure_from_buffer")
+   : Base(Action::PASTE_MEASURE_FROM_BUFFER_ACTION_IDENTIFIER)
    , yank_measure_buffer(yank_measure_buffer)
    , destination_measure(destination_measure)
 {

--- a/src/actions/reset_floating_measure_cursor_action.cpp
+++ b/src/actions/reset_floating_measure_cursor_action.cpp
@@ -28,19 +28,9 @@ bool Action::ResetFloatingMeasureCursor::execute()
    if (!floating_measure_cursor) throw std::runtime_error("Cannot reset nullptr floating_measure_cursor");
 
    FloatingMeasure *found_floating_measure = FloatingMeasure::find_first_in_staff_after_barline(staff_id, barline_num);
-   if (!found_floating_measure)
-   {
-      std::stringstream error_message;
-      error_message << "Cannot set floating measure cursor because there is not floating measure at (or beyond) the position (staff_id: "
-         << staff_id
-         << ", barline_num: "
-         << barline_num
-         << ")"
-         << std::endl;
-      throw std::runtime_error(error_message.str());
-   }
 
-   floating_measure_cursor->set_floating_measure_id(found_floating_measure->get_id());
+   if (!found_floating_measure) floating_measure_cursor->clear_floating_measure_id();
+   else floating_measure_cursor->set_floating_measure_id(found_floating_measure->get_id());
 
    return true;
 }

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -74,7 +74,7 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         true,  false, false, "split_note");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_7,         true,  false, false, "set_reference_by_id_measure");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    true,  false, false, "camera_zoom_default");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_M,         false,  false, false, Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER);
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_M,         false, false, false, Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER);
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         true,  false, false, "set_stack_measure");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_N,         false,  true, false, "create_new_grid_editor");
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_X,         false,  true, false, "set_current_grid_editor");

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -180,64 +180,6 @@ void AppController::key_char_func()
 
 
 
-void AppController::on_message(UIWidget *sender, std::string message)
-{
-   std::cout << "messages sent to AppController have been disabled.  \"" << message << "\" could not be processed\"" << std::endl;
-/*
-   std::cout << "message: " << message << std::endl;
-
-   if (sender == command_bar && message != "on_submit")
-   {
-      if (!message.empty())
-      {
-         std::string action_identifier = message;
-
-         Action::Base *action = ActionFactory::create_action(this, action_identifier);
-
-         if (action)
-         {
-            std::string success_message = action->get_action_name();
-
-            if (success_message != action_identifier)
-            {
-               success_message = "Calling non-atomic action: ";
-               success_message += message + " using " + action->get_action_name();
-            }
-
-            simple_notification_screen->spawn_notification(success_message);
-            action->execute();
-            delete action;
-
-            Action::Base *set_normal_mode_action = ActionFactory::create_action(this, "set_normal_mode");
-            if (!set_normal_mode_action) throw std::runtime_error("Cannot return to NORMAL_MODE; \"set_normal_mode\" action not found");
-            set_normal_mode_action->execute();
-            delete set_normal_mode_action;
-         }
-         else
-         {
-            std::string error_message = "Unfound action: ";
-            error_message += action_identifier;
-            simple_notification_screen->spawn_notification(error_message);
-         }
-      }
-      else
-      {
-         std::string error_message = "Unrecognized input: ";
-         error_message += message;
-         simple_notification_screen->spawn_notification(error_message);
-
-         Action::Base *set_normal_mode_action = ActionFactory::create_action(this, "set_normal_mode");
-         if (!set_normal_mode_action) throw std::runtime_error("Cannot return to NORMAL_MODE; \"set_normal_mode\" action not found");
-         set_normal_mode_action->execute();
-         delete set_normal_mode_action;
-      }
-   }
-*/
-}
-
-
-
-
 UIGridEditor *AppController::create_new_grid_editor(std::string name)
 {
    static int new_x = 0;

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -175,6 +175,12 @@ void AppController::key_char_func()
          }
          delete action;
       }
+      else
+      {
+         std::stringstream error_message;
+         error_message << "Action could not be found with the identifier \"" << identifier << "\"" << std::endl;
+         throw std::runtime_error(error_message.str());
+      }
    }
 }
 

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -42,63 +42,63 @@ AppController::AppController(Display *display, Config &config)
 void AppController::set_keyboard_input_mappings()
 {
    //                                        keycode,               shift, ctrl,  alt,   identifier
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_G,         false, false, false, "double_duration");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_R,         false, false, false, "toggle_rest");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_N,         false, false, false, "invert");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Z,         false, false, false, "retrograde");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_H,         false, false, false, "move_cursor_left");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_J,         false, false, false, "move_cursor_down");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SEMICOLON, false, false, false, "set_command_mode");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F2,        false, false, false, "toggle_show_debug_data");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SPACE,     false, false, false, "toggle_playback");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Q,         false, false, false, "reset_playback");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F7,        false, false, false, "save_grid");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F8,        false, false, false, "load_grid");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_4,         false, false, false, "set_time_signature_numerator_4");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_5,         false, false, false, "set_time_signature_numerator_5");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Y,         false, false, false, Action::YANK_GRID_MEASURE_TO_BUFFER_ACTION_IDENTIFIER);
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_P,         false, false, false, "paste_measure_from_buffer");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_O,         false, false, false, "octatonic_1");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_TAB,       false, false, false, "toggle_edit_mode_target");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_2,         false, false, false, "set_time_signature_numerator_2");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_MINUS,     false, false, false, "camera_zoom_out");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_K,         false, false, false, Action::MOVE_CURSOR_UP_ACTION_IDENTIFIER);
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_L,         false, false, false, Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER);
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_W,         false, false, false, Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER);
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_B,         true,  false, false, Action::MOVE_FLOATING_MEASURE_CURSOR_LEFT_IDENTIFIER);
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         false, false, false, "half_duration");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         false, false, false, "set_time_signature_numerator_3");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    false, false, false, "camera_zoom_in");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F,         false, false, false, "transpose_up");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_D,         false, false, false, "transpose_down");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         true,  false, false, "split_note");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_7,         true,  false, false, "set_reference_by_id_measure");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    true,  false, false, "camera_zoom_default");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_M,         false, false, false, Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER);
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         true,  false, false, "set_stack_measure");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_N,         false,  true, false, "create_new_grid_editor");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_X,         false,  true, false, "set_current_grid_editor");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_UP,        false, false, false, "move_camera_up");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_DOWN,      false, false, false, "move_camera_down");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_RIGHT,     false, false, false, "move_camera_right");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_LEFT,      false, false, false, "move_camera_left");
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_C,         false, false, false, Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER);
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_G,         false, false, false, {"double_duration"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_R,         false, false, false, {"toggle_rest"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_N,         false, false, false, {"invert"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Z,         false, false, false, {"retrograde"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_H,         false, false, false, {"move_cursor_left"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_J,         false, false, false, {"move_cursor_down"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SEMICOLON, false, false, false, {"set_command_mode"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F2,        false, false, false, {"toggle_show_debug_data"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SPACE,     false, false, false, {"toggle_playback"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Q,         false, false, false, {"reset_playback"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F7,        false, false, false, {"save_grid"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F8,        false, false, false, {"load_grid"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_4,         false, false, false, {"set_time_signature_numerator_4"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_5,         false, false, false, {"set_time_signature_numerator_5"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Y,         false, false, false, {Action::YANK_GRID_MEASURE_TO_BUFFER_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_P,         false, false, false, {"paste_measure_from_buffer"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_O,         false, false, false, {"octatonic_1"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_TAB,       false, false, false, {"toggle_edit_mode_target"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_2,         false, false, false, {"set_time_signature_numerator_2"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_MINUS,     false, false, false, {"camera_zoom_out"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_K,         false, false, false, {Action::MOVE_CURSOR_UP_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_L,         false, false, false, {Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_W,         false, false, false, {Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_B,         true,  false, false, {Action::MOVE_FLOATING_MEASURE_CURSOR_LEFT_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         false, false, false, {"half_duration"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         false, false, false, {"set_time_signature_numerator_3"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    false, false, false, {"camera_zoom_in"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F,         false, false, false, {"transpose_up"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_D,         false, false, false, {"transpose_down"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         true,  false, false, {"split_note"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_7,         true,  false, false, {"set_reference_by_id_measure"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    true,  false, false, {"camera_zoom_default"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_M,         false, false, false, {Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         true,  false, false, {"set_stack_measure"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_N,         false,  true, false, {"create_new_grid_editor"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_X,         false,  true, false, {"set_current_grid_editor"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_UP,        false, false, false, {"move_camera_up"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_DOWN,      false, false, false, {"move_camera_down"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_RIGHT,     false, false, false, {"move_camera_right"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_LEFT,      false, false, false, {"move_camera_left"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_C,         false, false, false, {Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
 
 
 
    // measure mode commands
-   normal_mode_measure_keyboard_mappings.set_mapping(ALLEGRO_KEY_F, false, true,  false, "ascend");
-   normal_mode_measure_keyboard_mappings.set_mapping(ALLEGRO_KEY_D, false, true,  false, "descend");
-   normal_mode_measure_keyboard_mappings.set_mapping(ALLEGRO_KEY_X, false, false, false, Action::DELETE_FLOATING_MEASURE_IDENTIFIER);
+   normal_mode_measure_keyboard_mappings.set_mapping(ALLEGRO_KEY_F, false, true,  false, {"ascend"});
+   normal_mode_measure_keyboard_mappings.set_mapping(ALLEGRO_KEY_D, false, true,  false, {"descend"});
+   normal_mode_measure_keyboard_mappings.set_mapping(ALLEGRO_KEY_X, false, false, false, {Action::DELETE_FLOATING_MEASURE_IDENTIFIER});
 
 
 
    // note mode commands
-   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_A,        false, false, false, "insert_note_after");
-   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_X,        false, false, false, "erase_note");
-   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_I,        false, false, false, "insert_note");
-   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_COMMA,    false, false, false, "remove_dot");
-   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_FULLSTOP, false, false, false, "add_dot_to_note");
+   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_A,        false, false, false, {"insert_note_after"});
+   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_X,        false, false, false, {"erase_note"});
+   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_I,        false, false, false, {"insert_note"});
+   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_COMMA,    false, false, false, {"remove_dot"});
+   normal_mode_note_keyboard_mappings.set_mapping(ALLEGRO_KEY_FULLSTOP, false, false, false, {"add_dot_to_note"});
 }
 
 
@@ -116,26 +116,26 @@ void AppController::primary_timer_func()
 
 
 
-std::string AppController::find_action_identifier(UIGridEditor::mode_t mode, UIGridEditor::edit_mode_target_t edit_mode_target, int al_keycode, bool shift, bool ctrl, bool alt)
+std::vector<std::string> AppController::find_action_mapping(UIGridEditor::mode_t mode, UIGridEditor::edit_mode_target_t edit_mode_target, int al_keycode, bool shift, bool ctrl, bool alt)
 {
    if (mode == UIGridEditor::NORMAL_MODE)
    {
       if (edit_mode_target == UIGridEditor::edit_mode_target_t::MEASURE_TARGET)
       {
-         std::string found_mapping = normal_mode_measure_keyboard_mappings.get_mapping(al_keycode, shift, ctrl, alt);
+         std::vector<std::string> found_mapping = normal_mode_measure_keyboard_mappings.get_mapping(al_keycode, shift, ctrl, alt);
          if (!found_mapping.empty()) return found_mapping;
       }
       else if (edit_mode_target == UIGridEditor::edit_mode_target_t::NOTE_TARGET)
       {
-         std::string found_mapping = normal_mode_note_keyboard_mappings.get_mapping(al_keycode, shift, ctrl, alt);
+         std::vector<std::string> found_mapping = normal_mode_note_keyboard_mappings.get_mapping(al_keycode, shift, ctrl, alt);
          if (!found_mapping.empty()) return found_mapping;
       }
 
-      std::string found_mapping = normal_mode_keyboard_mappings.get_mapping(al_keycode, shift, ctrl, alt);
+      std::vector<std::string> found_mapping = normal_mode_keyboard_mappings.get_mapping(al_keycode, shift, ctrl, alt);
       if (!found_mapping.empty()) return found_mapping;
    }
 
-   return "";
+   return {};
 }
 
 
@@ -152,25 +152,29 @@ void AppController::key_char_func()
    auto alt_pressed   = Framework::key_alt;
    auto ctrl_pressed  = Framework::key_ctrl;
 
-   std::string identifier = find_action_identifier(mode, target, keycode, shift_pressed, ctrl_pressed, alt_pressed);
-   Action::Base *action = ActionFactory::create_action(this, identifier);
+   std::vector<std::string> identifiers = find_action_mapping(mode, target, keycode, shift_pressed, ctrl_pressed, alt_pressed);
 
-   if (action)
+   for (auto &identifier : identifiers)
    {
-      try
+      Action::Base *action = ActionFactory::create_action(this, identifier);
+
+      if (action)
       {
-         if (!action->execute()) throw std::runtime_error("Generic could-not-execute-action exception");
+         try
+         {
+            if (!action->execute()) throw std::runtime_error("Generic could-not-execute-action exception");
+         }
+         catch (const std::runtime_error& e)
+         {
+            std::cout << "Exception caught while trying to run action "
+                      << "\"" << action->get_action_name() << "\""
+                      << " with the following message \""
+                      << e.what()
+                      << "\""
+                      << std::endl;
+         }
+         delete action;
       }
-      catch (const std::runtime_error& e)
-      {
-         std::cout << "Exception caught while trying to run action "
-                   << "\"" << action->get_action_name() << "\""
-                   << " with the following message \""
-                   << e.what()
-                   << "\""
-                   << std::endl;
-      }
-      delete action;
    }
 }
 

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -23,7 +23,7 @@ AppController::AppController(Display *display, Config &config)
    , current_grid_editor(nullptr)
    , grid_editors()
    //, command_bar(new UICommandBar(this))
-   , ui_measure_inspector(new UIMeasureInspector(this))
+   //, ui_measure_inspector(new UIMeasureInspector(this))
    , yank_measure_buffer()
    , normal_mode_keyboard_mappings()
    , normal_mode_note_keyboard_mappings()
@@ -106,9 +106,9 @@ void AppController::set_keyboard_input_mappings()
 
 void AppController::primary_timer_func()
 {
-   if (ui_measure_inspector) ui_measure_inspector->set_measure(current_grid_editor->get_measure_at_cursor());
-   ui_measure_inspector->place.position = vec2d(display->width(), 0);
-   ui_measure_inspector->place.size = vec2d(300, display->height());
+   //if (ui_measure_inspector) ui_measure_inspector->set_measure(current_grid_editor->get_measure_at_cursor());
+   //ui_measure_inspector->place.position = vec2d(display->width(), 0);
+   //ui_measure_inspector->place.size = vec2d(300, display->height());
 
    UIScreen::primary_timer_func();
 }

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -46,8 +46,10 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_R,         false, false, false, {"toggle_rest"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_N,         false, false, false, {"invert"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Z,         false, false, false, {"retrograde"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_H,         false, false, false, {"move_cursor_left"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_J,         false, false, false, {"move_cursor_down"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_H,         false, false, false, {Action::MOVE_CURSOR_LEFT_ACTION_IDENTIFIER
+                                                                                         ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_J,         false, false, false, {Action::MOVE_CURSOR_DOWN_ACTION_IDENTIFIER
+                                                                                         ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SEMICOLON, false, false, false, {"set_command_mode"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F2,        false, false, false, {"toggle_show_debug_data"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SPACE,     false, false, false, {"toggle_playback"});
@@ -62,8 +64,10 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_TAB,       false, false, false, {"toggle_edit_mode_target"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_2,         false, false, false, {"set_time_signature_numerator_2"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_MINUS,     false, false, false, {"camera_zoom_out"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_K,         false, false, false, {Action::MOVE_CURSOR_UP_ACTION_IDENTIFIER});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_L,         false, false, false, {Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_K,         false, false, false, {Action::MOVE_CURSOR_UP_ACTION_IDENTIFIER
+                                                                                         ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_L,         false, false, false, {Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER
+                                                                                         ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_W,         false, false, false, {Action::MOVE_FLOATING_MEASURE_CURSOR_RIGHT_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_B,         true,  false, false, {Action::MOVE_FLOATING_MEASURE_CURSOR_LEFT_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         false, false, false, {"half_duration"});
@@ -74,7 +78,8 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         true,  false, false, {"split_note"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_7,         true,  false, false, {"set_reference_by_id_measure"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    true,  false, false, {"camera_zoom_default"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_M,         false, false, false, {Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_M,         false, false, false, {Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER
+                                                                                         ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         true,  false, false, {"set_stack_measure"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_N,         false,  true, false, {"create_new_grid_editor"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_X,         false,  true, false, {"set_current_grid_editor"});

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -50,19 +50,19 @@ void AppController::set_keyboard_input_mappings()
                                                                                          ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_J,         false, false, false, {Action::MOVE_CURSOR_DOWN_ACTION_IDENTIFIER
                                                                                          ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SEMICOLON, false, false, false, {"set_command_mode"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SEMICOLON, false, false, false, {Action::SET_COMMAND_MODE_ACTION_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_MINUS,     false, false, false, {"camera_zoom_out"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    false, false, false, {"camera_zoom_in"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_UP,        false, false, false, {"move_camera_up"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_DOWN,      false, false, false, {"move_camera_down"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_RIGHT,     false, false, false, {"move_camera_right"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_LEFT,      false, false, false, {"move_camera_left"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_TAB,       false, false, false, {"toggle_edit_mode_target"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F2,        false, false, false, {"toggle_show_debug_data"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SPACE,     false, false, false, {"toggle_playback"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Q,         false, false, false, {"reset_playback"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F7,        false, false, false, {"save_grid"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F8,        false, false, false, {"load_grid"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_TAB,       false, false, false, {Action::TOGGLE_EDIT_MODE_TARGET_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F2,        false, false, false, {Action::TOGGLE_SHOW_DEBUG_DATA_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SPACE,     false, false, false, {Action::TOGGLE_PLAYBACK_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Q,         false, false, false, {Action::RESET_PLAYBACK_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F7,        false, false, false, {Action::SAVE_GRID_ACTION_IDENTIFIER});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F8,        false, false, false, {Action::LOAD_GRID_ACTION_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_4,         false, false, false, {"set_time_signature_numerator_4"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_5,         false, false, false, {"set_time_signature_numerator_5"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Y,         false, false, false, {Action::YANK_GRID_MEASURE_TO_BUFFER_ACTION_IDENTIFIER});

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -109,18 +109,6 @@ void AppController::set_keyboard_input_mappings()
 
 
 
-void AppController::primary_timer_func()
-{
-   //if (ui_measure_inspector) ui_measure_inspector->set_measure(current_grid_editor->get_measure_at_cursor());
-   //ui_measure_inspector->place.position = vec2d(display->width(), 0);
-   //ui_measure_inspector->place.size = vec2d(300, display->height());
-
-   UIScreen::primary_timer_func();
-}
-
-
-
-
 std::vector<std::string> AppController::find_action_mapping(UIGridEditor::mode_t mode, UIGridEditor::edit_mode_target_t edit_mode_target, int al_keycode, bool shift, bool ctrl, bool alt)
 {
    if (mode == UIGridEditor::NORMAL_MODE)

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -75,7 +75,7 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    false, false, false, {"camera_zoom_in"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F,         false, false, false, {"transpose_up"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_D,         false, false, false, {"transpose_down"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         true,  false, false, {"split_note"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         false,  true, false, {"split_note"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_7,         true,  false, false, {"set_reference_by_id_measure"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    true,  false, false, {"camera_zoom_default"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_M,         false, false, false, {Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -66,7 +66,7 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_4,         false, false, false, {"set_time_signature_numerator_4"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_5,         false, false, false, {"set_time_signature_numerator_5"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Y,         false, false, false, {Action::YANK_GRID_MEASURE_TO_BUFFER_ACTION_IDENTIFIER});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_P,         false, false, false, {"paste_measure_from_buffer"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_P,         false, false, false, {Action::PASTE_MEASURE_FROM_BUFFER_ACTION_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_O,         false, false, false, {"octatonic_1"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_2,         false, false, false, {"set_time_signature_numerator_2"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_K,         false, false, false, {Action::MOVE_CURSOR_UP_ACTION_IDENTIFIER

--- a/src/app_controller.cpp
+++ b/src/app_controller.cpp
@@ -51,6 +51,13 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_J,         false, false, false, {Action::MOVE_CURSOR_DOWN_ACTION_IDENTIFIER
                                                                                          ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SEMICOLON, false, false, false, {"set_command_mode"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_MINUS,     false, false, false, {"camera_zoom_out"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    false, false, false, {"camera_zoom_in"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_UP,        false, false, false, {"move_camera_up"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_DOWN,      false, false, false, {"move_camera_down"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_RIGHT,     false, false, false, {"move_camera_right"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_LEFT,      false, false, false, {"move_camera_left"});
+   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_TAB,       false, false, false, {"toggle_edit_mode_target"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F2,        false, false, false, {"toggle_show_debug_data"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_SPACE,     false, false, false, {"toggle_playback"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Q,         false, false, false, {"reset_playback"});
@@ -61,9 +68,7 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_Y,         false, false, false, {Action::YANK_GRID_MEASURE_TO_BUFFER_ACTION_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_P,         false, false, false, {"paste_measure_from_buffer"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_O,         false, false, false, {"octatonic_1"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_TAB,       false, false, false, {"toggle_edit_mode_target"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_2,         false, false, false, {"set_time_signature_numerator_2"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_MINUS,     false, false, false, {"camera_zoom_out"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_K,         false, false, false, {Action::MOVE_CURSOR_UP_ACTION_IDENTIFIER
                                                                                          ,Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_L,         false, false, false, {Action::MOVE_CURSOR_RIGHT_ACTION_IDENTIFIER
@@ -72,7 +77,6 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_B,         true,  false, false, {Action::MOVE_FLOATING_MEASURE_CURSOR_LEFT_IDENTIFIER});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         false, false, false, {"half_duration"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         false, false, false, {"set_time_signature_numerator_3"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_EQUALS,    false, false, false, {"camera_zoom_in"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_F,         false, false, false, {"transpose_up"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_D,         false, false, false, {"transpose_down"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_S,         false,  true, false, {"split_note"});
@@ -83,10 +87,6 @@ void AppController::set_keyboard_input_mappings()
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_3,         true,  false, false, {"set_stack_measure"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_N,         false,  true, false, {"create_new_grid_editor"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_X,         false,  true, false, {"set_current_grid_editor"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_UP,        false, false, false, {"move_camera_up"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_DOWN,      false, false, false, {"move_camera_down"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_RIGHT,     false, false, false, {"move_camera_right"});
-   normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_LEFT,      false, false, false, {"move_camera_left"});
    normal_mode_keyboard_mappings.set_mapping(ALLEGRO_KEY_C,         false, false, false, {Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER});
 
 

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -8,6 +8,7 @@
 #include <allegro_flare/useful_php.h>
 #include <fullscore/helpers/duration_helper.h>
 #include <fullscore/models/measure.h>
+#include <fullscore/renderers/measure_selection_box_renderer.h>
 #include <fullscore/services/music_engraver.h>
 #include <utility>
 
@@ -109,134 +110,31 @@ void MeasureRenderComponent::render()
       staff_line_color = color::blue;
    }
 
-   if (is_focused)
-      al_draw_rounded_rectangle(x_pos-2, row_middle_y-staff_height/2-2,
-            x_pos+measure_width+2, row_middle_y+staff_height/2+2,
-            5, 5, color::black, 2);
-
-   al_draw_filled_rounded_rectangle(x_pos, row_middle_y-staff_height/2,
-         x_pos+measure_width, row_middle_y+staff_height/2,
-         4, 4, measure_block_color);
+   // draw the music notes
 
    music_engraver->draw(measure, x_pos, y_pos + staff_height/2, full_measure_width, notation_color, staff_line_color);
 
-   ////
+   // draw the measure selection box
 
-   // draw a hilight box under the focused measure
-   //x Measure::Base *measure = ui_grid_editor.get_measure_at_cursor();
+   MeasureSelectionBoxRenderer::state_t measure_selection_box_renderer_state = MeasureSelectionBoxRenderer::STATE_UNDEF;
+   if (is_focused && in_edit_mode) measure_selection_box_renderer_state = MeasureSelectionBoxRenderer::STATE_NOTE_FOCUS;
+   else if (is_focused) measure_selection_box_renderer_state = MeasureSelectionBoxRenderer::STATE_MEASURE_FOCUS;
 
-   //x Note *note = ui_grid_editor.get_note_at_cursor();
-   std::vector<Note> *notes_in_measure = measure->get_notes_pointer();
-   Note *note = nullptr;
-   if (note_cursor_pos >= notes_in_measure->size() || note_cursor_pos < 0) {}
-   else note = &notes_in_measure->at(note_cursor_pos);
-
-   //x float CACHED_get_grid_cursor_real_x = ui_grid_editor.get_grid_cursor_real_x();
-   //x float CACHED_get_grid_cursor_real_y = ui_grid_editor.get_grid_cursor_real_y();
-
-   // draw the measure
-
-   //x float measure_width = ui_grid_editor.get_measure_width(measure) * FULL_MEASURE_WIDTH;
-   //x if (measure && measure->get_num_notes() == 0) measure_width = 16;
-
-   // measure box fill
-   if (is_focused)
-      al_draw_filled_rounded_rectangle(x_pos-2, row_middle_y-staff_height/2-2,
-            x_pos+measure_width+2, row_middle_y+staff_height/2+2,
-            4, 4, color::color(color::aliceblue, 0.2));
-   //al_draw_filled_rounded_rectangle(CACHED_get_grid_cursor_real_x, GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT,
-    //  CACHED_get_grid_cursor_real_x+measure_width, GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT,
-     // 4, 4, color::color(color::aliceblue, 0.2));
-
-   // measure box outline
-   if (is_focused && in_edit_mode)
+   if (measure_selection_box_renderer_state != MeasureSelectionBoxRenderer::STATE_UNDEF)
    {
-      float thickness = 2.0;
-      float h_thickness = thickness * 0.5;
+      std::vector<Note> *notes_in_measure = measure->get_notes_pointer();
+      Note *note = nullptr;
+      if (note_cursor_pos >= notes_in_measure->size() || note_cursor_pos < 0) {}
+      else note = &notes_in_measure->at(note_cursor_pos);
 
-      al_draw_rounded_rectangle(x_pos-h_thickness*2, row_middle_y-staff_height/2-2,
-            x_pos+measure_width+h_thickness*2, row_middle_y+staff_height/2+2,
-            4, 4, color::color(color::black, 0.3), thickness);
-
-      /*
-      al_draw_rounded_rectangle(
-            CACHED_get_grid_cursor_real_x - h_thickness*2,
-            GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT - h_thickness*2,
-            CACHED_get_grid_cursor_real_x+measure_width + h_thickness*2,
-            GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT + h_thickness*2,
-            4,
-            4,
-            color::color(color::black, 0.3),
-            thickness
-         );
-      */
-
-      al_draw_rounded_rectangle(
-            x_pos-h_thickness,
-            row_middle_y-staff_height/2-2,
-            x_pos+measure_width+h_thickness,
-            row_middle_y+staff_height/2+2,
-            4, 4, 
-            color::color(color::aliceblue, 0.7),
-            thickness
-         );
-
-/*
-      al_draw_rounded_rectangle(
-            CACHED_get_grid_cursor_real_x - h_thickness,
-            GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT - h_thickness,
-            CACHED_get_grid_cursor_real_x+measure_width + h_thickness,
-            GridDimensionsHelper::get_height_to_staff(grid, grid_cursor_y)*STAFF_HEIGHT+GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT + h_thickness,
-            4,
-            4,
-            color::color(color::aliceblue, 0.7),
-            thickness
-         );
-*/
-   }
-
-   // draw a hilight box at the focused note
-   if (is_focused && note && in_edit_mode)
-   {
-      float note_real_offset_x = __get_measure_length_to_note(measure, note_cursor_pos) * full_measure_width;
+      float note_offset_x = __get_measure_length_to_note(measure, note_cursor_pos) * full_measure_width;
       float real_note_width = DurationHelper::get_length(note->duration.denominator, note->duration.dots) * full_measure_width;
 
-      // note box fill
-      al_draw_filled_rounded_rectangle(
-            x_pos + note_real_offset_x,
-            y_pos,
-            x_pos + note_real_offset_x + real_note_width,
-            y_pos + staff_height,
-            //0 + GridDimensionsHelper::get_height_of_staff(grid, grid_cursor_y)*STAFF_HEIGHT,
-            6,
-            6,
-            color::color(color::pink, 0.4)
-         );
+      MeasureSelectionBoxRenderer measure_selection_box_renderer(measure_selection_box_renderer_state, x_pos, y_pos, measure_width, staff_height, note_offset_x, real_note_width);
+      measure_selection_box_renderer.render();
    }
 
-   ////
-
-   // draw debug info on the note
-   if (showing_debug_data)
-   {
-      ALLEGRO_FONT *text_font = Framework::font("DroidSans.ttf 20");
-      float x_cursor = x_pos;
-
-      for (auto &note : measure->get_notes_copy())
-      {
-         float width = DurationHelper::get_length(note.duration.denominator, note.duration.dots) * full_measure_width;
-
-         al_draw_text(text_font, color::white, x_cursor, y_pos, 0, tostring(note.pitch.scale_degree).c_str());
-         al_draw_text(text_font, color::white, x_cursor, y_pos+20, 0, (tostring(note.duration.denominator) + "(" + tostring(note.duration.dots) + ")").c_str());
-
-         std::tuple<std::string, std::string> context_pitch = __get_context_pitch_and_extension(context, &note);
-
-         al_draw_text(text_font, color::red, x_cursor, y_pos-30, ALLEGRO_FLAGS_EMPTY, std::get<0>(context_pitch).c_str());
-         al_draw_text(text_font, color::red, x_cursor, y_pos-15, ALLEGRO_FLAGS_EMPTY, std::get<1>(context_pitch).c_str());
-
-         x_cursor += width;
-      }
-   }
+   return;
 }
 
 

--- a/src/components/measure_render_component.cpp
+++ b/src/components/measure_render_component.cpp
@@ -124,11 +124,15 @@ void MeasureRenderComponent::render()
    {
       std::vector<Note> *notes_in_measure = measure->get_notes_pointer();
       Note *note = nullptr;
+      float real_note_width = 0;
       if (note_cursor_pos >= notes_in_measure->size() || note_cursor_pos < 0) {}
-      else note = &notes_in_measure->at(note_cursor_pos);
+      else
+      {
+         note = &notes_in_measure->at(note_cursor_pos);
+         real_note_width = DurationHelper::get_length(note->duration.denominator, note->duration.dots) * full_measure_width;
+      }
 
       float note_offset_x = __get_measure_length_to_note(measure, note_cursor_pos) * full_measure_width;
-      float real_note_width = DurationHelper::get_length(note->duration.denominator, note->duration.dots) * full_measure_width;
 
       MeasureSelectionBoxRenderer measure_selection_box_renderer(measure_selection_box_renderer_state, x_pos, y_pos, measure_width, staff_height, note_offset_x, real_note_width);
       measure_selection_box_renderer.render();

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -266,7 +266,7 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
       int current_staff_id = current_cursor_staff->get_id();
       int current_barline_num = current_grid_editor->grid_cursor_x;
       GridCoordinate grid_coordinate(current_staff_id, GridHorizontalCoordinate(current_barline_num, 0));
-      Measure::Base *static_measure = new Measure::Basic({0, 0, 0, 0});
+      Measure::Base *static_measure = new Measure::Basic({0});
 
       action = new Action::CreateFloatingMeasure(grid_coordinate, static_measure->get_id());
    }

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -266,7 +266,7 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
       int current_staff_id = current_cursor_staff->get_id();
       int current_barline_num = current_grid_editor->grid_cursor_x;
       GridCoordinate grid_coordinate(current_staff_id, GridHorizontalCoordinate(current_barline_num, 0));
-      Measure::Base *static_measure = new Measure::Basic({0});
+      Measure::Base *static_measure = new Measure::Basic({Note(0, {Duration::WHOLE})});
 
       action = new Action::CreateFloatingMeasure(grid_coordinate, static_measure->get_id());
    }

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -268,7 +268,13 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
       GridCoordinate grid_coordinate(current_staff_id, GridHorizontalCoordinate(current_barline_num, 0));
       Measure::Base *static_measure = new Measure::Basic({0});
 
-      action = new Action::CreateFloatingMeasure(grid_coordinate, static_measure->get_id());
+      std::string compound_action_name = Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER + " + " + Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER;
+      Action::Queue *action_queue = new Action::Queue(compound_action_name);
+
+      action_queue->add_action(new Action::CreateFloatingMeasure(grid_coordinate, static_measure->get_id()));
+      action_queue->add_action(create_action(app_controller, Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER));
+
+      action = action_queue;
    }
    else if (action_identifier == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(current_grid_editor);

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -268,13 +268,7 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
       GridCoordinate grid_coordinate(current_staff_id, GridHorizontalCoordinate(current_barline_num, 0));
       Measure::Base *static_measure = new Measure::Basic({0});
 
-      std::string compound_action_name = Action::CREATE_FLOATING_MEASURE_ACTION_IDENTIFIER + " + " + Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER;
-      Action::Queue *action_queue = new Action::Queue(compound_action_name);
-
-      action_queue->add_action(new Action::CreateFloatingMeasure(grid_coordinate, static_measure->get_id()));
-      action_queue->add_action(create_action(app_controller, Action::RESET_FLOATING_MEASURE_CURSOR_IDENTIFIER));
-
-      action = action_queue;
+      action = new Action::CreateFloatingMeasure(grid_coordinate, static_measure->get_id());
    }
    else if (action_identifier == "toggle_edit_mode_target")
       action = new Action::ToggleEditModeTarget(current_grid_editor);

--- a/src/factories/action_factory.cpp
+++ b/src/factories/action_factory.cpp
@@ -283,22 +283,7 @@ Action::Base *ActionFactory::create_action(AppController *app_controller, std::s
    else if (action_identifier == Action::YANK_GRID_MEASURE_TO_BUFFER_ACTION_IDENTIFIER)
       action = new Action::YankGridMeasureToBuffer(&app_controller->yank_measure_buffer, focused_measure);
    else if (action_identifier == "paste_measure_from_buffer")
-   {
-      Measure::Base *measure_at_cursor = current_grid_editor->get_measure_at_cursor();
-      if (measure_at_cursor && measure_at_cursor->get_type() == Measure::TYPE_IDENTIFIER_BASIC)
-      {
-         action = new Action::PasteMeasureFromBuffer(focused_measure, &app_controller->yank_measure_buffer);
-      }
-      else
-      {
-         std::stringstream error_message;
-         error_message
-            << "\""
-            << Action::PASTE_MEASURE_FROM_BUFFER_ACTION_IDENTIFIER
-            << "\" action disabled when there is already a measure present at this location";
-         throw std::runtime_error(error_message.str());
-      }
-   }
+      action = new Action::PasteMeasureFromBuffer(current_grid_editor->get_measure_at_cursor(), &app_controller->yank_measure_buffer);
 
    return action;
 }

--- a/src/models/floating_measure_cursor.cpp
+++ b/src/models/floating_measure_cursor.cpp
@@ -26,6 +26,13 @@ bool FloatingMeasureCursor::set_floating_measure_id(int floating_measure_id)
 
 
 
+void FloatingMeasureCursor::clear_floating_measure_id()
+{
+   this->floating_measure_id = -1;
+}
+
+
+
 int FloatingMeasureCursor::get_floating_measure_id()
 {
    return floating_measure_id;

--- a/src/models/plotters/basic.cpp
+++ b/src/models/plotters/basic.cpp
@@ -38,9 +38,9 @@ bool Plotter::Basic::plot()
 
       if (staff->is_type("instrument"))
       {
-         int staff_id = staff->get_id();
-         Measure::Base* plotted_measure = new Measure::Basic(notes); // < this automatically adds the measure to the base
-         new FloatingMeasure(GridCoordinate(staff_id, {barline_num, {random_int(0, 3)}}), plotted_measure->get_id());
+         //int staff_id = staff->get_id();
+         //Measure::Base* plotted_measure = new Measure::Basic(notes); // < this automatically adds the measure to the base
+         //new FloatingMeasure(GridCoordinate(staff_id, {barline_num, {random_int(0, 3)}}), plotted_measure->get_id());
       }
    }
 

--- a/src/renderers/measure_selection_box_renderer.cpp
+++ b/src/renderers/measure_selection_box_renderer.cpp
@@ -1,0 +1,62 @@
+
+
+
+#include <fullscore/renderers/measure_selection_box_renderer.h>
+
+
+
+#include <allegro5/allegro_primitives.h>
+#include <allegro_flare/color.h>
+
+
+
+MeasureSelectionBoxRenderer::MeasureSelectionBoxRenderer(state_t state, float x, float y, float w, float h, float selected_note_x, float selected_note_w)
+   : state(state)
+   , placement(x, y, w, h)
+   , selected_note_x(selected_note_x)
+   , selected_note_w(selected_note_w)
+{
+   placement.align = 0;
+}
+
+
+
+MeasureSelectionBoxRenderer::~MeasureSelectionBoxRenderer()
+{
+}
+
+
+
+void MeasureSelectionBoxRenderer::render()
+{
+   placement.start_transform();
+
+   float roundness = 8;
+   float outline_thickness = 8;
+   ALLEGRO_COLOR base_color = color::hex("fff200");
+
+   switch(state)
+   {
+   case STATE_NOTE_FOCUS:
+      al_draw_filled_rounded_rectangle(0, 0, placement.w, placement.h, roundness, roundness, color::color(base_color, 0.4));
+      al_draw_filled_rounded_rectangle(selected_note_x, 0, selected_note_x+selected_note_w, placement.h, roundness, roundness, color::color(color::orange, 0.4));
+      break;
+   case STATE_MEASURE_FOCUS:
+      {
+         float outline_padding = outline_thickness * 0.5;
+         float _thick_outline_padding = outline_padding * 1.5;
+         al_draw_filled_rounded_rectangle(0, 0, placement.w, placement.h, roundness, roundness, color::color(base_color, 0.4));
+         al_draw_rounded_rectangle(0-_thick_outline_padding, 0-_thick_outline_padding, placement.w+_thick_outline_padding, placement.h+_thick_outline_padding, roundness, roundness, color::color(base_color, 1), outline_thickness);
+         al_draw_rounded_rectangle(0-outline_padding, 0-outline_padding, placement.w+outline_padding, placement.h+outline_padding, roundness, roundness, color::color(color::black, 0.6), 2.0);
+         break;
+      }
+   default:
+      throw std::runtime_error("MeasureSelectionBoxRenderer fell back on default state switch statement");
+      break;
+   };
+
+   placement.restore_transform();
+}
+
+
+

--- a/tests/models/floating_measure_cursor_test.cpp
+++ b/tests/models/floating_measure_cursor_test.cpp
@@ -23,6 +23,18 @@ TEST(FloatingMeasureCursorTest, initializes_with_a_measure_id_of_negative_1)
 
 
 
+TEST(FloatingMeasureCursorTest, clearing_the_floating_measure_id_sets_floating_measure_id_to_negative_1)
+{
+   FloatingMeasureCursor floating_measure_cursor;
+
+   EXPECT_EQ(true, floating_measure_cursor.set_floating_measure_id(123));
+   EXPECT_EQ(123, floating_measure_cursor.get_floating_measure_id());
+   floating_measure_cursor.clear_floating_measure_id();
+   EXPECT_EQ(-1, floating_measure_cursor.get_floating_measure_id());
+}
+
+
+
 TEST(FloatingMeasureCursorTest, can_set_and_get_a_floating_measure_id)
 {
    FloatingMeasureCursor floating_measure_cursor;


### PR DESCRIPTION
## New `MeasureSelectionBoxRenderer` Component

This PR creates a `MeasureSelectionBoxRenderer` that is an isolated rendering component for drawing a selection box in its different states:

### Unfocused

<img width="238" alt="fullscore 2017-12-17 20-04-56" src="https://user-images.githubusercontent.com/772949/34085964-90bde8aa-e365-11e7-8816-eaedf8b2bab4.png">

### Focused on Measure

<img width="239" alt="fullscore 2017-12-17 20-03-58" src="https://user-images.githubusercontent.com/772949/34085958-871cbf42-e365-11e7-8a88-20784ae38d92.png">

### Focusing on Note Within Measure

<img width="237" alt="fullscore 2017-12-17 20-04-14" src="https://user-images.githubusercontent.com/772949/34085955-859e1bc0-e365-11e7-97b5-6201cab178b5.png">


This is a great decoupling of rendering logic.  Prior to the existence of this component, a lot of state (like `Measure` and its content) had to be in place to be injected (and then sorted through) in the rendering logic.

Now, only the necessary smallest pieces are needed, like the state (note-hilighted or measure-hilighted state), the dimensions, and the dimensions of the note-hilight box.

## Multi-Action Mapping

Actions were starting to fracture in their requirements.  On one hand, any action should be completely atomic in action.  That is, it should not expect or be acting on any pre-established state or otherwise.  On the other hand, some actions started to need to perform more complex changes.  Specifically, moving the position of the cursor also meant updating the focused measure, but these are two different atomic actions.

To solve this problem, [a change was made to the `KeyboardCommandMapper` in AllegroFlare](https://github.com/MarkOates/allegro_flare/pull/148) so that it would support an array of strings. In the case of Fullscore, multiple commands can now be mapped to a single key.

## Other Stuff

* `MeasureInspector` widget was commented out.  It might be removed altogether in the future.
* New measures, when created in the score, are created with a whole note.
* <kbd>Ctrl</kbd> was used to map `SplitNote`. <kbd>Ctrl</kbd> is now the preferred key to perform "fancy" measure transforms: `Ascend`, `SplitNote`, etc.