### PR TITLE
Move Duration Functions to Helper Class

### DIFF
--- a/include/fullscore/helpers/DurationHelper.h
+++ b/include/fullscore/helpers/DurationHelper.h
@@ -2,6 +2,10 @@
 
 
 
+#include <fullscore/models/Duration.h>
+
+
+
 class TimeSignature;
 
 class DurationHelper
@@ -9,6 +13,8 @@ class DurationHelper
 public:
    static float get_length(int duration, int dots);
    static float get_length(const TimeSignature &time_signature);
+   static Duration::denominator_t half_duration(Duration::denominator_t denominator);
+   static Duration::denominator_t double_duration(Duration::denominator_t denominator);
 };
 
 

--- a/include/fullscore/helpers/DurationHelper.h
+++ b/include/fullscore/helpers/DurationHelper.h
@@ -11,6 +11,7 @@ class TimeSignature;
 class DurationHelper
 {
 public:
+   static float get_length(Duration duration);
    static float get_length(int duration, int dots);
    static float get_length(const TimeSignature &time_signature);
    static Duration::denominator_t half_duration(Duration::denominator_t denominator);

--- a/include/fullscore/helpers/DurationHelper.h
+++ b/include/fullscore/helpers/DurationHelper.h
@@ -12,7 +12,6 @@ class DurationHelper
 {
 public:
    static float get_length(Duration duration);
-   static float get_length(int duration, int dots);
    static float get_length(const TimeSignature &time_signature);
    static Duration::denominator_t half_duration(Duration::denominator_t denominator);
    static Duration::denominator_t double_duration(Duration::denominator_t denominator);

--- a/include/fullscore/models/Duration.h
+++ b/include/fullscore/models/Duration.h
@@ -40,8 +40,4 @@ public:
 };
 
 
-Duration::denominator_t half_duration(Duration::denominator_t denominator);
-Duration::denominator_t double_duration(Duration::denominator_t denominator);
-
-
 

--- a/src/components/MeasureRenderComponent.cpp
+++ b/src/components/MeasureRenderComponent.cpp
@@ -19,7 +19,7 @@ float __get_measure_width(Measure::Base *m)  // TODO: should probably use a help
    if (!m) return 0;
    float sum = 0;
    for (auto &note : m->get_notes_copy())  // TODO: ineffecient use of get_notes_copy()
-      sum += DurationHelper::get_length(note.duration.get_denominator(), note.duration.get_dots());
+      sum += DurationHelper::get_length(note.duration);
    return sum;
 }
 
@@ -34,7 +34,7 @@ float __get_measure_length_to_note(Measure::Base *measure, int note_index)
    if (note_index < 0 || note_index >= notes.size()) return 0;
 
    for (int i=0; i<note_index; i++)
-      sum += DurationHelper::get_length(notes[i].duration.get_denominator(), notes[i].duration.get_dots());
+      sum += DurationHelper::get_length(notes[i].duration);
    return sum;
 }
 
@@ -129,7 +129,7 @@ void MeasureRenderComponent::render()
       else
       {
          note = &notes_in_measure->at(note_cursor_pos);
-         real_note_width = DurationHelper::get_length(note->duration.get_denominator(), note->duration.get_dots()) * full_measure_width;
+         real_note_width = DurationHelper::get_length(note->duration) * full_measure_width;
       }
 
       float note_offset_x = __get_measure_length_to_note(measure, note_cursor_pos) * full_measure_width;

--- a/src/helpers/DurationHelper.cpp
+++ b/src/helpers/DurationHelper.cpp
@@ -35,3 +35,19 @@ float DurationHelper::get_length(const TimeSignature &time_signature)
 
 
 
+Duration::denominator_t DurationHelper::half_duration(Duration::denominator_t denominator)
+{
+   if (denominator >= Duration::SIXTYFOURTH) return Duration::SIXTYFOURTH;
+   return (Duration::denominator_t)((int)denominator * 2);
+}
+
+
+
+Duration::denominator_t DurationHelper::double_duration(Duration::denominator_t denominator)
+{
+   if (denominator <= Duration::WHOLE) return Duration::WHOLE;
+   return (Duration::denominator_t)((int)denominator / 2);
+}
+
+
+

--- a/src/helpers/DurationHelper.cpp
+++ b/src/helpers/DurationHelper.cpp
@@ -9,6 +9,14 @@
 
 
 
+float DurationHelper::get_length(Duration duration)
+{
+   return get_length(duration.get_denominator(), duration.get_dots());
+}
+
+
+
+
 float DurationHelper::get_length(int duration, int dots)
 {
    float width = 1.0f / duration;

--- a/src/helpers/DurationHelper.cpp
+++ b/src/helpers/DurationHelper.cpp
@@ -11,18 +11,10 @@
 
 float DurationHelper::get_length(Duration duration)
 {
-   return get_length(duration.get_denominator(), duration.get_dots());
-}
-
-
-
-
-float DurationHelper::get_length(int duration, int dots)
-{
-   float width = 1.0f / duration;
+   float width = 1.0f / duration.get_denominator();
    float dots_percentage = 0.0f;
    float previous_ammount = 1.0f;
-   for (int i=0; i<dots; i++)
+   for (int i=0; i<duration.get_dots(); i++)
    {
       previous_ammount *= 0.5f;
       dots_percentage += previous_ammount;
@@ -36,7 +28,7 @@ float DurationHelper::get_length(int duration, int dots)
 
 float DurationHelper::get_length(const TimeSignature &time_signature)
 {
-   float denominator_duration_width = get_length(time_signature.get_denominator().get_denominator(), time_signature.get_denominator().get_dots());
+   float denominator_duration_width = get_length(time_signature.get_denominator());
    return denominator_duration_width * time_signature.get_numerator();
 }
 

--- a/src/models/Duration.cpp
+++ b/src/models/Duration.cpp
@@ -90,19 +90,3 @@ bool Duration::operator!=(const Duration &other) const
 
 
 
-Duration::denominator_t half_duration(Duration::denominator_t denominator)
-{
-   if (denominator >= Duration::SIXTYFOURTH) return Duration::SIXTYFOURTH;
-   return (Duration::denominator_t)((int)denominator * 2);
-}
-
-
-
-Duration::denominator_t double_duration(Duration::denominator_t denominator)
-{
-   if (denominator <= Duration::WHOLE) return Duration::WHOLE;
-   return (Duration::denominator_t)((int)denominator / 2);
-}
-
-
-

--- a/src/services/MusicEngraver.cpp
+++ b/src/services/MusicEngraver.cpp
@@ -69,7 +69,7 @@ void MusicEngraver::draw(Measure::Base *measure, float x, float y, const float w
          notes_as_string = std::string("{staff_color=") + color_as_name + "}" + notes_as_string;
       }
 		music_notation.draw(x + cursor_x, y, notes_as_string);
-		cursor_x += DurationHelper::get_length(notes[i].duration.get_denominator(), notes[i].duration.get_dots()) * whole_note_width;
+		cursor_x += DurationHelper::get_length(notes[i].duration) * whole_note_width;
 	}
 }
 

--- a/src/transforms/DoubleDurationTransform.cpp
+++ b/src/transforms/DoubleDurationTransform.cpp
@@ -4,7 +4,7 @@
 
 #include <fullscore/transforms/DoubleDurationTransform.h>
 
-#include <fullscore/models/Duration.h>
+#include <fullscore/helpers/DurationHelper.h>
 #include <algorithm>
 
 
@@ -30,7 +30,7 @@ std::vector<Note> Transform::DoubleDuration::transform(std::vector<Note> n)
 {
    std::vector<Note> result = n;
    for (auto &note : result)
-      note.duration.set_denominator(double_duration(note.duration.get_denominator()));
+      note.duration.set_denominator(DurationHelper::double_duration(note.duration.get_denominator()));
    return result;
 }
 

--- a/src/transforms/HalfDurationTransform.cpp
+++ b/src/transforms/HalfDurationTransform.cpp
@@ -4,7 +4,7 @@
 
 #include <fullscore/transforms/HalfDurationTransform.h>
 
-#include <fullscore/models/Duration.h>
+#include <fullscore/helpers/DurationHelper.h>
 #include <algorithm>
 
 
@@ -30,7 +30,7 @@ std::vector<Note> Transform::HalfDuration::transform(std::vector<Note> n)
 {
    std::vector<Note> result = n;
    for (auto &note : result)
-      note.duration.set_denominator(half_duration(note.duration.get_denominator()));
+      note.duration.set_denominator(DurationHelper::half_duration(note.duration.get_denominator()));
    return result;
 }
 

--- a/src/widgets/GridEditor.cpp
+++ b/src/widgets/GridEditor.cpp
@@ -107,7 +107,7 @@ float UIGridEditor::get_measure_width(Measure::Base *m)  // TODO: should probabl
    if (!m) return 0;
    float sum = 0;
    for (auto &note : m->get_notes_copy())  // TODO: ineffecient use of get_notes_copy()
-      sum += DurationHelper::get_length(note.duration.get_denominator(), note.duration.get_dots());
+      sum += DurationHelper::get_length(note.duration);
    return sum;
 }
 

--- a/tests/helpers/DurationHelperTest.cpp
+++ b/tests/helpers/DurationHelperTest.cpp
@@ -10,6 +10,27 @@
 
 
 
+TEST(DurationHelperTest, returns_the_length_of_a_duration)
+{
+   Duration duration_a(Duration::QUARTER, 0);
+   EXPECT_EQ(0.25, DurationHelper::get_length(duration_a));
+
+   Duration duration_b(Duration::WHOLE, 0);
+   EXPECT_EQ(1.0, DurationHelper::get_length(duration_b));
+
+   Duration duration_c(Duration::HALF, 2);
+   EXPECT_EQ(0.875, DurationHelper::get_length(duration_c));
+
+   Duration duration_d(Duration::QUARTER, 1);
+   EXPECT_EQ(0.375, DurationHelper::get_length(duration_d));
+
+   Duration duration_e(Duration::SIXTEENTH, 0);
+   EXPECT_EQ(0.0625, DurationHelper::get_length(duration_e));
+}
+
+
+
+
 TEST(DurationHelperTest, returns_the_length_of_a_time_signature)
 {
    TimeSignature time_signature_a(4, Duration(Duration::QUARTER, 0));

--- a/tests/helpers/DurationHelperTest.cpp
+++ b/tests/helpers/DurationHelperTest.cpp
@@ -37,3 +37,40 @@ TEST(DurationHelperTest, returns_the_length_of_a_time_signature)
 
 
 
+TEST(DurationTest, half_duration__halves_the_duration)
+{
+   EXPECT_EQ(Duration::SIXTYFOURTH, DurationHelper::half_duration(Duration::THIRTYSECOND));
+   EXPECT_EQ(Duration::THIRTYSECOND, DurationHelper::half_duration(Duration::SIXTEENTH));
+   EXPECT_EQ(Duration::SIXTEENTH, DurationHelper::half_duration(Duration::EIGHTH));
+   EXPECT_EQ(Duration::QUARTER, DurationHelper::half_duration(Duration::HALF));
+   EXPECT_EQ(Duration::HALF, DurationHelper::half_duration(Duration::WHOLE));
+}
+
+
+
+TEST(DurationTest, double_duration__doubles_the_duration)
+{
+   EXPECT_EQ(Duration::THIRTYSECOND, DurationHelper::double_duration(Duration::SIXTYFOURTH));
+   EXPECT_EQ(Duration::SIXTEENTH, DurationHelper::double_duration(Duration::THIRTYSECOND));
+   EXPECT_EQ(Duration::EIGHTH, DurationHelper::double_duration(Duration::SIXTEENTH));
+   EXPECT_EQ(Duration::QUARTER, DurationHelper::double_duration(Duration::EIGHTH));
+   EXPECT_EQ(Duration::HALF, DurationHelper::double_duration(Duration::QUARTER));
+   EXPECT_EQ(Duration::WHOLE, DurationHelper::double_duration(Duration::HALF));
+}
+
+
+
+TEST(DurationTest, half_duration__when_halving_SIXTYFOURTH_returns_SIXTYFOURTH)
+{
+   EXPECT_EQ(Duration::SIXTYFOURTH, DurationHelper::half_duration(Duration::SIXTYFOURTH));
+}
+
+
+
+TEST(DurationTest, double_duration__when_doubling_WHOLE_returns_WHOLE)
+{
+   EXPECT_EQ(Duration::WHOLE, DurationHelper::double_duration(Duration::WHOLE));
+}
+
+
+

--- a/tests/models/DurationTest.cpp
+++ b/tests/models/DurationTest.cpp
@@ -98,43 +98,6 @@ TEST(DurationTest, equality_operator_returns_false_on_unequal_durations)
 
 
 
-TEST(DurationTest, halves_the_duration)
-{
-   EXPECT_EQ(Duration::SIXTYFOURTH, half_duration(Duration::THIRTYSECOND));
-   EXPECT_EQ(Duration::THIRTYSECOND, half_duration(Duration::SIXTEENTH));
-   EXPECT_EQ(Duration::SIXTEENTH, half_duration(Duration::EIGHTH));
-   EXPECT_EQ(Duration::QUARTER, half_duration(Duration::HALF));
-   EXPECT_EQ(Duration::HALF, half_duration(Duration::WHOLE));
-}
-
-
-
-TEST(DurationTest, doubles_the_duration)
-{
-   EXPECT_EQ(Duration::THIRTYSECOND, double_duration(Duration::SIXTYFOURTH));
-   EXPECT_EQ(Duration::SIXTEENTH, double_duration(Duration::THIRTYSECOND));
-   EXPECT_EQ(Duration::EIGHTH, double_duration(Duration::SIXTEENTH));
-   EXPECT_EQ(Duration::QUARTER, double_duration(Duration::EIGHTH));
-   EXPECT_EQ(Duration::HALF, double_duration(Duration::QUARTER));
-   EXPECT_EQ(Duration::WHOLE, double_duration(Duration::HALF));
-}
-
-
-
-TEST(DurationTest, when_halving_SIXTYFOURTH_returns_SIXTYFOURTH)
-{
-   EXPECT_EQ(Duration::SIXTYFOURTH, half_duration(Duration::SIXTYFOURTH));
-}
-
-
-
-TEST(DurationTest, when_doubling_WHOLE_returns_WHOLE)
-{
-   EXPECT_EQ(Duration::WHOLE, double_duration(Duration::WHOLE));
-}
-
-
-
 TEST(DurationTest, returns_true_if_an_integer_is_a_valid_denominator)
 {
    EXPECT_EQ(true, Duration::is_valid_denominator(Duration::WHOLE));


### PR DESCRIPTION
## Two Refactors

This simple change moves the dangling functions `double_duration()` and `half_duration()` and moves them to a helper class `DurationHelper`.

Also, a function `get_length(int duration, int dots)` was removed and replaced with a more appropriate `get_duration(Duration duration)` signature.